### PR TITLE
DOCS-6498 Strip literal footnote markup from CREATE TABLE syntax fences

### DIFF
--- a/server/reference/sql-statements/data-definition/create/create-table.md
+++ b/server/reference/sql-statements/data-definition/create/create-table.md
@@ -11,7 +11,7 @@ description: >-
 <pre class="language-sql"><code class="lang-sql">CREATE [OR REPLACE] [TEMPORARY] TABLE [IF NOT EXISTS] tbl_name
     (<a data-footnote-ref href="#user-content-fn-1">create_definition</a>,...) [<a data-footnote-ref href="#user-content-fn-2">table_options</a>    ]... [<a data-footnote-ref href="#user-content-fn-3">partition_options</a>]
 CREATE [OR REPLACE] [TEMPORARY] TABLE [IF NOT EXISTS] tbl_name
-    [(<a data-footnote-ref href="#user-content-fn-2">create_definition</a>,...)] [<a data-footnote-ref href="#user-content-fn-4">table_options</a>   ]... [<a data-footnote-ref href="#user-content-fn-3">partition_options</a>]
+    [(<a data-footnote-ref href="#user-content-fn-1">create_definition</a>,...)] [<a data-footnote-ref href="#user-content-fn-2">table_options</a>   ]... [<a data-footnote-ref href="#user-content-fn-3">partition_options</a>]
     select_statement
 CREATE [OR REPLACE] [TEMPORARY] TABLE [IF NOT EXISTS] tbl_name
    { LIKE old_table_name | (LIKE old_table_name) }
@@ -622,9 +622,9 @@ table_option:
   | ADAPTIVE_HASH_INDEX [=] {DEFAULT | YES | NO}
   | AUTO_INCREMENT [=] number
   | AVG_ROW_LENGTH [=] number
-  | [DEFAULT] CHARACTER SET [=] <a data-footnote-ref href="#user-content-fn-7">charset_name</a>
+  | [DEFAULT] CHARACTER SET [=] charset_name
   | CHECKSUM [=] {0 | 1}
-  | [DEFAULT] COLLATE [=] <a data-footnote-ref href="#user-content-fn-7">collation_name</a>
+  | [DEFAULT] COLLATE [=] collation_name
   | COMMENT [=] 'string'
   | CONNECTION [=] 'connect_string'
   | DATA DIRECTORY [=] 'absolute path to directory'
@@ -852,7 +852,7 @@ partition_options:
         | [LINEAR] KEY(column_list)
         | RANGE(expr)
         | LIST(expr)
-        | SYSTEM_TIME [INTERVAL time_quantity <a data-footnote-ref href="#user-content-fn-8">time_unit</a>] [LIMIT num] }
+        | SYSTEM_TIME [INTERVAL time_quantity time_unit] [LIMIT num] }
     [PARTITIONS num]
     [SUBPARTITION BY
         { [LINEAR] HASH(expr)


### PR DESCRIPTION
Fixes [DOCS-6498](https://mariadbcorp.atlassian.net/browse/DOCS-6498).

`create-table.md` is one of the highest-traffic reference pages in the docs, and readers of the `table_option` and `partition_options` syntax listings were being shown raw HTML.

## The defect

GitBook **interprets** annotation markup inside a `<pre class="language-…">` block but **escapes** it inside a plain ` ```bnf ` fence. This page uses both forms, and three annotation tags had been pasted into the fenced listings, so they printed as literal tag text:

```
  | [DEFAULT] CHARACTER SET [=] <a data-footnote-ref href="#user-content-fn-7">charset_name</a>
  | [DEFAULT] COLLATE [=] <a data-footnote-ref href="#user-content-fn-7">collation_name</a>
        | SYSTEM_TIME [INTERVAL time_quantity <a data-footnote-ref href="#user-content-fn-8">time_unit</a>] [LIMIT num] }
```

Verified against the live rendered page, not inferred: `user-content-fn-` survives literally exactly 6 times in the published HTML — 4× fn-7 and 2× fn-8, i.e. these three lines counted once in the markup and once in the page's JSON payload. Every other annotation on the page renders correctly as a `<dfn>` tooltip with a dotted underline.

**Stripping loses nothing.** These refs point at footnotes 7 and 8, and the page defines only `[^1]`–`[^6]`. They were dead even in the block type where GitBook would have interpreted them.

## Drive-by fix (same file)

The second `CREATE TABLE` form annotated `create_definition` with footnote **2** (→ Table Options) and `table_options` with footnote **4** (→ Periods). The first form annotates those same two identifiers with **1** (→ Column Definitions) and **2** (→ Table Options). The page contradicted itself, and the second form's tooltips were sending readers to the wrong sections — a working tooltip pointing somewhere wrong, which is harder to notice than a broken one.

Corrected to match the first form. Note this deviates from the ticket's literal acceptance criterion ("the working tooltips … are untouched"), which I wrote before spotting the mismatch; the intent was "don't break the working ones", and CI lints changed *files*, so leaving a known-wrong ref on a file I'm already touching seemed worse.

## Verification

- **Live HTML** — 3 escaped `data-footnote-ref` inside `highlight-line` spans before; the three source lines now carry no markup at all.
- **No HTML anchor remains inside any plain fence on this file** — 0, checked by walking fence state.
- **Every footnote ref now resolves**: refs `[1,2,3,4,5,6]`, defs `[1,2,3,4,5,6]`, undefined `[]` (was `[7,8]`).
- **Repo-wide audit** of footnote ref↔definition numbering across all 9 files that use this markup: create-table.md was the **only** file with an undefined ref. The other 8 are all internally consistent.
- `doc-lint.sh` exit 0; `codespell` (CI-exact invocation) exit 0.
- `lychee` with the CI-exact argument list on the changed file: **219 total, 219 OK, 0 errors**.
- `fragcheck new main`: no new dead heading anchors, no new stolen ids.

## Note for DOCS-6503 (fragcheck accuracy)

While auditing this I confirmed a fragcheck blind spot worth recording on that ticket: `fragcheck` reports **21 `[footnote]` findings** across 9 files, and **all 21 are false positives**. It flags every `#user-content-fn-N` link as dead because it does not parse `[^N]:` definition lines. The genuine defect on create-table.md was invisible to it for the opposite reason — the three bad refs sit inside a code fence, which it correctly skips. Neither the true positive nor the false ones were actionable from its output alone.


[DOCS-6498]: https://mariadbcorp.atlassian.net/browse/DOCS-6498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ