### PR TITLE
DOCS-6504 Correct the ExasolRouter settings on the configuration settings page

### DIFF
--- a/maxscale/reference/maxscale-configuration-settings.md
+++ b/maxscale/reference/maxscale-configuration-settings.md
@@ -3146,13 +3146,13 @@ description: >-
 * Dynamic: Yes
 * Default: None
 
-**\[switchover\_on\_low\_disk\_space`\*\*](../reference/maxscale-monitors/mariadb-monitor.md#switchover_on_low_disk_space)**
+[**switchover\_on\_low\_disk\_space**](maxscale-monitors/mariadb-monitor.md#switchover_on_low_disk_space)
 
 * Type: [boolean](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: Yes
 * Default: `false`&#x20;
-* Description: Lists the servers that are excluded from being promoted to primary during failover or automatic selection.
+* Description: Enables automatic switchover of a primary server that is low on disk space to a replica without disk space issues.
 
 [**switchover\_timeout**](maxscale-monitors/mariadb-monitor.md#switchover_timeout)
 
@@ -3347,70 +3347,6 @@ description: >-
 * Mandatory: No
 * Default: `""`&#x20;
 * Description: Specifies the username used for backend connections when the MongoDB client is unauthenticated.
-
-### reference/maxscale-rest-api
-
-#### [maxscale-filter-resource](maxscale-rest-api/maxscale-filter-resource.md)
-
-**Resource Operations**
-
-**\[Create a filter]\(../reference/maxscale-rest-api/maxscale-filter-resource.md#Create a filter)**
-
-* Type of the object, must be `filters`
-* `data.attributes.module`
-* The filter module to use
-
-#### [maxscale-listener-resource](maxscale-rest-api/maxscale-listener-resource.md)
-
-**Resource Operations**
-
-**\[Create a new listener]\(../reference/maxscale-rest-api/maxscale-listener-resource.md#Create a new listener)**
-
-* Type of the object, must be `listeners`
-* `data.attributes.parameters.port` OR `data.attributes.parameters.socket`
-* The TCP port or UNIX Domain Socket the listener listens on. Only one of the fields can be defined.
-* `data.relationships.services.data`
-* The service relationships data, must define a JSON object with an `id` value that defines the service to use and a `type` value set to `services`.
-
-#### [maxscale-monitor-resource](maxscale-rest-api/maxscale-monitor-resource.md)
-
-**Resource Operations**
-
-**\[Create a monitor]\(../reference/maxscale-rest-api/maxscale-monitor-resource.md#Create a monitor)**
-
-* Type of the object, must be `monitors`
-* `data.attributes.module`
-* The monitor module to use
-* `data.attributes.parameters.user`
-* The [`user`](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user) to use
-* `data.attributes.parameters.password`
-* The [password](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#password) to use
-
-#### [maxscale-server-resource](maxscale-rest-api/maxscale-server-resource.md)
-
-**Resource Operations**
-
-**\[Create a server]\(../reference/maxscale-rest-api/maxscale-server-resource.md#Create a server)**
-
-* Type of the object, must be `servers`
-* `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [`address`](maxscale-servers.md#address) or [`socket`](maxscale-servers.md#socket) to use. Only one of the fields can be defined.
-* `data.attributes.parameters.port`
-* The [`port`](maxscale-servers.md#port) to use. Needs to be defined if the `address` field is defined.
-
-#### [maxscale-service-resource](maxscale-rest-api/maxscale-service-resource.md)
-
-**Resource Operations**
-
-**\[Create a service]\(../reference/maxscale-rest-api/maxscale-service-resource.md#Create a service)**
-
-* Type of the object, must be `services`
-* `data.attributes.router`
-* The router module to use
-* `data.attributes.parameters.user`
-* The [`user`](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#user) to use
-* `data.attributes.parameters.password`
-* The [`password`](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#password) to use
 
 ### reference/maxscale-routers
 
@@ -3672,22 +3608,54 @@ description: >-
 * Dynamic: No
 * Description: Specifies the Exasol ODBC connection string used to connect to the database.
 
+[**kill\_connection\_timeout**](maxscale-routers/maxscale-exasolrouter.md#kill_connection_timeout)
+
+* Type: [duration](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#durations)
+* Mandatory: No
+* Dynamic: No
+* Default: `10s`&#x20;
+* Description: Sets how long an unused kill connection is kept alive after the last KILL command. A value of `0` closes it immediately after each use.
+
+[**login\_timeout**](maxscale-routers/maxscale-exasolrouter.md#login_timeout)
+
+* Type: [duration](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#durations)
+* Mandatory: No
+* Dynamic: No
+* Default: `30s`&#x20;
+* Description: Sets the login timeout for a connection, overriding `LOGINTIMEOUT` in the connection string. A value of `0` leaves the connection string value in effect.
+
 [**preprocessor**](maxscale-routers/maxscale-exasolrouter.md#preprocessor)
 
-* Type: String
+* Type: string
 * Mandatory: No
 * Dynamic: No
-* Values: `auto`, `activate-only`, `custom:<path>`, `disabled`
-* Default: `auto`&#x20;
-* Description: Defines how the Exasol preprocessor script is managed: auto-installed, activate-only, custom path, or disabled.
+* Values: `disabled`, `external[:preprocessor-script-name]`, `internal[:preprocessor-script-path]`
+* Default: `internal`, if the distribution provides a new enough Python implementation, `disabled` if not&#x20;
+* Description: Determines how MariaDB SQL is transpiled for Exasol: internally with a Python script, externally by a preprocessor script in Exasol, or not at all.
 
-[**preprocessor\_script**](maxscale-routers/maxscale-exasolrouter.md)
+[**python\_libdir**](maxscale-routers/maxscale-exasolrouter.md#python_libdir)
 
-* Type: String
+* Type: path
 * Mandatory: No
 * Dynamic: No
-* Default: "UTIL.maria\_preprocessor"
-* Description: Specifies the name of a custom Exasol preprocessor script when using a custom preprocessor path.
+* Default: `<maxscale-libdir>/python3/site-packages`&#x20;
+* Description: Specifies the directory that SQLGlot is loaded from when `preprocessor` is `internal`.
+
+[**query\_timeout**](maxscale-routers/maxscale-exasolrouter.md#query_timeout)
+
+* Type: [duration](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#durations)
+* Mandatory: No
+* Dynamic: No
+* Default: `30s`&#x20;
+* Description: Sets the query timeout for a connection, overriding `QUERYTIMEOUT` in the connection string. A value of `0` leaves the connection string value in effect.
+
+[**quote\_identifiers**](maxscale-routers/maxscale-exasolrouter.md#quote_identifiers)
+
+* Type: [boolean](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#booleans)
+* Mandatory: No
+* Dynamic: No
+* Default: `true`&#x20;
+* Description: Determines whether the router quotes identifiers when converting a `COM_INIT_DB` packet to `OPEN SCHEMA`, and when transpiling internally with `preprocessor` set to `disabled`.
 
 #### [maxscale-kafkacdc](maxscale-routers/maxscale-kafkacdc.md)
 

--- a/maxscale/reference/maxscale-monitors/mariadb-monitor.md
+++ b/maxscale/reference/maxscale-monitors/mariadb-monitor.md
@@ -815,7 +815,7 @@ The following series of events demonstrates failback switchover:
 6. Some time later, P comes back online. Monitor rejoins it to the cluster.
 7. If P successfully replicates from R2 (no diverged histories) and catches up, the monitor runs switchover to restore P as primary.
 
-#### `switchover_on_low_disk_space`\*\*
+#### `switchover_on_low_disk_space`
 
 * Type: [boolean](../../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md#booleans)
 * Mandatory: No


### PR DESCRIPTION
Fixes [DOCS-6504](https://mariadbcorp.atlassian.net/browse/DOCS-6504).

## Correcting the ticket first

**The ticket's central claim is wrong, and it matters.** I wrote that the documented values "look invented rather than stale" and that `activate-only` "does not occur anywhere in the source, nor in recent history on any branch."

Both are false. Every value on that page was real:

| MaxScale | `preprocessor` accepts | default | `preprocessor_script` |
| --- | --- | --- | --- |
| 25.10.1 | `auto`, `activate-only`, `custom:path`, `disabled` | *(empty)* | exists, default `UTIL.maria_preprocessor` |
| **25.10.2** | `auto`, `activate-only`, `custom:path`, `disabled` | **`auto`** | **exists, default `UTIL.maria_preprocessor`** |
| 25.10.3 | `disabled`, `external[:…]`, `internal[:…]` | `internal` | **removed** |

The settings page is an exact description of **25.10.2** — values, default, and the `preprocessor_script` entry with its documented default. It is stale by one patch release, not invented. My "not in recent history" check simply did not find the three commits that a history search does find.

This changes the useful conclusion. "Invented values" would point at bad authoring; **stale values point at a page that is generated and then never regenerated**, which is a recurring mechanism rather than a one-off mistake.

## What the page said vs. what 25.10.3 does

The docs target 25.10.3 (the trial, tutorial and upgrade pages all reference it). A reader configuring from the settings page would write `preprocessor=auto` — the documented default — or `preprocessor=custom:/path`. Neither is accepted, and nothing on the page hinted that the ExasolRouter page contradicted it. That is the Major part.

The block also listed only **3 of the router's 8** real parameters. This adds the five that were missing: `login_timeout`, `query_timeout`, `python_libdir`, `kill_connection_timeout`, `quote_identifiers`.

## How the block was produced — the ticket's open question

`maxscale/gen_settings_reference` generates this page by scraping `* Type` blocks out of the per-module reference pages. So the settings page is a snapshot of the other docs pages, and the Exasol block went stale because the ExasolRouter page was updated for 25.10.3 while the settings page was not regenerated.

**Regenerating is not available as a fix.** The live page carries **514 `* Description:` bullets, and zero exist in any source page** — they were added by hand after generation. Regenerating produces 3,286 lines against the current 4,350 and drops every description. The page has become a fork of its own inputs with no way to resync, which is the finding worth acting on beyond this ticket.

## Was anything else stale? Measured, not assumed

I compared every entry on the settings page against the source pages the generator reads, field by field (`Type`, `Values`, `Default`, `Mandatory`, `Dynamic`) — **481 shared entries**.

**Result: 2 mismatches, both Exasol's `preprocessor`.** Nothing else on the page has drifted. So the answer to "do other router sections carry the same problem?" is no, and no wider sweep is needed.

I should flag that my first two attempts at this audit reported **16** mismatches, including an apparent `Type`/`Default` row-shift across six configuration-guide parameters. That was a bug in my comparison script, not the docs: entries on this page are delimited by `**bold**` lines, which *start with* `*`, so my bullet scanner consumed the next entry's fields. I only caught it because I opened the page and read one of the six, which was correct. The six are fine.

## Drive-by fixes on the same page

**1. Removed the `Resource Operations` section (5 entries).** The generator matches any line starting with `* Type`, which catches the REST-API pages' nested `* Type of the object, must be …` bullet. It emitted five entries that are not configuration settings, rendering as escaped literal markup over unrelated bullet fragments:

```
**\[Create a filter]\(../reference/maxscale-rest-api/maxscale-filter-resource.md#Create a filter)**

* Type of the object, must be `filters`
* `data.attributes.module`
```

The whole section consisted of nothing else, so it is removed rather than left with empty headings. This is a generator bug (`* Type` should be `* Type:`) and is reported on the ticket.

**2. Repaired the `switchover_on_low_disk_space` entry**, which rendered as literal markup *and* carried `servers_no_promotion`'s description. The cause was a stray `\*\*` on the heading in `mariadb-monitor.md` — the only such heading in the MaxScale docs — fixed there as well. **The heading's anchor is unchanged** (`gitbook_slug` returns `switchover_on_low_disk_space` before and after), so the two inbound links still resolve.

Each of the three parts is independent if you want to take some and not others.

## Verification

- **Exasol now matches source exactly**: 8 parameters, `stale: []`, `missing: []`, and the field-by-field audit is clean.
- **All 8 anchors resolve** on the ExasolRouter page (checked against its published h2–h4 anchors).
- `fragcheck new main`: no new dead heading anchors, no new stolen ids.
- **Fragment-link delta reconciled entry by entry**: 777 → 779. +10 added (5 new parameter anchors, 3 `#durations` and 1 `#booleans` type links for the new duration/boolean parameters, 1 for the switchover link that is now a real link), −8 removed (7 from the deleted section, 1 the old mangled form). +10 −8 = +2, matching the checker's 16,176 → 16,178 exactly.
- 0 mangled `**\[` artifacts remain on the page (was 6).
- `doc-lint.sh` 0; `codespell` CI-exact 0; `lychee` CI-exact on both files: **927 total, 927 OK, 0 errors**.


[DOCS-6504]: https://mariadbcorp.atlassian.net/browse/DOCS-6504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ