### PR TITLE
DOCS-6499 Repair 50 dead heading anchors in MaxScale docs

### DIFF
--- a/maxscale/maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md
+++ b/maxscale/maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md
@@ -2441,9 +2441,9 @@ This feature has a significant drawback: when a backend connection is reused, it
 
 This feature should only be used when limiting the backend connection count is a priority, even at the cost of query delay and throughput. This feature only works when the following server settings are also set in MaxScale configuration:
 
-1. [max\_routing\_connections](maxscale-configuration-guide.md#max_routing_connections)
-2. [persistpoolmax](maxscale-configuration-guide.md#persistpoolmax)
-3. [persistmaxtime](maxscale-configuration-guide.md#persistmaxtime)
+1. [max\_routing\_connections](../../../reference/maxscale-servers.md#max_routing_connections)
+2. [persistpoolmax](../../../reference/maxscale-servers.md#persistpoolmax)
+3. [persistmaxtime](../../../reference/maxscale-servers.md#persistmaxtime)
 
 Since reusing a backend connection is an expensive operation, MaxScale only pools connections when another session requires them. _idle\_session\_pool\_time_ thus effectively limits the frequency at which a connection can be moved from one session to another. Setting `idle_session_pool_time=0ms` causes MaxScale to move connections as soon as possible.
 
@@ -2463,7 +2463,7 @@ The most common such state is a transaction. When a transaction is on, connectio
 * Temporary tables and some problematic user or session variables such as `LAST_INSERT_ID()`. For `LAST_INSERT_ID()`, the value returned by the connector must be used instead of the variable.
 * Stored procedures that cause session level side-effects.
 
-Several settings affect connection sharing and its effectiveness. Reusing a connection is an expensive operation so its frequency should be minimized. The important configuration settings in addition to _idle\_session\_pool\_time_ are MaxScale server settings [persistpoolmax](maxscale-configuration-guide.md#persistpoolmax), [persistmaxtime](maxscale-configuration-guide.md#persistmaxtime) and [max\_routing\_connections](maxscale-configuration-guide.md#max_routing_connections). The service settings [max\_sescmd\_history](maxscale-configuration-guide.md#max_sescmd_history), [prune\_sescmd\_history](maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These settings should be tuned according to the use case.
+Several settings affect connection sharing and its effectiveness. Reusing a connection is an expensive operation so its frequency should be minimized. The important configuration settings in addition to _idle\_session\_pool\_time_ are MaxScale server settings [persistpoolmax](../../../reference/maxscale-servers.md#persistpoolmax), [persistmaxtime](../../../reference/maxscale-servers.md#persistmaxtime) and [max\_routing\_connections](../../../reference/maxscale-servers.md#max_routing_connections). The service settings [max\_sescmd\_history](maxscale-configuration-guide.md#max_sescmd_history), [prune\_sescmd\_history](maxscale-configuration-guide.md#prune_sescmd_history) and [multiplex\_timeout](maxscale-configuration-guide.md#multiplex_timeout) also have an effect. These settings should be tuned according to the use case.
 
 _persistpoolmax_ limits how many connections can be kept in a pool for a given server. If the pool is full, no more connections are detached from sessions even if they are idle and required. The pool size should be large enough to contain any connections being transferred between sessions, but not be greater than _max\_routing\_connections_. Using the value of _max\_routing\_connections_ is a reasonable starting point.
 

--- a/maxscale/maxscale-security/authentication-modules.md
+++ b/maxscale/maxscale-security/authentication-modules.md
@@ -27,7 +27,7 @@ As the UAM is shared between all listeners of a service, its settings are define
 
 To properly fetch user account information, the MaxScale service user must be able to read from various tables in the _mysql_-database: _user_, _db_, _tables\_priv_, _columns\_priv_, _procs\_priv_, _proxies\_priv_, _global\_priv_ and _roles\_mapping_. The user should also have the _SHOW DATABASES_-grant.
 
-The _SET USER_ grant is optional but recommended if MaxScale is used with MariaDB version 12 or newer. Granting it to the service user allows the backend authentication to use the service credentials to log in after which the final user account is selected using the `SET SESSION AUTHORIZATION` command. For more information, refer to the documentation of the [use\_service\_credentials](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#use_service_credentials) setting.
+The _SET USER_ grant is optional but recommended if MaxScale is used with MariaDB version 12 or newer. Granting it to the service user allows the backend authentication to use the service credentials to log in after which the final user account is selected using the `SET SESSION AUTHORIZATION` command. For more information, refer to the documentation of the [use\_service\_credentials](../reference/maxscale-servers.md#use_service_credentials) setting.
 
 ```sql
 CREATE USER 'maxscale'@'maxscalehost' IDENTIFIED BY 'maxscale-password';
@@ -56,7 +56,7 @@ When a client logs in to MaxScale, MaxScale sees the client's IP address. When M
 There are two primary ways to deal with this:
 
 1. Duplicate user accounts. For every user account with a restricted hostname an equivalent user account for MaxScale is added (`'alice'@'maxscale-ip'`).
-2. Use [proxy protocol](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#proxy_protocol).
+2. Use [proxy protocol](../reference/maxscale-servers.md#proxy_protocol).
 
 Option 1 limits the passwords for user accounts with shared usernames. Such accounts must use the same password since they will effectively share the MaxScale-to-backend user account. Option 2 requires server support.
 

--- a/maxscale/reference/maxscale-authenticators/maxscale-ed25519-authenticator.md
+++ b/maxscale/reference/maxscale-authenticators/maxscale-ed25519-authenticator.md
@@ -52,7 +52,7 @@ authenticator_options=ed_mode=sha256,
 
 ### Using a Mapping File
 
-To enable MaxScale to authenticate to backends, [user mapping](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user_mapping_file) can be used. The mapping and backend passwords are given in a JSON file. The client can map to an identical username or to another user, and the backend authentication scheme can be something else than `ed25519`.
+To enable MaxScale to authenticate to backends, [user mapping](../maxscale-listeners.md#user_mapping_file) can be used. The mapping and backend passwords are given in a JSON file. The client can map to an identical username or to another user, and the backend authentication scheme can be something else than `ed25519`.
 
 The following example maps user "alpha" to "beta" and MaxScale then uses standard authentication to log into backends as "beta". User "alpha" authenticates to MaxScale using whatever method configured in the server. User "gamma" does not map to another user, just the password is given.
 

--- a/maxscale/reference/maxscale-authenticators/maxscale-pam-authenticator.md
+++ b/maxscale/reference/maxscale-authenticators/maxscale-pam-authenticator.md
@@ -95,9 +95,9 @@ If set to "mariadb", MaxScale will authenticate clients to backends using standa
 
 Because the client still needs to authenticate to MaxScale normally, an anonymous user may be required. If the backends do not allow such a user, one can be manually added using the service setting [user\_accounts\_file](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user_accounts_file).
 
-To map usernames, the PAM service needs to use a module such as \_user\_map.so\_. This module is not a standard Linux component and needs to be installed separately. It is included in recent MariaDB Server packages and can also be compiled from source. See [user mapping](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user_mapping_file) for more information on how to configure the module. If the goal is to only map users from PAM to MariaDB in MaxScale, then configuring user mapping on just the machine running MaxScale is enough.
+To map usernames, the PAM service needs to use a module such as \_user\_map.so\_. This module is not a standard Linux component and needs to be installed separately. It is included in recent MariaDB Server packages and can also be compiled from source. See [user mapping](../maxscale-listeners.md#user_mapping_file) for more information on how to configure the module. If the goal is to only map users from PAM to MariaDB in MaxScale, then configuring user mapping on just the machine running MaxScale is enough.
 
-Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user_mapping_file), as it is easier to configure. `pam_backend_mapping` should only be used when the user mapping needs to be defined by pam.
+Instead of using `pam_backend_mapping`, consider using the listener setting [user\_mapping\_file](../maxscale-listeners.md#user_mapping_file), as it is easier to configure. `pam_backend_mapping` should only be used when the user mapping needs to be defined by pam.
 
 #### `pam_mapped_pw_file`
 
@@ -138,7 +138,7 @@ An example file is below.
 
 ## Anonymous User Mapping
 
-When backend authenticator mapping is not in use (`authenticator_options=pam_backend_mapping=none`), the PAM authenticator supports a limited version of [user mapping](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user_mapping_file). It requires less configuration but is also less accurate than proper mapping. Anonymous mapping is enabled in MaxScale if the following user exists:
+When backend authenticator mapping is not in use (`authenticator_options=pam_backend_mapping=none`), the PAM authenticator supports a limited version of [user mapping](../maxscale-listeners.md#user_mapping_file). It requires less configuration but is also less accurate than proper mapping. Anonymous mapping is enabled in MaxScale if the following user exists:
 
 * Empty username (e.g. `''@'%'` or `''@'myhost.com'`)
 * `plugin = 'pam'`

--- a/maxscale/reference/maxscale-authenticators/maxscale-parsec-authenticator.md
+++ b/maxscale/reference/maxscale-authenticators/maxscale-parsec-authenticator.md
@@ -19,7 +19,7 @@ Similarly to the ed25519 authentication plugin, it signs the response with a ed2
 
 This authentication plugin is intended to be used with MariaDB version 12 or later and requires that the service user has the `SET USER` grant.
 
-MariaDB versions 11.6 or later that include the PARSEC authentication plugin are supported but the passwords for the users must be provided via the [user mapping file](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user_mapping_file). The documentation for the [Ed25519 authenticator](maxscale-ed25519-authenticator.md#using-a-mapping-file) contains an example of how to configure the user mapping.
+MariaDB versions 11.6 or later that include the PARSEC authentication plugin are supported but the passwords for the users must be provided via the [user mapping file](../maxscale-listeners.md#user_mapping_file). The documentation for the [Ed25519 authenticator](maxscale-ed25519-authenticator.md#using-a-mapping-file) contains an example of how to configure the user mapping.
 
 ### Configuration
 

--- a/maxscale/reference/maxscale-configuration-settings.md
+++ b/maxscale/reference/maxscale-configuration-settings.md
@@ -1145,7 +1145,7 @@ description: >-
 
 #### Settings for File-based Key Manager
 
-[**file.keyfile**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#file.keyfile)
+[**file.keyfile**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-file-based-key-manager)
 
 * Type: path
 * Mandatory: Yes
@@ -1154,49 +1154,49 @@ description: >-
 
 #### Settings for HashiCorp Vault Key Manager
 
-[**vault.ca**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#vault.ca)
+[**vault.ca**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-hashicorp-vault-key-manager)
 
 * Type: path
 * Default: `""`
 * Dynamic: Yes
 * Description: Defines the CA certificate used for validating Vault server connections.
 
-[**vault.host**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#vault.host)
+[**vault.host**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-hashicorp-vault-key-manager)
 
 * Type: string
 * Default: `localhost`
 * Dynamic: Yes
 * Description: Specifies the hostname of the Vault server.
 
-[**vault.mount**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#vault.mount)
+[**vault.mount**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-hashicorp-vault-key-manager)
 
 * Type: string
 * Default: `secret`
 * Dynamic: Yes
 * Description: Provides the Key-Value mount path in Vault where secrets are stored.
 
-[**vault.port**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#vault.port)
+[**vault.port**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-hashicorp-vault-key-manager)
 
 * Type: integer
 * Default: `8200`
 * Dynamic: Yes
 * Description: Defines the port on which the Vault server listens.
 
-[**vault.timeout**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#vault.timeout)
+[**vault.timeout**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-hashicorp-vault-key-manager)
 
 * Type: [duration](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#durations)
 * Default: 30s
 * Dynamic: Yes
 * Description: Sets the timeout for requests and connections to the Vault server.
 
-[**vault.tls**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#vault.tls)
+[**vault.tls**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-hashicorp-vault-key-manager)
 
 * Type: [boolean](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#booleans)
 * Default: true
 * Dynamic: Yes
 * Description: Manages whether encrypted (HTTPS) or unencrypted (HTTP) connections are used when communicating with the Vault server.
 
-[**vault.token**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#vault.token)
+[**vault.token**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-hashicorp-vault-key-manager)
 
 * Type: password
 * Mandatory: Yes
@@ -1205,34 +1205,34 @@ description: >-
 
 #### Settings for KMIP Key Manager
 
-[**kmip.ca**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#kmip.ca)
+[**kmip.ca**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-kmip-key-manager)
 
 * Type: path
 * Default: `""`
 * Dynamic: Yes
 * Description: CA ceritficate for KMIP server.
 
-[**kmip.cert**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#kmip.cert)
+[**kmip.cert**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-kmip-key-manager)
 
 * Type: path
 * Mandatory: Yes
 * Dynamic: Yes
 * Description: Client certificate for KMIP authentication.
 
-[**kmip.host**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#kmip.host)
+[**kmip.host**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-kmip-key-manager)
 
 * Type: string
 * Mandatory: Yes
 * Dynamic: Yes
 
-[**kmip.key**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#kmip.key)
+[**kmip.key**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-kmip-key-manager)
 
 * Type: path
 * Mandatory: Yes
 * Dynamic: Yes
 * Description: Specifies the client private key used for connecting to the KMIP server.
 
-[**kmip.port**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#kmip.port)
+[**kmip.port**](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#settings-for-kmip-key-manager)
 
 * Type: integer
 * Mandatory: Yes
@@ -1417,7 +1417,7 @@ description: >-
 
 [**sql\_mode**](maxscale-listeners.md#sql_mode)
 
-* Type: [enum](maxscale-listeners.md#enumerations)
+* Type: [enum](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#enumerations)
 * Mandatory: No
 * Dynamic: Yes
 * Values: `default`, `oracle`
@@ -3394,9 +3394,9 @@ description: >-
 
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [`address`](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#address) or [`socket`](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#socket) to use. Only one of the fields can be defined.
+* The [`address`](maxscale-servers.md#address) or [`socket`](maxscale-servers.md#socket) to use. Only one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [`port`](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#port) to use. Needs to be defined if the `address` field is defined.
+* The [`port`](maxscale-servers.md#port) to use. Needs to be defined if the `address` field is defined.
 
 #### [maxscale-service-resource](maxscale-rest-api/maxscale-service-resource.md)
 
@@ -3681,7 +3681,7 @@ description: >-
 * Default: `auto`&#x20;
 * Description: Defines how the Exasol preprocessor script is managed: auto-installed, activate-only, custom path, or disabled.
 
-[**preprocessor\_script**](maxscale-routers/maxscale-exasolrouter.md#preprocessor_script)
+[**preprocessor\_script**](maxscale-routers/maxscale-exasolrouter.md)
 
 * Type: String
 * Mandatory: No

--- a/maxscale/reference/maxscale-filters/maxscale-consistent-critical-read-filter.md
+++ b/maxscale/reference/maxscale-filters/maxscale-consistent-critical-read-filter.md
@@ -61,7 +61,7 @@ After processing a data modifying SQL statement, a counter is set to the value o
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters) control which statements trigger statement re-routing. Only non-SELECT statements are inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works similarly.
+These [regular expression settings](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#regular-expressions) control which statements trigger statement re-routing. Only non-SELECT statements are inspected. For CCRFilter, the _exclude_-parameter is instead named _ignore_, yet works similarly.
 
 ```
 match=.*INSERT.*

--- a/maxscale/reference/maxscale-filters/maxscale-named-server-filter.md
+++ b/maxscale/reference/maxscale-filters/maxscale-named-server-filter.md
@@ -63,7 +63,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `ignorecase`
 
-[Regular expression options](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters) for `matchXY`.
+[Regular expression options](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#regular-expressions) for `matchXY`.
 
 ### `targetXY`
 

--- a/maxscale/reference/maxscale-filters/maxscale-top-filter.md
+++ b/maxscale/reference/maxscale-filters/maxscale-top-filter.md
@@ -66,7 +66,7 @@ count=30
 * Dynamic: Yes
 * Default: None
 
-[Limits](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters) the queries logged by the filter.
+[Limits](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#regular-expressions) the queries logged by the filter.
 
 ```
 match=select.*from.*customer.*where
@@ -81,7 +81,7 @@ options=case,extended
 * Dynamic: Yes
 * Default: None
 
-[Limits](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters) the queries logged by the filter.
+[Limits](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#regular-expressions) the queries logged by the filter.
 
 ### `options`
 
@@ -91,7 +91,7 @@ options=case,extended
 * Values: `ignorecase`, `case`, `extended`
 * Default: `case`
 
-[Regular expression options](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#standard-regular-expression-settings-for-filters) for `match` and `exclude`.
+[Regular expression options](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#regular-expressions) for `match` and `exclude`.
 
 ### `source`
 

--- a/maxscale/reference/maxscale-listeners.md
+++ b/maxscale/reference/maxscale-listeners.md
@@ -93,7 +93,7 @@ This defines additional options for authentication. As of MaxScale 2.5.0, only _
 
 ### `sql_mode`
 
-* Type: [enum](maxscale-listeners.md#enumerations)
+* Type: [enum](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#enumerations)
 * Mandatory: No
 * Dynamic: Yes
 * Values: `default`, `oracle`
@@ -103,7 +103,7 @@ Specify the sql mode for the listener similarly to global `sql_mode` setting. If
 
 ### `proxy_protocol_networks`
 
-Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) when connecting. The proxy header contains the original client IP-address and port, and MaxScale will use that information in its internal bookkeeping. This means the client is authenticated as if it was connecting from the host in the proxy header. If proxy protocol is also enabled in MaxScale server settings, MaxScale will relay the original client address and port to the server. See [server settings](maxscale-listeners.md#proxy_protocol) for more information.
+Define an IP-address or a subnetwork which may send a [proxy protocol header](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) when connecting. The proxy header contains the original client IP-address and port, and MaxScale will use that information in its internal bookkeeping. This means the client is authenticated as if it was connecting from the host in the proxy header. If proxy protocol is also enabled in MaxScale server settings, MaxScale will relay the original client address and port to the server. See [server settings](maxscale-servers.md#proxy_protocol) for more information.
 
 This setting may be useful if a compatible load balancer is relaying client connections to MaxScale. If proxy headers are used, both MaxScale and the backends will know where the client originally came from.
 

--- a/maxscale/reference/maxscale-maxgui.md
+++ b/maxscale/reference/maxscale-maxgui.md
@@ -238,7 +238,7 @@ There are two ways to quickly insert an object to the editor:
 
 **Show object creation statement and insights info**
 
-To view the statement that creates the given object in the [Schemas objects sidebar](maxscale-maxgui.md#schemas-objects-sidebar), right-clicking on schema or table node and select the `View Insights` option. For other objects such as view, stored procedure, function and trigger, select the `Show Create` option.
+To view the statement that creates the given object in the Schemas objects sidebar, right-clicking on schema or table node and select the `View Insights` option. For other objects such as view, stored procedure, function and trigger, select the `Show Create` option.
 
 **Editor**
 
@@ -262,7 +262,7 @@ By default, all statements in the "Query Tab" are split by semicolons and execut
 
 **Re-execute old queries**
 
-Every executed query will be saved in the browser's storage (IndexedDB). Query history can be seen in the `History/Snippets` tab. To re-execute a query, follow the same step to [insert an object into the editor](maxscale-maxgui.md#quickly-insert-an-object-into-the-editor) and click the execute query button in the editor.
+Every executed query will be saved in the browser's storage (IndexedDB). Query history can be seen in the `History/Snippets` tab. To re-execute a query, follow the same step to insert an object into the editor and click the execute query button in the editor.
 
 **Create query snippet**
 

--- a/maxscale/reference/maxscale-protocols/maxscale-mariadb-protocol-module.md
+++ b/maxscale/reference/maxscale-protocols/maxscale-mariadb-protocol-module.md
@@ -19,7 +19,7 @@ The [Connection Redirection](../../../server/ha-and-performance/connection-redir
 
 To prevent the accidental redirection of clients away from MaxScale, the notification about the change of the system variable `redirect_url` is intercepted by MaxScale and renamed into `mxs_rdir_url`. This prevents any automated redirects from taking place while still allowing clients to see the information if they need it.
 
-To redirect clients away from MaxScale, use the [redirect\_url](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#redirect_url) parameter.
+To redirect clients away from MaxScale, use the [redirect\_url](../maxscale-listeners.md#redirect_url) parameter.
 
 ## Configuration
 

--- a/maxscale/reference/maxscale-protocols/maxscale-nosql-protocol-module.md
+++ b/maxscale/reference/maxscale-protocols/maxscale-nosql-protocol-module.md
@@ -1303,9 +1303,9 @@ The following fields are relevant.
 | query         | document | Optional. The query predicate.                                                                                                                            |
 | sort          | document | Optional. The sort specification used when the document is selected.                                                                                      |
 | remove        | boolean  | Mandatory, if update is not specified. If true, the document will be deleted.                                                                             |
-| update        | document | Mandatory, if remove is not specified. See [Update.behavior](maxscale-nosql-protocol-module.md#behavior) for details.                                     |
+| update        | document | Mandatory, if remove is not specified. See [Update.behavior](maxscale-nosql-protocol-module.md#update) for details.                                     |
 | new           | boolean  | Optional. If true the modified document and not the original document is returned. If remove is specified, then the original document is always returned. |
-| fields        | document | Optional. Specified which fields to return. See [Find.projection](maxscale-nosql-protocol-module.md#projection) for details.                              |
+| fields        | document | Optional. Specified which fields to return. See [Find.projection](maxscale-nosql-protocol-module.md#find) for details.                              |
 | upsert        | boolean  | Optional. If true then a document will be created, if one is not found.                                                                                   |
 
 All other fields are ignored.

--- a/maxscale/reference/maxscale-rest-api/maxscale-server-resource.md
+++ b/maxscale/reference/maxscale-rest-api/maxscale-server-resource.md
@@ -843,9 +843,9 @@ Create a new server by defining the resource. The posted object must define at l
 * `data.type`
   * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-  * The [`address`](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#address) or [`socket`](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#socket) to use. Only one of the fields can be defined.
+  * The [`address`](../maxscale-servers.md#address) or [`socket`](../maxscale-servers.md#socket) to use. Only one of the fields can be defined.
 * `data.attributes.parameters.port`
-  * The [`port`](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#port) to use. Needs to be defined if the `address` field is defined.
+  * The [`port`](../maxscale-servers.md#port) to use. Needs to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
 

--- a/maxscale/reference/maxscale-servers.md
+++ b/maxscale/reference/maxscale-servers.md
@@ -90,7 +90,7 @@ monitoruser=mymonitoruser
 monitorpw=mymonitorpasswd
 ```
 
-`monitorpw` may be either a plain text password or an encrypted password. See the section [encrypting passwords](maxscale-servers.md#encrypting-passwords) for more information.
+`monitorpw` may be either a plain text password or an encrypted password. See the section [encrypting passwords](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#encrypting-passwords) for more information.
 
 ### `extra_port`
 
@@ -142,11 +142,11 @@ A DCB placed in the persistent pool for a server will only be reused if the elap
 
 Maximum number of routing connections to this server. Connections held in a pool also count towards this maximum. Does not limit monitor connections or user account fetching. A value of 0 means no limit, which is the default for MaxScale. MaxScle Trial is limited to a maximum of 15 connections per server.
 
-Since every client session can generate a connection to a server, the server may run out of memory when the number of clients is high enough. This setting limits server memory use caused by MaxScale. The effect depends on if the service setting [idle\_session\_pool\_time](maxscale-servers.md#idle_session_pool_time), i.e. connection sharing, is enabled or not.
+Since every client session can generate a connection to a server, the server may run out of memory when the number of clients is high enough. This setting limits server memory use caused by MaxScale. The effect depends on if the service setting [idle\_session\_pool\_time](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#idle_session_pool_time), i.e. connection sharing, is enabled or not.
 
 If connection sharing is not on, _max\_routing\_connections_ simply sets a limit. Any sessions attempting to exceed this limit will fail to connect to the backend. The client can still connect to MaxScale, but queries will fail.
 
-If connection sharing is on, sessions exceeding the limit will be put on hold until a connection is available. Such sessions will appear unresponsive, as queries will hang, possibly for a long time. The timeout is controlled by [multiplex\_timeout](maxscale-servers.md#multiplex_timeout).
+If connection sharing is on, sessions exceeding the limit will be put on hold until a connection is available. Such sessions will appear unresponsive, as queries will hang, possibly for a long time. The timeout is controlled by [multiplex\_timeout](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#multiplex_timeout).
 
 ```
 max_routing_connections=1234
@@ -161,7 +161,7 @@ max_routing_connections=1234
 
 If `proxy_protocol` is enabled, MaxScale will send a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) header when connecting client sessions to the server. The header contains the original client IP address and port, as seen by MaxScale. The server will then read the header and perform authentication as if the connection originated from this address instead of MaxScale's IP address. With this feature, the user accounts on the backend server can be simplified to only contain the actual client hosts and not the MaxScale host.
 
-**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](maxscale-servers.md#proxy_protocol_networks) in MaxScale. This also needs to be done whenever one MaxScale may connect to another Maxscale and the connecting MaxScale has `proxy_protocol` enabled.
+**NOTE**: If you use a cloud load balancer like AWS ELB that supports the proxy protocol in front of a MaxScale, you need to configure [proxy\_protocol\_networks](maxscale-listeners.md#proxy_protocol_networks) in MaxScale. This also needs to be done whenever one MaxScale may connect to another Maxscale and the connecting MaxScale has `proxy_protocol` enabled.
 
 PROXY protocol will be supported by MariaDB 10.3, which this feature has been tested with. To use it, enable the PROXY protocol in MaxScale for every compatible server and configure the MariaDB servers themselves to accept the protocol headers from MaxScale's IP address. On the server side, the protocol should be enabled only for trusted IPs, as it allows the sender to spoof the connection origin. If a proxy header is sent to a server not expecting it, the connection will fail. Usually PROXY protocol should be enabled for every server in a cluster, as they typically have similar grants.
 


### PR DESCRIPTION
The **maxscale** slice of [DOCS-6499](https://mariadbcorp.atlassian.net/browse/DOCS-6499) (phase 3b). **50 occurrences / 35 decisions / 15 files**, all live→live. Second slice, after connectors (#945, now merged).

**Rebased onto current `main` after #945 merged, and re-measured** — the figures below are against the post-#945 baseline of 377, not the 413 this branch was first cut from. Diffstat unchanged through the rebase (15 files, 46/46), so nothing was dropped.

**Link targets only — no headings added, no prose moved.**

## This slice isn't typos, it's an un-followed reorganisation

Object settings were moved **out of `maxscale-configuration-guide.md`** into the per-object reference pages, and the inbound links never followed. Several point the wrong way in *both directions at once*: the configuration guide links to server settings it no longer holds, while `maxscale-servers.md` carries same-page links to settings that now live in the guide.

That made most decisions verifiable rather than judgement calls — the pages name their own answers:

* The PAM authenticator page says *"consider using **the listener setting** `user_mapping_file`"* — and `maxscale-listeners.md` publishes `#user_mapping_file`.
* On the listeners page the link text already read **"server settings"** while pointing at itself.
* `idle_session_pool_time` and `multiplex_timeout` are described in their own prose as **service** settings, which is where the guide documents them.
* Both `address`/`socket`/`port` sources sit under a **`maxscale-server-resource`** heading — which resolves the one real ambiguity in the slice, since the listeners *and* servers pages both publish those three anchors.

## Repairs

| Fix | Occ |
| --- | --- |
| → `maxscale-listeners.md` (`user_mapping_file` 5×, `redirect_url`) | 6 |
| → `maxscale-servers.md` (`use_service_credentials`, `proxy_protocol` 2×, `max_routing_connections`/`persistpoolmax`/`persistmaxtime` 2× each, `address`/`socket`/`port` 2× each) | 12 |
| → the configuration guide (`idle_session_pool_time`, `multiplex_timeout`, Encrypting Passwords) | 3 |
| → `maxscale-listeners.md#proxy_protocol_networks` | 1 |
| Bold blocks (no anchor) → the enclosing h4 that contains them | 20 |
| → the guide's real `#enumerations` h4 — wrong *page*, not a stale fragment | 2 |
| Unlinked — link and target block in the same MaxGUI section | 2 |
| `preprocessor_script` — fragment dropped, see below | 1 |
| Regular-expression filter settings (part of the 20 above) | *5* |

The 20 bold-block repairs are the same **KB→GitBook heading demotion** that #945 hit and DOCS-6497 phase 3a documented: 13 key-manager settings (`file.keyfile`, `kmip.*`, `vault.*`) to their respective *Settings for … Key Manager* sections, 5 *Standard regular expression settings for filters* links to *Regular Expressions*, and the two NoSQL links to the `find` and `update` command sections that their own link text already names (*"Find.projection"*, *"Update.behavior"*).

## One finding worth a reviewer's eye

`preprocessor_script` loses its fragment rather than being repointed. Verified against the MaxScale source: **the ExasolRouter has no such parameter** — that name is an internal variable, and the router's real setting is `preprocessor`. The router page's documented values and default for `preprocessor` match the source; the settings page's entry for it does **not**, and the settings page additionally documents `preprocessor_script` as a parameter that does not exist.

That factual discrepancy is out of scope for an anchor-repair PR and is filed separately. Here the link simply points at the router page, which documents the router's real settings.

## Verification

| Check | Result |
| --- | --- |
| `fragcheck check` — `absent` | **377 → 327**, i.e. −50, exactly the number fixed |
| MaxScale findings remaining | **0** |
| Unresolvable targets | unchanged at 1 — which is what proves **no rewritten relative path is broken** |
| `fragcheck new origin/main` | clean — no new dead anchors, no new stolen ids |
| `fragcheck ids` | 0 |
| Fragment-link total | 16,304 → 16,301 — exactly the 2 unlinks plus the 1 dropped fragment, an *independent* second count |
| Diff invariance | 44/46 line pairs identical once link targets are blanked; the other 2 are the unlinks, **byte-identical** in reader-visible text |
| `doc-lint.sh` (paths passed) | exit 0 |
| `codespell` (CI-exact) | exit 0 |
| `lychee` (CI-exact args, 1,191 links) | 0 errors, exit 0 |
| Live rendered anchors | **290/290** on the four target pages whose structure is unchanged, incl. the configuration guide at 227/227; both NoSQL targets confirmed present in rendered HTML |

Baseline re-measured against current `main` both before applying and again after rebasing onto merged #945, per the ticket's rule 1. The two slices share no file, which is why the rebase was conflict-free.

## Also spotted, filed not fixed

`fragcheck.py` computes `#type` / `#elemmatch` / `#accumulators-group` for the NoSQL page's `$`-prefixed headings, but **GitBook maps `$` to the literal `usd`** (`$type` → `usdtype`, `Accumulators ($group)` → `accumulators-usdgroup`). A missing symbol rule alongside `&`→and and `>`→greater-than, same family as the h5 gap in DOCS-6503. No link in the tree targets the miscomputed anchors, so the campaign baseline is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6499]: https://mariadbcorp.atlassian.net/browse/DOCS-6499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
