### PR TITLE
DOCS-6519 Correct the READ COMMITTED isolation level section

### DIFF
--- a/agent-skills/granular/statements/mariadb-set-transaction/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-set-transaction/SKILL.md
@@ -59,7 +59,7 @@ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 The default is **`REPEATABLE READ`** — set it at startup with `--transaction-isolation=REPEATABLE-READ` (dashes, not spaces, for the option/config-file form) or check it live via `SELECT @@transaction_isolation;`.
 
 - **`READ UNCOMMITTED`** — non-locking reads may see an uncommitted ("dirty") earlier or concurrent version of a row.
-- **`READ COMMITTED`** — each consistent read (even within the same transaction) takes a fresh snapshot; locking reads (`FOR UPDATE`/`LOCK IN SHARE MODE`) skip gap locks except for foreign-key/unique-key checks, so requires row-based binary logging.
+- **`READ COMMITTED`** — each consistent read (even within the same transaction) takes a fresh snapshot; locking reads (`FOR UPDATE`/`LOCK IN SHARE MODE`), `UPDATE`, and `DELETE` skip gap locks, the sole exception being duplicate-key checking on a unique index, which takes a next-key lock at every isolation level. Cannot be combined with `binlog_format=STATEMENT` (fails with error 1665); the default `MIXED` and `ROW` are both fine.
 - **`REPEATABLE READ`** *(default)* — all consistent reads in a transaction reuse the snapshot from the transaction's first read. Minimum isolation level required for non-distributed XA transactions.
 - **`SERIALIZABLE`** — like `REPEATABLE READ`, but plain `SELECT` is implicitly converted to `SELECT ... LOCK IN SHARE MODE` when `autocommit` is disabled. Required for distributed XA transactions.
 

--- a/server/reference/sql-statements/transactions/set-transaction.md
+++ b/server/reference/sql-statements/transactions/set-transaction.md
@@ -76,18 +76,35 @@ The following sections describe how MariaDB supports the different transaction l
 
 A somewhat Oracle-like isolation level with respect to consistent (non-locking) reads: Each consistent read, even within the same transaction, sets and reads its own fresh snapshot. See [innodb-consistent-read.html](https://dev.mysql.com/doc/refman/en/innodb-consistent-read.html).
 
-For locking reads (`SELECT` with `FOR UPDATE` or `LOCK IN SHARE MODE`), InnoDB locks only index records, not the gaps before them, and thus allows the free insertion of new records next to locked records. For `UPDATE` and `DELETE` statements, locking depends on whether the statement uses a unique index with a unique search condition (such as `WHERE id = 100`), or a range-type search condition (such as `WHERE id > 100`). For a unique index with a unique search condition, InnoDB locks only the index record found, not the gap before it. For range-type searches, InnoDB locks the index range scanned, using gap locks or next-key (gap plus index-record) locks to block insertions by other sessions into the gaps covered by the range. This is necessary because "phantom rows" must be blocked for MariaDB replication and recovery to work.
+#### Gap Locking at READ COMMITTED
+
+InnoDB takes no [gap locks](../../../server-usage/storage-engines/innodb/innodb-lock-modes.md#gap-locks) at this isolation level. For locking reads (`SELECT` with `FOR UPDATE` or `LOCK IN SHARE MODE`), and for `UPDATE` and `DELETE` statements, InnoDB locks only the index records it examines, not the gaps before them, and thus allows the free insertion of new records next to locked records. This applies to range-type search conditions (such as `WHERE id > 100`) as well as to unique searches (such as `WHERE id = 100`).
+
+Duplicate-key checking is the exception: when InnoDB checks a unique index for a duplicate value, it takes a next-key (gap plus index-record) lock regardless of the isolation level. [Foreign key](../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md) constraint checks, by contrast, do not take gap locks at `READ COMMITTED`.
+
+Gap locks are what block phantom rows, so without them InnoDB cannot be logged safely one statement at a time. With [binary logging](../../../server-management/server-monitoring-logs/binary-log/) enabled and [binlog\_format](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#binlog_format) set to `STATEMENT`, InnoDB rejects any statement that would write rows:
+
+```sql
+SET SESSION binlog_format = STATEMENT;
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+UPDATE t SET v = 9 WHERE id = 1;
+ERROR 1665 (HY000): Cannot execute statement: impossible to write to binary log
+since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine
+limited to row-based logging. InnoDB is limited to row-logging when transaction
+isolation level is READ COMMITTED or READ UNCOMMITTED.
+```
+
+The default `binlog_format` of `MIXED` is unaffected, as is `ROW`.
+
+#### Semi-Consistent Reads
+
+In a semi-consistent read, an `UPDATE` or `DELETE` statement skips a row that another transaction has locked, provided the latest committed version of that row does not match the `WHERE` condition. The statement proceeds instead of waiting for the lock, which means you might see only a partially consistent read.
 
 {% hint style="info" %}
-If the `READ COMMITTED` isolation level is used or the [innodb\_locks\_unsafe\_for\_binlog](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_locks_unsafe_for_binlog) system variable is enabled, there is no InnoDB gap locking except for [foreign-key](../../../ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys.md) constraint checking and
-duplicate-key checking. Also, record locks for non-matching rows are released after MariaDB has evaluated the `WHERE` condition. If you use `READ COMMITTED` or enable `innodb_locks_unsafe_for_binlog`, you must use row-based binary logging.
+At `READ COMMITTED`, semi-consistent reads apply only when [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) is disabled. That variable is enabled by default from MariaDB 11.6.2, and while it is enabled, `READ COMMITTED` performs an ordinary locking read and waits for the lock. Semi-consistent reads then apply to `READ UNCOMMITTED` only.
 {% endhint %}
 
-{% hint style="info" %}
-Rows that don't match are not being locked in a so called semiconsistent read. This means you might see only a partially consistent read when the transaction isolation level is `READ COMMITTED` or `READ UNCOMMITTED`.
-
-(A semiconsistent read applies to `UPDATE` and `DELETE` statements. Those statements skip locked rows, provided the version in the current read does not match the `WHERE` condition. Also, if the latest version of a record was successfully locked, but found not to match the condition, the lock is released.)
-{% endhint %}
+Separately, and regardless of `innodb_snapshot_isolation`, if InnoDB locks a record at `READ COMMITTED` or `READ UNCOMMITTED` and then finds that the record does not match the `WHERE` condition, it releases that record lock — unless the transaction has itself modified the row.
 
 ### REPEATABLE READ
 
@@ -112,10 +129,10 @@ This is the minimum isolation level for non-distributed [XA transactions](xa-tra
 #### Snapshot Isolation and DML Operations
 
 {% hint style="info" %}
-This behavior is available from MariaDB 11.6.2 and 12.3.
+[innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) is enabled by default from MariaDB 11.6.2. It was added, defaulting to `OFF`, in MariaDB 10.6.18, 10.11.8, 11.0.6, 11.1.5, 11.2.4, and 11.4.2.
 {% endhint %}
 
-The [`innodb_snapshot_isolation`](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) system variable is enabled by default. This introduces a stricter enforcement of `REPEATABLE READ` for `UPDATE` and `DELETE` statements:<br>
+While `innodb_snapshot_isolation` is enabled, MariaDB enforces `REPEATABLE READ` more strictly for `UPDATE` and `DELETE` statements:
 
 * **Conflict Detection:** If an `UPDATE` or `DELETE` attempts to modify a row that has been changed by a concurrent transaction since your snapshot was established, the operation is rejected.
 * [**ER\_CHECKREAD**](../../error-codes/mariadb-error-codes-1000-to-1099/e1020.md) **(1020):** This rejection triggers error `ER_CHECKREAD`. The revised error message suggests that the user should try restarting the transaction.
@@ -132,17 +149,9 @@ This level is like `REPEATABLE READ`, but InnoDB implicitly converts all plain `
 
 Distributed [XA transactions](xa-transactions.md) should always use this isolation level.
 
-### innodb\_snapshop\_isolation
+### innodb\_snapshot\_isolation
 
-{% tabs %}
-{% tab title="Current" %}
-If the [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) system variable is not set to `ON`, strictly-speaking anything other than `READ UNCOMMITTED` is not clearly defined. [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) defaults to `OFF` for backwards compatibility. Setting to `ON` will result in attempts to acquire a lock on a record that does not exist in the current read view raising an error, and the transaction being rolled back.
-{% endtab %}
-
-{% tab title="< 11.4.2 / 11.2.4 / 11.1.15 / 11.0.6 / 10.11.8 / 10.6.18" %}
-If the [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) system variable is not set to `ON`, strictly-speaking anything other than `READ UNCOMMITTED` is not clearly defined.
-{% endtab %}
-{% endtabs %}
+If the [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) system variable is not set to `ON`, strictly speaking anything other than `READ UNCOMMITTED` is not clearly defined. While it is `ON`, an attempt to acquire a lock on a record that does not exist in the current read view raises an error and rolls the transaction back.
 
 ### Access Mode
 

--- a/server/server-usage/storage-engines/innodb/innodb-lock-modes.md
+++ b/server/server-usage/storage-engines/innodb/innodb-lock-modes.md
@@ -154,15 +154,15 @@ Locks are also required for auto-increments - see [AUTO\_INCREMENT handling in I
 
 ## Gap Locks
 
-With the default [isolation level](../../../reference/sql-statements/transactions/set-transaction.md), `REPEATABLE READ`, and, until [MariaDB 10.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.4/what-is-mariadb-104), the default setting of the [innodb\_locks\_unsafe\_for\_binlog](innodb-system-variables.md#innodb_locks_unsafe_for_binlog) variable, a method called gap locking is used. When InnoDB sets a shared or exclusive lock on a record, it's actually on the index record. Records will have an internal InnoDB index even if they don't have a unique index defined. At the same time, a lock is held on the gap before the index record, so that another transaction cannot insert a new index record in the gap between the record and the preceding record.
+With the default [isolation level](../../../reference/sql-statements/transactions/set-transaction.md), `REPEATABLE READ`, a method called gap locking is used. When InnoDB sets a shared or exclusive lock on a record, it's actually on the index record. Records will have an internal InnoDB index even if they don't have a unique index defined. At the same time, a lock is held on the gap before the index record, so that another transaction cannot insert a new index record in the gap between the record and the preceding record.
 
 The gap can be a single index value, multiple index values, or not exist at all depending on the contents of the index.
 
-If a statement uses all the columns of a unique index to search for unique row, gap locking is not used.
+MariaDB does not relax gap locking for unique indexes, so a statement that searches for a single row through all the columns of a unique index still takes a next-key lock.
 
 Similar to the shared and exclusive intention locks described above, there can be a number of types of gap locks. These include the shared gap lock, exclusive gap lock, intention shared gap lock and intention exclusive gap lock.
 
-Gap locks are disabled if the [innodb\_locks\_unsafe\_for\_binlog](innodb-system-variables.md#innodb_locks_unsafe_for_binlog) system variable is set (until [MariaDB 10.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.4/what-is-mariadb-104)), or the [isolation level](../../../reference/sql-statements/transactions/set-transaction.md) is set to `READ COMMITTED`.
+Gap locks are disabled if the [isolation level](../../../reference/sql-statements/transactions/set-transaction.md) is set to [READ COMMITTED](../../../reference/sql-statements/transactions/set-transaction.md#read-committed) or `READ UNCOMMITTED`. Duplicate-key checking on a unique index is the exception, taking a next-key lock at every isolation level.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 


### PR DESCRIPTION
Fixes [DOCS-6519](https://mariadbcorp.atlassian.net/browse/DOCS-6519).

Michael "Monty" Widenius flagged three claims about `READ COMMITTED` as false in `#server-dev` on 2026-08-24. Two of the three turned out to be in our docs near-verbatim, and checking them against the source surfaced four more defects on the same page.

Every claim below was verified against `mariadb-server` at `main` (13.1.0-alpha); the binary-logging example was executed on a live 12.3.3 server.

## The page contradicted itself about gap locking

Line 79 said that at `READ COMMITTED`, range searches lock the index range scanned "using gap locks or next-key (gap plus index-record) locks". The hint three lines below said "there is no InnoDB gap locking". The hint was right:

```
storage/innobase/row/row0sel.cc:4776

  /* Do not lock gaps at READ UNCOMMITTED or READ COMMITTED
  isolation level */
  const bool set_also_gap_locks =
    prebuilt->select_lock_type != LOCK_NONE
    && trx->isolation_level > TRX_ISO_READ_COMMITTED
```

Line 79 was inherited MySQL manual prose describing the pre-10.5 `innodb_locks_unsafe_for_binlog=OFF` world. It is gone; the section now makes one statement, under a `Gap Locking at READ COMMITTED` heading.

## Foreign key checks were the wrong exception

The old text named "foreign-key constraint checking and duplicate-key checking" as the two exceptions. Foreign key checks skip gap locks at `READ COMMITTED` in MariaDB — `row_ins_check_foreign_constraint()` sets `skip_gap_lock = (trx->isolation_level <= TRX_ISO_READ_COMMITTED)` (`row0ins.cc:1479`), then skips the supremum lock, downgrades `LOCK_ORDINARY` to `LOCK_REC_NOT_GAP`, and drops the `LOCK_GAP`.

Duplicate-key checking is the only real exception: `row_ins_scan_sec_index_for_duplicate()` hardcodes `const ulint lock_type = LOCK_ORDINARY;` (`row0ins.cc:2122`) at every isolation level.

## The semi-consistent read hint has been wrong by default since 11.6.2

Semi-consistent read is disabled at `READ COMMITTED` whenever `innodb_snapshot_isolation` is `ON`:

```
storage/innobase/row/row0sel.cc:5405

      /* ... As read view wasn't opened, do locking read
      instead of semi-consistent one for READ COMMITTED. */
      || (trx->snapshot_isolation && trx->isolation_level
        == TRX_ISO_READ_COMMITTED )) {
```

That arrived in 10.6.19 (MDEV-34108), and `innodb_snapshot_isolation` has defaulted to `ON` since 11.6.2 (MDEV-35124). So on default settings the old hint described `READ UNCOMMITTED` only. The narrower surviving claim — a record lock released when the row turns out not to match the `WHERE` condition, unless this transaction modified it (`unlock_row()` / `row_unlock_for_mysql()`) — is now stated separately and scoped correctly.

## Row-based binary logging is not required

The old text said `READ COMMITTED` requires row logging. `binlog_format` defaults to `MIXED` (`sql/sys_vars.cc:718`) and the InnoDB check fires only on `BINLOG_FORMAT_STMT` (`ha_innodb.cc:16654`). Reproduced on 12.3.3 — `STATEMENT` fails with error 1665, `MIXED` and `ROW` both succeed — and the failing case is now shown as a worked example.

## innodb_locks_unsafe_for_binlog was presented as a live variable

Removed in 10.5.0 (MDEV-19544). Our own reference page already records "Removed: MariaDB 10.5.0". Both mentions on `set-transaction.md` are gone, as are the two on `innodb-lock-modes.md`.

## innodb_snapshot_isolation was documented twice, with opposite defaults

Line 118 said "enabled by default"; the *Current* tab of the section below said "defaults to `OFF` for backwards compatibility". The latter was stale and is gone, along with a now-empty version tab. The heading also read `innodb_snapshop_isolation` — no page linked to the misspelt anchor, so renaming it breaks nothing (confirmed with `fragcheck.py new main`).

The version boundary is now stated once: enabled by default from 11.6.2, added defaulting to `OFF` in 10.6.18, 10.11.8, 11.0.6, 11.1.5, 11.2.4, and 11.4.2.

## Drive-by fixes

`server/server-usage/storage-engines/innodb/innodb-lock-modes.md` claimed that "if a statement uses all the columns of a unique index to search for unique row, gap locking is not used". MariaDB stopped relaxing gap locking for unique indexes in 11.0 / 10.11.2 / 10.6.12 and friends — which `set-transaction.md` already documented in its *Current* REPEATABLE READ tab, so the two pages disagreed. The source comment is explicit: "Set next-key lock both for delete- and non-delete-marked records for unique search, because non-delete-marked record can be marked as deleted while transaction suspends" (`row0sel.cc:5334`). The only surviving relaxation is the narrow clustered-index `>=`-exact-match case, not any unique search.

`agent-skills/granular/statements/mariadb-set-transaction/SKILL.md` had inherited the wrong foreign-key exception and the row-logging requirement; both corrected.

## Not in this PR

The question that started the thread — whether `READ COMMITTED` is advisable for high-concurrency workloads — still has no answer in the docs, and `mariadb-transactions-and-isolation-levels-for-sql-server-users.md:164` currently recommends it on scalability grounds that Marko contradicted in the thread (a fresh read view per statement can make `READ COMMITTED` slower than `REPEATABLE READ`). That needs his sign-off rather than source reading alone, so it is filed as [DOCS-6520](https://mariadbcorp.atlassian.net/browse/DOCS-6520) rather than guessed at here. Checking the page while filing turned up three further defects that need no sign-off — the `tx_isolation = 'READ COMMITTED'` config-file recipe on that page is not a valid startup option at all and stops the server from booting — so they are on that ticket too.

## Checks

- `codespell --check-filenames --skip ./.git --ignore-words .codespellignore` on the three changed files: clean.
- `lychee` with the `link-check-pr.yml` excludes: 43 links, 0 errors.
- `fragcheck.py new main`: no new dead heading anchors, no stolen ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6519]: https://mariadbcorp.atlassian.net/browse/DOCS-6519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[DOCS-6520]: https://mariadbcorp.atlassian.net/browse/DOCS-6520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ