### PR TITLE
DOCS-6503 Fix six accuracy defects in fragcheck.py

### DIFF
--- a/.claude/hooks/fragcheck.py
+++ b/.claude/hooks/fragcheck.py
@@ -12,17 +12,35 @@ WHY THIS EXISTS
     This implements GitBook's rules instead. `validate` re-derives them from the
     rendered pages, so they stay checkable rather than folkloric.
 
+WHICH HEADINGS PUBLISH AN ANCHOR:  h2, h3 and h4 ONLY  (DOCS-6503)
+    h1 is the page title. h5 and h6 render as <p><strong class="font-bold">...</strong>
+    </p> with no id at all -- grep '<h5' on any rendered page returns 0. Crediting
+    them made this checker wrong in the OPTIMISTIC direction: it computed an anchor
+    that does not exist, so a link to it was reported as resolving while the reader
+    lands at the top of the page. Such a link is now reported as
+    [unanchored-heading]; the honest repair is to raise the heading to h4, or to
+    retarget the link at the enclosing section -- never to promote a bold paragraph
+    to "#####", which reads as a fix and repairs nothing.
+
 THE SLUG RULES  (each derived from a rendered id="..." on mariadb.com/docs)
-    * a level-1 heading is the page title and publishes no anchor
     * lowercase; dots and underscores survive
     * an explicit <a ... id="x"> inside the heading line WINS over the text slug
       (KB-migration debris, and GitBook honours it) -- an id="..." in prose does not
-    * & -> and, | -> or, > -> greater-than, < -> less-than
+    * HTML entities are decoded FIRST, so a trailing "&#x20;" is a space and not an
+      "&" to be spelled out (columnstore_cache_use_import&#x20; -> ..._import)
+    * a footnote reference in the heading contributes nothing:
+      "EITS[^1] vs. InnoDB Statistics" -> eits-vs.-innodb-statistics
+    * a trailing kramdown "{#id}" is removed from the text
+    * CHARMAP characters are spelled out rather than collapsed to a dash:
+      & -> and, | -> or, > -> greater-than, < -> less-than, $ -> usd
+      ("$type" -> usdtype, "Accumulators ($group)" -> accumulators-usdgroup),
+      U+00AE -> -r- ("MongoDB(R) Shell" -> mongodb-r-shell)
     * apostrophes vanish leaving no dash (Node's -> nodes)
     * every other run of non-word characters collapses to one dash
       (TLS/SSL -> tls-ssl, "(options) -> PoolCluster" -> options-greater-than-poolcluster)
     * "+" vanishes AFTER that collapse, so it leaves its two dashes behind:
-      "5.3.2 + MyISAM" -> "5.3.2--myisam", while "x--an Imperfect Solution"
+      "5.3.2 + MyISAM" -> "5.3.2--myisam" (then id- prefixed, being digit-led),
+      while "x--an Imperfect Solution"
       (a literal double dash, one separator run) -> "x-an-imperfect-solution"
     * leading/trailing "-" and trailing "." / "_" are trimmed
     * a digit-leading slug is prefixed "id-" (2_DIGIT_YEAR -> id-2_digit_year)
@@ -30,12 +48,19 @@ THE SLUG RULES  (each derived from a rendered id="..." on mariadb.com/docs)
     * duplicate slugs get -1, -2, ... in document order
 
     Validated at 4,599/4,599 computed anchors over 99 pages (47 sampled at
-    random, 45 chosen for punctuation density, 7 used to derive the rules).
+    random, 45 chosen for punctuation density, 7 used to derive the rules) -- and
+    that sample, picked for punctuation DENSITY, happened to contain no h5, no "$"
+    and no "(R)", which is how five rule gaps survived it (DOCS-6503). The second
+    sweep picked pages for STRUCTURAL variety instead: every character that occurs
+    in a heading anywhere in the repo and is not a plain ASCII word character, two
+    pages each -- 33 pages, 1,317 anchors. Whatever GitBook transliterates that
+    CHARMAP does not cover is REPORTED rather than guessed at; see unmappable().
 
 MODES
     fragcheck.py check [path ...]        dead anchors under each path (default: repo)
     fragcheck.py new <rev> [path ...]    only what <rev> had fine -- the gate
     fragcheck.py ids [path ...]          headings publishing another heading's anchor
+    fragcheck.py risky [path ...]        headings whose computed anchor is a guess
     fragcheck.py anchors <file.md>       the anchors one file publishes
     fragcheck.py validate <file.md> ...  compare computed anchors to the live page
 
@@ -49,6 +74,7 @@ inbound links from untouched pages still fails. It gates two classes:
       invisible to every link checker, this one included, because the anchors all
       exist and resolve; they just land on the wrong section
 """
+import html
 import os
 import re
 import shutil
@@ -56,6 +82,7 @@ import subprocess
 import sys
 import tempfile
 import pathlib
+import unicodedata
 import urllib.parse
 from collections import Counter
 
@@ -63,23 +90,45 @@ BASE_URL = 'https://mariadb.com/docs'
 CACHE = pathlib.Path(tempfile.gettempdir()) / 'fragcheck-cache'
 MAX_SLUG = 100
 
+# The levels GitBook renders as <h2>/<h3>/<h4 id="..."> — see the header comment.
+ANCHORED = (2, 3, 4)
+
 # Not GitBook spaces, so their links are never published: skip them.
 UNPUBLISHED = ('agent-skills/', 'help-tables/', 'dev-docs/', 'dist/', 'pdf/',
-               '.claude/', '.github/')
+               '.claude/', '.github/', '.git/')
 
 FENCE = re.compile(r'^\s*(```|~~~)')
 HEADING = re.compile(r'^(#{1,6})\s+(.*?)\s*$')
 HEADING_ID = re.compile(r'''<a\b[^>]*\bid\s*=\s*["']([^"']+)["']''')
+KRAMDOWN_ID = re.compile(r'\s*\{#[A-Za-z0-9._:-]+\}\s*$')
+FOOTNOTE_REF = re.compile(r'\[\^[^\]]+\]')
+FOOTNOTE_DEF = re.compile(r'^\[\^([^\]]+)\]:')
+FOOTNOTE_ANCHOR = re.compile(r'^user-content-fn(?:ref)?-(.+)$')
 CODESPAN = re.compile(r'`+([^`]*)`+')
 LINK = re.compile(r'\]\(\s*<?([^)>\s]+)>?\s*\)')
 ATTR = re.compile(r'''\b(?:href|url)\s*=\s*["']([^"']+)["']''')
 SKIP_PREFIX = ('http://', 'https://', 'mailto:', 'ftp://', '//', '/')
+
+# Spelled out instead of collapsing to a dash. Every entry was read off a rendered
+# id rather than assumed: "&" from "Source format & GitBook blocks", "$" from
+# "#### $type" -> usdtype and "Status Values ($1)" -> status-values-usd1, U+00AE
+# from "MongoDB(R) Shell" -> mongodb-r-shell. The values are GitBook's replacement
+# text, so the separator run around them is left to the collapse step: "(r)" and
+# " and " both end up as one dash on each side. Currency and trademark signs point
+# at a speakingurl-style charmap, so more entries almost certainly exist -- but
+# only the ones a rendered page has confirmed belong here; unmappable() reports
+# the rest instead of extrapolating.
+CHARMAP = {'&': ' and ', '|': ' or ', '>': ' greater than ',
+           '<': ' less than ', '$': 'usd', '®': '(r)'}
 
 
 # ---------------------------------------------------------------- slug rules
 
 def strip_inline(text):
     """Reduce heading markup to the words GitBook renders."""
+    text = html.unescape(text)                              # &#x20; is a space
+    text = KRAMDOWN_ID.sub('', text)                        # trailing {#id}
+    text = FOOTNOTE_REF.sub('', text)                       # [^1] renders as a marker
     text = re.sub(r'!\[([^\]]*)\]\([^)]*\)', r'\1', text)   # images
     text = re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', text)    # links -> label
     text = re.sub(r'<[^>]+>', '', text)                     # html tags
@@ -101,8 +150,8 @@ def strip_inline(text):
 
 def gitbook_slug(heading):
     s = strip_inline(heading).lower()
-    s = (s.replace('&', '-and-').replace('|', '-or-')
-          .replace('>', '-greater-than-').replace('<', '-less-than-'))
+    for char, spelled in CHARMAP.items():
+        s = s.replace(char, spelled)
     s = re.sub(r"['‘’]", '', s)     # apostrophes leave no dash
     s = re.sub(r'[^a-z0-9._+]+', '-', s)      # separator runs -> one dash
     s = s.replace('+', '')                    # ... then "+" drops out
@@ -113,29 +162,89 @@ def gitbook_slug(heading):
     return s[:MAX_SLUG]
 
 
-def headings_of(path):
-    """(line_no, raw_text, explicit_id_or_None) for each level-2..6 heading."""
+def unmappable(heading):
+    """Characters in a heading that these rules cannot slug faithfully.
+
+    GitBook transliterates rather than collapses: "China - 中国" publishes as
+    china-zhong-guo, so it is running a full Unicode charmap that CHARMAP only
+    covers the part of. Everything non-ASCII in this repo's headings that is NOT
+    a letter -- arrows, em/en dashes, smart quotes, the acute accent, six emoji --
+    was confirmed live to collapse to a dash like any other separator, so only
+    non-ASCII LETTERS are unknowable. Guessing at those would put a confidently
+    wrong anchor in the inventory, which is the whole failure this checker exists
+    to avoid, so `risky` lists them and a link that could be one of them is
+    reported [uncertain-slug] -- see could_be_guessed(), which keeps unrelated
+    dead anchors on the same page plainly [absent].
+    """
+    return sorted({c for c in strip_inline(heading)
+                   if ord(c) > 127 and unicodedata.category(c).startswith('L')})
+
+
+def uncomment(line, in_comment):
+    """Blank out HTML comments, returning (visible_text, still_open)."""
     out = []
-    in_fence = False
+    while line:
+        if in_comment:
+            close = line.find('-->')
+            if close < 0:
+                return ''.join(out), True
+            line, in_comment = line[close + 3:], False
+        else:
+            open_ = line.find('<!--')
+            if open_ < 0:
+                out.append(line)
+                break
+            out.append(line[:open_])
+            line, in_comment = line[open_ + 4:], True
+    return ''.join(out), in_comment
+
+
+def content_lines(path):
+    """(line_no, visible_text, in_fence) for each line.
+
+    HTML comments are blanked, because GitBook publishes nothing from them: two
+    Python comments inside a commented-out example in
+    connectors/mariadb-connector-python/usage.md were otherwise read as level-1
+    headings, which corrupts any "nearest enclosing heading level" reasoning
+    (DOCS-6503 -- reported there as indented code blocks, but HEADING anchors "#"
+    at column 0, so an indented block can never match; the cause was the comment).
+    Comment markers are not tracked inside a fence, where "<!--" is just text.
+    """
+    in_fence = in_comment = False
     for n, line in enumerate(read(path).splitlines(), 1):
         if FENCE.match(line):
             in_fence = not in_fence
             continue
+        if not in_fence:
+            line, in_comment = uncomment(line, in_comment)
+        yield n, line, in_fence
+
+
+def headings_of(path):
+    """(line_no, level, raw_text, explicit_id_or_None) for every h1..h6."""
+    out = []
+    for n, line, in_fence in content_lines(path):
         if in_fence:
             continue
         m = HEADING.match(line)
-        if not m or len(m.group(1)) == 1:
+        if not m:
             continue
         explicit = HEADING_ID.search(m.group(2))
-        out.append((n, m.group(2), explicit.group(1) if explicit else None))
+        out.append((n, len(m.group(1)), m.group(2),
+                    explicit.group(1) if explicit else None))
     return out
+
+
+def anchored_headings(path):
+    """Only the headings GitBook gives an id to."""
+    return [h for h in headings_of(path) if h[1] in ANCHORED]
 
 
 def anchors_of(path):
     """Anchors a markdown file publishes, in document order."""
     seen = Counter()
     out = []
-    for _, text, explicit in headings_of(path):
+    for _, _, text, explicit in anchored_headings(path):
         base = explicit if explicit else gitbook_slug(text)
         if not base:
             continue
@@ -143,6 +252,34 @@ def anchors_of(path):
         seen[base] += 1
         out.append(base if n == 0 else f'{base}-{n}')
     return out
+
+
+def deep_slugs(path):
+    """What an h5/h6 heading WOULD publish if GitBook anchored it. It does not."""
+    return {gitbook_slug(text) for _, level, text, _ in headings_of(path)
+            if level > max(ANCHORED)} - {''}
+
+
+def guessed_slugs(path):
+    """Anchors this file publishes that these rules can only guess at."""
+    return {gitbook_slug(text) for _, _, text, explicit in anchored_headings(path)
+            if not explicit and unmappable(text)} - {''}
+
+
+def footnote_defs(path):
+    """Labels defined by a "[^label]:" line, i.e. the live footnote anchors.
+
+    GitBook serialises an annotation as <a data-footnote-ref href="#user-content-
+    fn-N">, and renders it as a hover tooltip carrying the definition text -- no
+    #user-content-fn-N id is emitted anywhere on the page (checked: 0 hits for
+    both "user-content-fn" and "data-footnote" in the rendered HTML). So the
+    fragment is unreachable BY DESIGN and a defined footnote is not a defect.
+    Treating all of them as dead made [footnote] 21 findings / 0 true positives
+    (DOCS-6503); resolving them against these labels leaves only the real class,
+    a reference whose definition is missing, where the tooltip comes up empty.
+    """
+    return {m.group(1) for _, line, in_fence in content_lines(path)
+            if not in_fence for m in [FOOTNOTE_DEF.match(line)] if m}
 
 
 def stolen_ids(path):
@@ -161,12 +298,12 @@ def stolen_ids(path):
 
     Flagging all 48 would be a 6x overstatement -- DOCS-6413's failure mode.
     """
-    heads = headings_of(path)
+    heads = anchored_headings(path)
     own = {}
-    for n, text, _ in heads:
+    for n, _, text, _ in heads:
         own.setdefault(gitbook_slug(text), n)
     out = []
-    for n, text, explicit in heads:
+    for n, _, text, explicit in heads:
         if not explicit:
             continue
         mine = gitbook_slug(text)
@@ -187,11 +324,7 @@ def read(path):
 def links_of(path):
     """(raw_target, line_no) for every local link carrying a fragment."""
     out = []
-    in_fence = False
-    for n, line in enumerate(read(path).splitlines(), 1):
-        if FENCE.match(line):
-            in_fence = not in_fence
-            continue
+    for n, line, in_fence in content_lines(path):
         if in_fence:
             continue
         for target in LINK.findall(line) + ATTR.findall(line):
@@ -237,11 +370,28 @@ def relpath(path, root):
 
 
 def md_files(root, base):
+    """Published .md files under root, each real file once.
+
+    The dedupe is load-bearing: a symlinked page makes rglob yield both names
+    while relpath() resolves them to the same string, so every fragment link on
+    it is counted and reported twice, indistinguishably from two real links on
+    one line. That overstated the DOCS-6499 inventory by 3 -- the "262 remaining"
+    figure was really 259 -- and only surfaced because an apply script asserted
+    an occurrence count (DOCS-6503).
+    """
     root = pathlib.Path(root)
     if root.is_file():
         return [root]
-    return [p for p in sorted(root.rglob('*.md'))
-            if not relpath(p, base).startswith(UNPUBLISHED)]
+    out, seen = [], set()
+    for p in sorted(root.rglob('*.md')):
+        if relpath(p, base).startswith(UNPUBLISHED):
+            continue
+        real = p.resolve()
+        if real in seen:
+            continue
+        seen.add(real)
+        out.append(p)
+    return out
 
 
 def loose(frag):
@@ -253,10 +403,35 @@ def squash(frag):
     return re.sub(r'[^a-z0-9]', '', frag.lower())
 
 
-def classify(frag, live):
+def could_be_guessed(frag, guessed):
+    """Might this fragment be one of the anchors we could only guess at?
+
+    Transliteration only ever EXPANDS an unmappable character into more letters,
+    so the guess (where it collapsed to a dash) and the truth share the mappable
+    segments in order: guess "china" against truth "china-zhong-guo". Matching on
+    that keeps the doubt where it belongs — an unrelated dead anchor on the same
+    page is still plainly [absent], not excused by the page's one odd heading.
+    """
+    for guess in guessed:
+        if frag == guess:
+            return True
+        rest = frag
+        for part in filter(None, guess.split('-')):
+            at = rest.find(part)
+            if at < 0:
+                break
+            rest = rest[at + len(part):]
+        else:
+            return True
+    return False
+
+
+def classify(frag, live, deep=(), guessed=()):
     """Bucket a dead anchor and, where possible, name the anchor it meant."""
-    if frag.startswith('user-content-fn'):
-        return 'footnote', ''      # GitBook publishes no footnote anchors at all
+    if frag in deep:
+        return 'unanchored-heading', ''
+    if could_be_guessed(frag, guessed):
+        return 'uncertain-slug', ''
     by_case = {a.lower(): a for a in live}
     if frag.lower() in by_case:
         return 'case-only', by_case[frag.lower()]
@@ -268,6 +443,22 @@ def classify(frag, live):
     if frag.lstrip('-') in live:
         return 'leading-dash', frag.lstrip('-')
     return 'absent', ''
+
+
+def page_facts(path):
+    """(anchors, h5/h6 slugs, footnote labels, unslugabble?) for one target page.
+
+    A guessed anchor is deliberately WITHHELD from the live set rather than
+    offered as known-good. Leaving it in silently resolved every link to it —
+    which for "China - 中国" means blessing #china, when the page publishes
+    #china-zhong-guo. Withholding it puts both spellings in [uncertain-slug],
+    where a human confirms against the rendered page, instead of putting one of
+    them in the "resolves" pile on the strength of a guess.
+    """
+    guessed = guessed_slugs(path)
+    anchors = {a for a in anchors_of(path)
+               if re.sub(r'-\d+$', '', a) not in guessed}
+    return anchors, deep_slugs(path), footnote_defs(path), guessed
 
 
 def check(paths, base):
@@ -283,15 +474,37 @@ def check(paths, base):
                     unresolved.append((relpath(f, base), line, target))
                     continue
                 if tgt not in cache:
-                    cache[tgt] = set(anchors_of(tgt))
+                    cache[tgt] = page_facts(tgt)
                 checked += 1
-                live = cache[tgt]
+                live, deep, notes, guessed = cache[tgt]
                 if frag in live:
                     continue
-                bucket, fix = classify(frag, live)
+                fn = FOOTNOTE_ANCHOR.match(frag)
+                if fn:
+                    # No id is published either way, so the reachable question is
+                    # whether the tooltip has any text: defined means fine.
+                    if fn.group(1) in notes:
+                        continue
+                    findings.append((relpath(f, base), line, frag,
+                                     relpath(tgt, base), 'footnote', ''))
+                    continue
+                bucket, fix = classify(frag, live, deep, guessed)
                 findings.append((relpath(f, base), line, frag,
                                  relpath(tgt, base), bucket, fix))
     return checked, findings, unresolved
+
+
+def scan_risky(paths, base):
+    """Headings whose computed anchor is a guess, as (file, line, chars, slug)."""
+    out = []
+    for root in paths:
+        for f in md_files(root, base):
+            for line, _, text, explicit in anchored_headings(f):
+                bad = [] if explicit else unmappable(text)
+                if bad:
+                    out.append((relpath(f, base), line, ''.join(bad),
+                                gitbook_slug(text)))
+    return out
 
 
 def scan_ids(paths, base):
@@ -327,14 +540,28 @@ def describe(finding):
     return f'{src}:{line}: #{frag} -> {tgt}{suffix}'
 
 
+MECHANICAL = ('case-only', 'punctuation', 'dash-count', 'leading-dash')
+
+BUCKET_NOTES = {
+    'unanchored-heading':
+        'the target IS an h5/h6 heading, which GitBook renders as a bold\n'
+        '                        paragraph with no id — raise it to h4 or retarget the link',
+    'footnote':
+        'a footnote reference with no "[^label]:" definition, so the\n'
+        '                        tooltip comes up empty',
+    'uncertain-slug':
+        'the target page has a heading GitBook transliterates and these\n'
+        '                        rules do not — see `risky`; may not be dead at all',
+}
+
+
 def summarize(checked, findings, unresolved, label='dead'):
     print(f'\n{checked} fragment links checked | {len(findings)} {label} | '
           f'{len(unresolved)} unresolvable targets')
     for bucket, n in Counter(f[4] for f in findings).most_common():
-        mechanical = bucket in ('case-only', 'punctuation', 'dash-count',
-                                'leading-dash')
-        print(f'  {n:6d}  {bucket}'
-              + ('  (mechanical: the fix is named above)' if mechanical else ''))
+        note = ('  (mechanical: the fix is named above)' if bucket in MECHANICAL
+                else '  ' + BUCKET_NOTES[bucket] if bucket in BUCKET_NOTES else '')
+        print(f'  {n:6d}  {bucket}{note}')
 
 
 def cmd_check(args):
@@ -343,6 +570,22 @@ def cmd_check(args):
     for f in findings:
         print('DEAD ' + describe(f))
     summarize(checked, findings, unresolved)
+    return 0
+
+
+def cmd_risky(args):
+    """List headings whose anchor these rules cannot compute faithfully."""
+    root = repo_root(args[0] if args else '.')
+    found = scan_risky([pathlib.Path(a) for a in args] or [root], root)
+    for src, line, chars, slug in found:
+        print(f'RISKY {src}:{line}: {chars!r} — guessed #{slug}, '
+              f'GitBook transliterates')
+    print(f'\nrisky: {len(found)} heading(s) whose computed anchor is a guess')
+    if found:
+        print('\n          GitBook runs a Unicode charmap ("China - 中国" publishes as\n'
+              '          china-zhong-guo) that CHARMAP only covers part of. A link to one\n'
+              '          of these anchors is reported [uncertain-slug], not [absent]:\n'
+              '          confirm it against the rendered page before treating it as dead.')
     return 0
 
 
@@ -408,6 +651,12 @@ def cmd_new(args):
         print('\n          A renamed heading breaks every inbound link to its old anchor,\n'
               '          including links from pages this commit never touched. Either restore\n'
               '          the heading text or retarget the links listed above.', file=sys.stderr)
+        if any(f[4] == 'unanchored-heading' for f in fresh):
+            print('\n          [unanchored-heading] means the target is an h5/h6, which GitBook\n'
+                  '          renders as a bold paragraph with no id. Promoting a bold block to\n'
+                  '          "#####" therefore fixes nothing, however much it looks like it does\n'
+                  '          (DOCS-6503): use "####" or shallower, or link the enclosing section.',
+                  file=sys.stderr)
 
     # Diffed against <rev> for the same reason as the dead anchors: this repo is
     # also edited from the GitBook UI, so an absolute check would fail unrelated
@@ -448,7 +697,7 @@ def fetch(url):
 
 def cmd_validate(args):
     """Compare computed anchors against the ids the live site renders."""
-    total = miss = 0
+    total = miss = risky = 0
     for arg in args:
         path = pathlib.Path(arg).resolve()
         root = repo_root(path)
@@ -463,14 +712,23 @@ def cmd_validate(args):
             print(f'SKIP (no live content) {arg}')
             continue
         mine = anchors_of(path)
-        bad = [a for a in mine if a not in live]
+        # A heading these rules cannot slug faithfully is a known unknown, not a
+        # rule failure — count it apart so the confirmed figure stays an oracle.
+        guessed = guessed_slugs(path)
+        bad = [a for a in mine if a not in live and a not in guessed]
+        unsure = [a for a in mine if a not in live and a in guessed]
         total += len(mine)
         miss += len(bad)
+        risky += len(unsure)
         print(f'{"OK  " if not bad else "MISS"} {len(mine):3d} anchors, '
-              f'{len(bad)} unmatched  {arg}')
+              f'{len(bad)} unmatched'
+              + (f', {len(unsure)} unslugabble' if unsure else '') + f'  {arg}')
         for a in bad:
             print(f'       computed {a!r} is not among the live ids')
-    print(f'\nvalidate: {total - miss}/{total} computed anchors confirmed live')
+        for a in unsure:
+            print(f'       guessed  {a!r} — transliterated heading, see `risky`')
+    print(f'\nvalidate: {total - miss - risky}/{total - risky} computed anchors '
+          f'confirmed live' + (f' ({risky} unslugabble, excluded)' if risky else ''))
     return 1 if miss else 0
 
 
@@ -486,6 +744,8 @@ def main():
         return cmd_new(args)
     if mode == 'ids':
         return cmd_ids(args)
+    if mode == 'risky':
+        return cmd_risky(args)
     if mode == 'check':
         return cmd_check(args)
     print(__doc__, file=sys.stderr)

--- a/.claude/skills/docs-check/SKILL.md
+++ b/.claude/skills/docs-check/SKILL.md
@@ -77,6 +77,13 @@ on the file set, from the repo root:
   page, or with `.claude/hooks/fragcheck.py validate <file>`. Needs python3 and a git work tree;
   missing either is a SKIP. Costs ~14s, so `DOC_LINT_SKIP_FRAGMENTS=1` skips it while iterating.
   Added in DOCS-6491.
+- **GitBook anchors `##`, `###` and `####` only.** A `#####` heading renders as a bold paragraph
+  with no `id`, so it cannot be linked to. When repairing a dead anchor, add the missing heading
+  at `####` or shallower: promoting a bold pseudo-heading to `#####` looks like a fix, drops the
+  dead-anchor count, and still lands the reader at the top of the page (DOCS-6503). A link to one
+  is reported `[unanchored-heading]`. A heading GitBook transliterates and the rules cannot
+  reproduce — `中国` publishes as `zhong-guo` — is listed by `.claude/hooks/fragcheck.py risky`
+  and reported `[uncertain-slug]`, never silently resolved against a guess.
 - The same gate catches a heading that publishes **another heading's** anchor. Duplicate a
   heading line for a new section, edit its text but leave its `<a href="#x" id="x">` behind, and
   GitBook honours that explicit id over the text slug: the two sections share one anchor, the

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -55,6 +55,15 @@ an anchor to satisfy it; check the rendered page instead, or run
 the live site emits. `.claude/hooks/fragcheck.py check` prints the whole current inventory with a
 suggested target for each mechanically fixable one.
 
+**GitBook publishes a heading anchor for `##`, `###` and `####` only.** A `#####` heading
+renders as a bold paragraph with no `id`, so it is not a link target at all. That matters when
+you are repairing a dead anchor: adding the missing heading works only at `####` or shallower,
+and promoting a bold pseudo-heading to `#####` produces a page that looks fixed and still sends
+the reader to the top (DOCS-6503). A link pointing at one is reported `[unanchored-heading]` —
+raise the heading or retarget the link at the enclosing section. A heading GitBook
+transliterates and the checker cannot reproduce — `中国` publishes as `zhong-guo` — is listed by
+`.claude/hooks/fragcheck.py risky` and reported `[uncertain-slug]` rather than guessed at.
+
 The same gate catches one thing no link checker can: a heading that publishes **another
 heading's** anchor. Duplicate a heading line for a new section, edit its text but leave its
 `<a href="#x" id="x">` behind, and GitBook honours that explicit id over the text slug — the two


### PR DESCRIPTION
[DOCS-6503](https://mariadbcorp.atlassian.net/browse/DOCS-6503)

Six defects in `.claude/hooks/fragcheck.py`, all of the same family: the checker computed an anchor GitBook does not publish, or refused one it does. Every one made the dead-anchor count confidently wrong, which is what stops the inventory delta from being usable as a verification oracle on its own.

Repo inventory: **41 dead → 20 dead**, all 21 removed findings being false positives.

## The six

| # | Defect | Wrong in which direction | Fix |
|---|---|---|---|
| 1 | h5/h6 credited with an anchor | Optimistic — link reported as resolving | Only h2–h4 publish; a link to an h5/h6 slug reports `[unanchored-heading]` |
| 2 | `$` collapsed to a dash | Optimistic | `CHARMAP`: `$` → `usd`, so `#### $type` → `usdtype` |
| 3 | `®` missing from the charmap | Optimistic | `®` → `(r)`, so `MongoDB® Shell` → `mongodb-r-shell` |
| 4 | HTML entities not decoded | Optimistic — 20 anchors on 10 files | `html.unescape()` first, so a trailing `&#x20;` is a space, not `-and-x20` |
| 5 | `[footnote]` = 21 findings, 0 true positives | Pessimistic | `#user-content-fn-N` resolved against `[^label]:` definitions |
| 6 | Symlinked page walked twice | Double-counted | `md_files()` dedupes by resolved path |

Plus, from the same sweep: a footnote reference or a trailing kramdown `{#id}` inside a heading polluted its slug; HTML comments were not skipped, so two Python comments in a commented-out example were read as h1 headings; and `.git/` was not excluded from the walk.

### On defect 1 — why it cost real work

On the DOCS-6499 connectors slice, promoting eight bold pseudo-headings to `#####` made `fragcheck check` fall by 11 — a textbook-clean inventory delta for a change that repaired **nothing**, because GitBook renders `#####` as `<p><strong>` with no `id`. That trap is now a gate failure: the promotion canary below exits 1 with `[unanchored-heading]`.

### On defect 5 — what the live page actually shows

GitBook serialises an annotation as `<a data-footnote-ref href="#user-content-fn-N">` and renders it as a hover tooltip. The rendered HTML contains **no** `user-content-fn` id and no `data-footnote` attribute (0 hits on three sampled pages), but the definition text is present as an annotation fragment in the page payload. So the fragment is unreachable *by design* and a defined footnote is not a defect — only a reference whose `[^label]:` definition is missing, where the tooltip comes up empty.

## One new class, deliberately not fixed

GitBook transliterates rather than collapses: `China - 中国` publishes as `china-zhong-guo`, so it runs a Unicode charmap that `CHARMAP` covers only part of. Rather than extrapolate, `unmappable()` detects non-ASCII **letters** (everything else non-ASCII in this repo's headings — arrows, dashes, smart quotes, six emoji — was confirmed live to collapse like any separator), the new `fragcheck.py risky` mode lists them, and such an anchor is **withheld from the resolving set** so a link to either spelling reports `[uncertain-slug]`. One heading in the repo qualifies.

`could_be_guessed()` keeps that doubt narrow: an unrelated dead anchor on the same page is still plainly `[absent]`. That was a hole in my first attempt, caught by its own canary.

## Verification

**Not the count.** The count was the thing that was broken.

- **Live re-validation of every file whose anchor set moved.** 20 files; 1,607/1,607 computed anchors confirmed against rendered `id="…"` values (1,317 over the structural sample + 290 over the remainder). The one unslugabble heading is excluded and named rather than counted as a pass.
- **A held-out sample chosen for structural variety** — every character occurring in any heading anywhere in the repo that is not a plain ASCII word character, two pages each: 33 pages, 1,317 anchors, `1300/1317 → 1317/1317`. The original DOCS-6491 sample was chosen for punctuation *density*, which is precisely how five of these gaps survived 4,599 confirmations.
- **`pitr.md`** (the repo's only h5 page): `18/21 → 18/18`, confirming the three h5 anchors are gone and dedup numbering was unaffected.
- **Full anchor-inventory diff, old vs new implementation:** 44,263 → 44,261 anchors, 20 files changed, every difference individually accounted for and live-checked.
- **The 21 removed findings are exactly the footnote class** — diffed finding-by-finding against the baseline; nothing else moved, and links checked is unchanged at 16,177.
- **A canary per fix, because a check that never fires proves nothing:** symlink (113 → 75 links on one directory), heading-in-comment (old computes it, new does not), link-to-h5 (old: silently resolving; new: `[unanchored-heading]`), undefined footnote (fires), transliterated heading (both spellings `[uncertain-slug]`, unrelated dead anchor still `[absent]`).
- **Gate still fires both ways:** clean tree passes; a heading rename surfaces 40 inbound links across untouched pages and exits 1; an h5 promotion exits 1 with the new advice text.
- `codespell` (CI-exact) and `doc-lint.sh` clean on all three files, run with file arguments — a bare invocation exits 0 having checked nothing.

## Also updated

`dev-docs/cookbook-pre-pr.md` and `.claude/skills/docs-check/SKILL.md` now state the h2–h4 ceiling, since it changes how an author repairs a dead anchor: add the heading at `####` or shallower, never promote a bold block to `#####`.

## Corrections to the ticket

- The spurious h1 headings were blamed on **indented code blocks**. They cannot be: `HEADING` anchors `#` at column 0. The real cause is an **HTML comment** in `connectors/mariadb-connector-python/usage.md`.
- The ticket suggested relaxing fence-skipping to catch the two real footnote defects on `create-table.md`. Not needed and not done: DOCS-6498 fixed that page (refs 1–6 against definitions 1–6), and those refs sit in `<pre class="language-…">` HTML rather than a fence, so they were always visible. A footnote ref inside a *plain* fence renders as literal text, so its fragment is not a link at all — a rendering defect, not a fragment one.
- The ticket lists three defects and a comment adds a fourth; the sweep found **six**, the two extra (`®`, HTML entities) both from the structural-variety sample the ticket asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6503]: https://mariadbcorp.atlassian.net/browse/DOCS-6503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ