### PR TITLE
DOCS-6499 Repair 9 dead anchors aimed at bold paragraphs

### DIFF
--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -73,6 +73,11 @@ jobs:
           # Actions runners outright (serves 200 to a normal client), and
           # csm.mariadb.com is the customer support portal, which answers 403 to
           # anyone not logged in. Both links are valid for readers.
+          # DOCS-6499 adds docs.ansible.com, same class as blogspot.com: it
+          # answers the runners with 429 on every request (7 links on one page,
+          # two consecutive runs) while serving 301 -> 200 to a normal client.
+          # The 429 is host-level rate limiting, so replacing the URLs with
+          # their resolved /projects/ansible/ form would not help.
           #
           # Note for editors: the args block below is a YAML folded scalar, so
           # a '#' line inside it is NOT a comment -- it would be passed to
@@ -221,6 +226,7 @@ jobs:
             --exclude www\.shannon-sys\.com
             --exclude www\.hashicorp\.com
             --exclude blogspot\.com
+            --exclude docs\.ansible\.com
             --exclude www\.poliarch\.org
             --exclude www\.reddit\.com
             --exclude csm\.mariadb\.com

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -975,7 +975,7 @@ GRANT <privilege> ON <db_name>.<object> TO PUBLIC;
 REVOKE <privilege> ON <db_name>.<object> FROM PUBLIC;
 ```
 
-`GRANT ... TO PUBLIC` grants privileges to all users with access to the server. The privileges also apply to users created after the privileges are granted. This can be useful when you only want to state once that all users need to have a certain set of privileges. When running [SHOW GRANTS](../administrative-sql-statements/show/show-grants.md), a user also sees all privileges inherited from `PUBLIC`. [SHOW GRANTS FOR PUBLIC](../administrative-sql-statements/show/show-grants.md#for-public) only shows `TO PUBLIC` grants.
+`GRANT ... TO PUBLIC` grants privileges to all users with access to the server. The privileges also apply to users created after the privileges are granted. This can be useful when you only want to state once that all users need to have a certain set of privileges. When running [SHOW GRANTS](../administrative-sql-statements/show/show-grants.md), a user also sees all privileges inherited from `PUBLIC`. [SHOW GRANTS FOR PUBLIC](../administrative-sql-statements/show/show-grants.md#roles) only shows `TO PUBLIC` grants.
 
 **Example**
 

--- a/server/reference/sql-statements/table-statements/analyze-table.md
+++ b/server/reference/sql-statements/table-statements/analyze-table.md
@@ -49,7 +49,7 @@ The [Aria](../../../server-usage/storage-engines/aria/) storage engine supports 
 
 {% tabs %}
 {% tab title="Current" %}
-**Skipping Long CHAR/VARCHAR Columns**
+### Skipping Long CHAR/VARCHAR Columns
 
 When using `ANALYZE TABLE PERSISTENT`, MariaDB skips long [`CHAR`](../../data-types/string-data-types/char.md)/[`VARCHAR`](../../data-types/string-data-types/varchar.md) columns during statistics collection if they exceed the value of the [`analyze_max_length`](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#analyze_max_length) system variable.
 

--- a/server/security/encryption/data-at-rest-encryption/data-at-rest-encryption-tde-fundamentals.md
+++ b/server/security/encryption/data-at-rest-encryption/data-at-rest-encryption-tde-fundamentals.md
@@ -298,7 +298,7 @@ plugin_load_add = file_key_management
 {% step %}
 **Verify encryption is turned off.**
 
-Use [the same SQL statement shown above](data-at-rest-encryption-tde-fundamentals.md#verify-encryption-is-turned-on) to verify encryption is turned off.
+Use [the same SQL statement shown above](data-at-rest-encryption-tde-fundamentals.md#enabling-data-at-rest-encryption) to verify encryption is turned off.
 {% endstep %}
 {% endstepper %}
 

--- a/server/server-management/automated-mariadb-deployment-and-administration/ansible-and-mariadb/installing-mariadb-deb-files-with-ansible.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/ansible-and-mariadb/installing-mariadb-deb-files-with-ansible.md
@@ -13,7 +13,7 @@ Here we discuss how to automate such tasks using Ansible. For example, here we s
 
 ## Adding apt Repositories
 
-To [add a repository](../../install-and-upgrade-mariadb/installing-mariadb/binary-packages/installing-mariadb-deb-files.md#executing-add-apt-repository):
+To [add a repository](../../install-and-upgrade-mariadb/installing-mariadb/binary-packages/installing-mariadb-deb-files.md#using-the-mariadb-repository-configuration-tool):
 
 ```yaml
 - name: Add specified repository into sources list
@@ -22,7 +22,7 @@ To [add a repository](../../install-and-upgrade-mariadb/installing-mariadb/binar
     state: present
 ```
 
-If you prefer to keep the repository information in a [source list file](../../install-and-upgrade-mariadb/installing-mariadb/binary-packages/installing-mariadb-deb-files.md#creating-a-source-list-file) in the Ansible repository, you can upload that file to the target hosts in this way:
+If you prefer to keep the repository information in a [source list file](../../install-and-upgrade-mariadb/installing-mariadb/binary-packages/installing-mariadb-deb-files.md#using-the-mariadb-repository-configuration-tool) in the Ansible repository, you can upload that file to the target hosts in this way:
 
 ```yaml
 - name: Create a symbolic link

--- a/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-options.md
+++ b/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-options.md
@@ -124,7 +124,7 @@ When enabled, whether using `ON` or `AUTO`, `mariadb-backup` retrieves informati
 mariadb-backup --binlog-info --backup
 ```
 
-Currently, the `LOCKLESS` option depends on features unsupported by MariaDB Server. See the description of the [xtrabackup\_binlog\_pos\_innodb](files-created-by-mariadb-backup.md#xtrabackup_binlog_pos_innodb) file for more information. If you attempt to run `mariadb-backup` with this option, then it causes the utility to exit with an error.
+Currently, the `LOCKLESS` option depends on features unsupported by MariaDB Server. See the description of the [xtrabackup\_binlog\_pos\_innodb](files-created-by-mariadb-backup.md) file for more information. If you attempt to run `mariadb-backup` with this option, then it causes the utility to exit with an error.
 
 ### `--close-files`
 
@@ -158,7 +158,7 @@ The `--compress` option only supports the now deprecated `quicklz` algorithm.
 mariadb-backup --compress --backup
 ```
 
-If a backup is compressed using this option, then `mariadb-backup` will record that detail in the [xtrabackup\_info](files-created-by-mariadb-backup.md#xtrabackup_info) file.
+If a backup is compressed using this option, then `mariadb-backup` will record that detail in the [xtrabackup\_info](files-created-by-mariadb-backup.md) file.
 
 ### `--compress-chunk-size`
 
@@ -594,7 +594,7 @@ mariadb-backup --backup --history=backup_all
 
 Information is written to `mysql.mariadb_backup_history`.
 
-`mariadb-backup` also records this in the [mariadb\_backup\_info](files-created-by-mariadb-backup.md#mariadb_backup_info) file.
+`mariadb-backup` also records this in the [mariadb\_backup\_info](files-created-by-mariadb-backup.md) file.
 {% endtab %}
 
 {% tab title="< 10.11" %}
@@ -612,7 +612,7 @@ mariadb-backup --backup --history=backup_all
 
 Information is written to `PERCONA_SCHEMA.xtrabackup_history`.
 
-`mariadb-backup` also records this in the [xtrabackup\_info](files-created-by-mariadb-backup.md#xtrabackup_info) file.
+`mariadb-backup` also records this in the [xtrabackup\_info](files-created-by-mariadb-backup.md) file.
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
Sixth slice of DOCS-6499. Nine dead anchors that all share one root cause: the
link aims at a **bold paragraph** rather than a heading, so GitBook publishes no
`id` and the reader is dropped at the top of the page. Inventory (against
`main`) **262 → 253**; stacked after #949 it lands at **176**.

## Only one of the nine is a promotion

The obvious fix — promote the bold text to a real heading — is correct exactly
once. Checking each case against the surrounding markup rather than assuming
turned up two reasons it is wrong elsewhere.

**Repairable (1).** `analyze-table.md:52` — "Skipping Long CHAR/VARCHAR Columns"
is a plain bold paragraph sitting between two `h2` sections, where every
comparable subsection on the page is an `h3`. Promoted to `h3`. Confirmed
against the live page: its `h3` and `h2` neighbours (`queries-that-benefit`,
`performance-impact`) both emit `id="…"`, while this one emits nothing.

**The bold is a component's own markup (5).** In
`files-created-by-mariadb-backup.md` and
`data-at-rest-encryption-tde-fundamentals.md` the bold labels are inside
`{% tabs %}` / `{% tab %}` and `{% stepper %}` / `{% step %}` blocks — the tab's
per-version file name, the step's title. They are supposed to be bold, and
turning them into headings would break the component. Repointed to the enclosing
section.

**Promotion would publish nothing (2).** In `installing-mariadb-deb-files.md`,
"Executing add-apt-repository" and "Creating a Source List File" are sub-steps of
an `h4`. Promoting them would produce an `h5`, and GitBook publishes anchors for
**h2–h4 only** (DOCS-6503) — the checker would have called it fixed while the
links stayed broken. Both are repointed to the enclosing `h4`,
`#using-the-mariadb-repository-configuration-tool`, which is where the two
Ansible links from `installing-mariadb-deb-files-with-ansible.md` want the reader
to be.

## A page that lost all its anchors

The four links from `mariadb-backup-options.md` into
`files-created-by-mariadb-backup.md` lose their fragment entirely rather than
being retargeted. That page documents the files mariadb-backup writes, and a
tabs conversion replaced the per-file headings with bold labels paired
old-name/new-name inside `{% tabs %}`. Two of its entries still have `###`
headings (`backup-my.cnf`, `ib_logfile0`); six do not, so there is no anchor to
aim at and no single heading that could name both tab variants. The links now
point at the page.

Worth a follow-up on its own — six file entries on a reference page are
unlinkable and absent from the page's table of contents — but restructuring that
page is not a link repair, so it is not folded in here.

## Verification

* `fragcheck check` — **262 → 253 absent**; `fragcheck new origin/main` reports
  no new dead anchors and no new stolen ids.
* Unresolvable targets unchanged at 1.
* Checked fragment links 16256 → 16252. The −4 is exactly the four
  mariadb-backup links that stop carrying a fragment — an independent count.
* The one promotion verified to land at **h3**, inside GitBook's publishing
  range, and confirmed against the rendered page.
* `codespell` (CI-exact invocation) clean; `lychee` with the CI-exact argument
  list run locally over all five changed files — **0 errors**.

## Drive-by: a CI exclude for `docs.ansible.com`

`link-check` failed on seven **pre-existing** external links on
`installing-mariadb-deb-files-with-ansible.md` — all `429 Too Many Requests`
from `docs.ansible.com`. My two hunks on that file are at lines 16 and 25; the
failures are at 40, 63 and 112–116, and `main` already carries all six of those
links. CI scans changed files, so it had to be dealt with for the slice to pass.

Not treated as flakiness: the run failed, was re-run with `--failed`, and
returned **the identical seven 429s**. A local lychee run with the CI-exact
argument list reports 0 errors on the same file, and `curl` gets `301 → 200`.
That is the `blogspot.com` class already in the list — a host that fails only
from CI — so `docs.ansible.com` is excluded, documented in the comment block
*above* `args:` (the block is a YAML folded scalar, so a `#` inside it would be
passed to lychee as an argument).

Replacing the URLs with their resolved `/projects/ansible/…` form was considered
and rejected: the 429 is host-level rate limiting, not per-URL, so it would not
have helped.
