### PR TITLE
Fix SysLogLevel -> SyslogLevel capitalization in systemd configuring docs

### DIFF
--- a/server/server-management/starting-and-stopping-mariadb/systemd/configuring.md
+++ b/server/server-management/starting-and-stopping-mariadb/systemd/configuring.md
@@ -243,7 +243,7 @@ When using `systemd`, if you would like to redirect the [error log](../../server
 * Set [StandardOutput=syslog](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardOutput=).
 * Set [StandardError=syslog](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardError=).
 * Set [SyslogFacility=daemon](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#SyslogFacility=).
-* Set [SysLogLevel=err](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#SyslogLevel=).
+* Set [SyslogLevel=err](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#SyslogLevel=).
 
 For example:
 
@@ -254,7 +254,7 @@ sudo systemctl edit mariadb.service
 StandardOutput=syslog
 StandardError=syslog
 SyslogFacility=daemon
-SysLogLevel=err
+SyslogLevel=err
 ```
 
 If you have multiple instances of MariaDB, then you may also want to set [SyslogIdentifier](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#SyslogIdentifier=) with a different tag for each instance.


### PR DESCRIPTION
## Summary

Fixes the capitalization of the systemd `SyslogLevel=` directive on the [systemd configuring](https://mariadb.com/docs/server/server-management/starting-and-stopping-mariadb/systemd/configuring) page. Two occurrences in `server/server-management/starting-and-stopping-mariadb/systemd/configuring.md` spelled it `SysLogLevel` (capital `L`):

- the bullet list under **Configuring MariaDB to Write the Error Log to Syslog**
- the example `systemctl edit mariadb.service` drop-in immediately below it

## Why this matters

systemd's directive is `SyslogLevel=`, documented in [`systemd.exec(5)`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#SyslogLevel=).

Unit file key names are **case-sensitive**. `SysLogLevel` is therefore not an alias — systemd parses it as an unrecognized key, drops it with an `Unknown key name 'SysLogLevel' in section 'Service', ignoring` warning in the journal, and the service silently keeps the default syslog level. A reader who copy-pastes the example gets a drop-in that looks correct but does not set the level at all, and the only clue is a warning they have no reason to go looking for.

## The page already disagrees with itself

Three signals on this same page confirm the lowercase spelling is the intended one:

1. The hyperlink on the affected bullet already points at `systemd.exec.html#SyslogLevel=` — the anchor and the link text disagreed.
2. The systemd options table earlier in the page (line 144) already renders it as `SyslogLevel=err`.
3. The sibling directives in the same snippet — `SyslogFacility=`, `SyslogIdentifier=` — all use the lowercase `l`.

So only these two spots were out of step; no other file in the repo contains the misspelling (`grep -rn SysLogLevel` returns nothing after this change).

## Test plan

- `grep -rn "SysLogLevel" .` → no matches
- Diff is 2 lines, text-only, no structural or link changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ps55wNCJgRZ91AGpULTBQj
