### PR TITLE
DOCS-6499 Repair the last four hand-written dead anchors in Tools

### DIFF
--- a/tools/mariadb-ai-rag/deployment/overview.md
+++ b/tools/mariadb-ai-rag/deployment/overview.md
@@ -23,7 +23,7 @@ Ensure your environment meets the following requirements before starting the dep
 * Operating System: 64-bit Linux
 * Software: Docker Engine and Docker Compose must be installed.
 * Mandatory Credentials:
-  * [MariaDB License Key](overview.md#obtain-and-configure-the-mariadb-license-key): A valid key is required for the application to pass the startup check.
+  * [MariaDB License Key](overview.md#obtain-the-mariadb-license-key): A valid key is required for the application to pass the startup check.
   * Model Provider API Keys: Credentials for chosen model providers (e.g., Google Gemini or OpenAI).
 * Database: A [MariaDB 11.8+](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/11.8/what-is-mariadb-118) instance is required for native vector search support.
 

--- a/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/agent-installation-t-copy.md
+++ b/tools/mariadb-enterprise-manager/administration/deployment/adding-databases/agent-installation-t-copy.md
@@ -96,7 +96,7 @@ The agent is now installed and running as a service.
 
 After the agent is installed, it is running but not yet configured or linked to your MariaDB Enterprise Manager server.
 
-The final step is to link the agent, which is done from the Enterprise Manager UI. Please refer to the ["Adding Databases to MariaDB Enterprise Manager" guide](./#adding-databases-to-mariadb-enterprise-manager) for the specific steps to generate the linking command.
+The final step is to link the agent, which is done from the Enterprise Manager UI. Please refer to the [Adding Databases guide](./) for the specific steps to generate the linking command.
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 

--- a/tools/mariadb-enterprise-operator/security/tls.md
+++ b/tools/mariadb-enterprise-operator/security/tls.md
@@ -170,7 +170,7 @@ For details about the server certificate, see [MariaDB certificate specification
 
 ## CA bundle
 
-As you could appreciate in [MariaDB certificate specification](tls.md#mariadb-certificate-specification) and [MaxScale certificate specification](tls.md#maxscale-certificate-specification), the TLS setup involves multiple CAs. In order to establish trust in a more convenient way, the operator groups the CAs together in a CA bundle that will need to be specified when [securely connecting from your applications](tls.md#connect-applications-with-tls). Every `MariaDB` and `MaxScale` resources have a dedicated bundle of its own available in a `Secret` named `<instance-name>-ca-bundle`.
+As you could appreciate in [MariaDB certificate specification](tls.md#mariadb-certificate-specification) and [MaxScale certificate specification](tls.md#maxscale-certificate-specification), the TLS setup involves multiple CAs. In order to establish trust in a more convenient way, the operator groups the CAs together in a CA bundle that will need to be specified when [securely connecting from your applications](tls.md#secure-application-connections-with-tls). Every `MariaDB` and `MaxScale` resources have a dedicated bundle of its own available in a `Secret` named `<instance-name>-ca-bundle`.
 
 These trust bundles contain non expired CAs needed to connect to the instances. New CAs are automatically added to the bundle after [renewal](tls.md#ca-renewal), whilst old CAs are removed after they expire. It is important to note that both the new and old CAs remain in the bundle for a while to ensure a smooth update when the new certificates are issued by the new CA.
 

--- a/tools/mariadb-enterprise-operator/topologies/maxscale.md
+++ b/tools/mariadb-enterprise-operator/topologies/maxscale.md
@@ -473,7 +473,7 @@ spec:
   # [...]
 ```
 
-Note that, the `Connection` uses the `Service` described in the [Kubernetes Service](maxscale.md#kubernetes-service) section and you are able to specify which MaxScale service to connect to by providing the port (`spec.port`) of the corresponding MaxScale listener.
+Note that, the `Connection` uses the `Service` described in the [Kubernetes Services](maxscale.md#kubernetes-services) section and you are able to specify which MaxScale service to connect to by providing the port (`spec.port`) of the corresponding MaxScale listener.
 
 ## High availability
 


### PR DESCRIPTION
The last hand-written dead anchors anywhere in the docs. 4 anchors, 4 files. **24 → 20**, and everything still standing is either generated output (DOCS-6509) or cloud-owned (DOCS-6510).

A `#fragment` that names no heading still returns 200, so no CI gate sees it — the reader is silently dropped at the top of the page.

| Source | Was | Now | Why |
|---|---|---|---|
| `mariadb-ai-rag/deployment/overview.md:26` | `#obtain-and-configure-the-mariadb-license-key` | `#obtain-the-mariadb-license-key` | The heading dropped "and Configure" — configuring the key is a separate step further down the same page (`#configure-database-and-security-keys`). This link is the Prerequisites bullet pointing forward at the obtain step, so it wants the shorter one. |
| `mariadb-enterprise-operator/security/tls.md:173` | `#connect-applications-with-tls` | `#secure-application-connections-with-tls` | Renamed. |
| `mariadb-enterprise-operator/topologies/maxscale.md:476` | `#kubernetes-service` | `#kubernetes-services` | Heading is plural. The link text was singular too, so it's now aligned with the section it points at. |
| `…/adding-databases/agent-installation-t-copy.md:99` | `./#adding-databases-to-mariadb-enterprise-manager` | `./` | See below. |

## The one that wasn't a section

`agent-installation-t-copy.md` pointed at `./#adding-databases-to-mariadb-enterprise-manager`. That fragment is a **page title**, not a section — and GitBook publishes no anchor for an `h1`, so it could never have worked in this space. The README it points at is now titled "Adding Databases" and has only two sections (`Option 1: …`, `Option 2: …`), neither of which is what the sentence wants: it's telling the reader to go read that guide. So the page is the destination, and the visible text now matches the page it lands on.

## A deletion I checked and did not make

That filename looks like a GitBook editor copy artefact, so before repairing its link I checked whether the file should just go. It shouldn't:

- it's in `tools/SUMMARY.md` as the nav entry "Agent Installation";
- two other pages link to it (`quickstart-guide.md:137`, `deployment/README.md:26`);
- its `# Agent Installation` heading is distinct from every sibling — it isn't a duplicate of anything.

So it's a real page wearing a bad filename. Renaming it would improve the published URL (`.../agent-installation-t-copy`) but changes a live path and needs a redirect, which is well outside a link-repair PR. Worth its own ticket if anyone cares about the URL; I'd rather flag it than smuggle it in here.

## Verification

- Inventory: `24 → 20` absent (exactly 4).
- `fragcheck new main` → no new dead anchors, no stolen heading ids.
- Unresolvable targets steady at 1.
- Checked fragment links `16177 → 16176`, down by exactly the one link that stops carrying a fragment — an independent second count.
- All three replacement anchors verified at h2–h4 (DOCS-6503).
- codespell CI-exact: clean. lychee CI-exact, locally: 109 OK / 0 errors.

## Campaign total

This closes out the repairable part of DOCS-6499. Across 12 slices: **1,256 → 20**, and the 20 that remain are 15 in a generated CRD reference (needs a generator change, DOCS-6509) and 5 in the cloud docs (DOCS-6510). No hand-authored dead heading anchor is left in the corpus.
