### PR TITLE
DOCS-6439 Restore superscripts in numeric size suffix table

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -85,11 +85,11 @@ Variables that take a numeric size can either be specified in full, or with a su
 | Suffix | Description | Value                                                                                                                   |
 | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
 | K      | kilobytes   | 1024                                                                                                                    |
-| M      | megabytes   | 10242                                                                                                                   |
-| G      | gigabytes   | 10243                                                                                                                   |
-| T      | terabytes   | 10244 (from [MariaDB 10.3.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/10.3.3)) |
-| P      | petabytes   | 10245 (from [MariaDB 10.3.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/10.3.3)) |
-| E      | exabytes    | 10246 (from [MariaDB 10.3.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/10.3.3)) |
+| M      | megabytes   | 1024<sup>2</sup>                                                                                                        |
+| G      | gigabytes   | 1024<sup>3</sup>                                                                                                        |
+| T      | terabytes   | 1024<sup>4</sup> (from [MariaDB 10.3.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/10.3.3)) |
+| P      | petabytes   | 1024<sup>5</sup> (from [MariaDB 10.3.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/10.3.3)) |
+| E      | exabytes    | 1024<sup>6</sup> (from [MariaDB 10.3.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/10.3.3)) |
 
 The suffix can be upper or lower-case.
 


### PR DESCRIPTION
The M/G/T/P/E rows of the size-suffix table in server-system-variables rendered as flat digits (10242, 10243, ...) because the exponent markup was lost in the original KB-to-GitBook migration. Restore them with <sup> so they read 1024^2 ... 1024^6.

Values verified against server mysys/my_getopt.c eval_num_suffix() (K=1<<10 ... E=1<<60).


Fix flattened superscript exponents in size-suffix table

The M/G/T/P/E rows in the numeric-size suffix table on server-system-variables.md rendered exponents as plain digits
(e.g. 10242 instead of 1024^2), lost during the original MariaDB-KB to GitBook migration. Restored using <sup> tags,
matching the existing table-cell superscript convention used elsewhere in the repo (CVE footnotes, upgrade-path markers),
and confirmed to survive GitBook sync via live precedent.

Values verified against mysys/my_getopt.c eval_num_suffix() (server @ bab03b0f).