### PR TITLE
DOCS-6526 Scope semi-consistent reads to UPDATE and non-unique searches

### DIFF
--- a/server/reference/sql-statements/transactions/set-transaction.md
+++ b/server/reference/sql-statements/transactions/set-transaction.md
@@ -100,7 +100,7 @@ The default `binlog_format` of `MIXED` is unaffected, as is `ROW`.
 
 In a semi-consistent read, an `UPDATE` statement skips a row that another transaction has locked, provided the latest committed version of that row does not match the `WHERE` condition. The statement proceeds instead of waiting for the lock, which means you might see only a partially consistent read.
 
-Semi-consistent reads are limited to `UPDATE`; a `DELETE` waits for the lock. They also require the statement to scan the clustered index with a non-unique search condition. An `UPDATE` that matches every column of a unique index exactly, such as `WHERE id = 100`, waits for the lock, as does one that scans a secondary index.
+Semi-consistent reads are deliberately limited to `UPDATE`: the optimization was never implemented for `DELETE`, which waits for the lock. They also require the statement to scan the clustered index with a non-unique search condition. An `UPDATE` that matches every column of a unique index exactly, such as `WHERE id = 100`, waits for the lock, as does one that scans a secondary index.
 
 {% hint style="info" %}
 At `READ COMMITTED`, semi-consistent reads apply only when [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) is disabled. That variable is enabled by default from MariaDB 11.6.2, and while it is enabled, `READ COMMITTED` performs an ordinary locking read and waits for the lock. Semi-consistent reads then apply to `READ UNCOMMITTED` only.

--- a/server/reference/sql-statements/transactions/set-transaction.md
+++ b/server/reference/sql-statements/transactions/set-transaction.md
@@ -98,13 +98,15 @@ The default `binlog_format` of `MIXED` is unaffected, as is `ROW`.
 
 #### Semi-Consistent Reads
 
-In a semi-consistent read, an `UPDATE` or `DELETE` statement skips a row that another transaction has locked, provided the latest committed version of that row does not match the `WHERE` condition. The statement proceeds instead of waiting for the lock, which means you might see only a partially consistent read.
+In a semi-consistent read, an `UPDATE` statement skips a row that another transaction has locked, provided the latest committed version of that row does not match the `WHERE` condition. The statement proceeds instead of waiting for the lock, which means you might see only a partially consistent read.
+
+Semi-consistent reads are limited to `UPDATE`; a `DELETE` waits for the lock. They also require the statement to scan the clustered index with a non-unique search condition. An `UPDATE` that matches every column of a unique index exactly, such as `WHERE id = 100`, waits for the lock, as does one that scans a secondary index.
 
 {% hint style="info" %}
 At `READ COMMITTED`, semi-consistent reads apply only when [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) is disabled. That variable is enabled by default from MariaDB 11.6.2, and while it is enabled, `READ COMMITTED` performs an ordinary locking read and waits for the lock. Semi-consistent reads then apply to `READ UNCOMMITTED` only.
 {% endhint %}
 
-Separately, and regardless of `innodb_snapshot_isolation`, if InnoDB locks a record at `READ COMMITTED` or `READ UNCOMMITTED` and then finds that the record does not match the `WHERE` condition, it releases that record lock — unless the transaction has itself modified the row.
+Releasing a lock on a non-matching row is separate, and is not restricted in either of those ways. For a `DELETE` as much as an `UPDATE`, and regardless of `innodb_snapshot_isolation`, if InnoDB locks a record at `READ COMMITTED` or `READ UNCOMMITTED` and then finds that the record does not match the `WHERE` condition, it releases that record lock — unless the transaction has itself modified the row.
 
 ### REPEATABLE READ
 

--- a/server/reference/sql-statements/transactions/set-transaction.md
+++ b/server/reference/sql-statements/transactions/set-transaction.md
@@ -106,7 +106,9 @@ Semi-consistent reads are deliberately limited to `UPDATE`: the optimization was
 At `READ COMMITTED`, semi-consistent reads apply only when [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) is disabled. That variable is enabled by default from MariaDB 11.6.2, and while it is enabled, `READ COMMITTED` performs an ordinary locking read and waits for the lock. Semi-consistent reads then apply to `READ UNCOMMITTED` only.
 {% endhint %}
 
-Releasing a lock on a non-matching row is separate, and is not restricted in either of those ways. For a `DELETE` as much as an `UPDATE`, and regardless of `innodb_snapshot_isolation`, if InnoDB locks a record at `READ COMMITTED` or `READ UNCOMMITTED` and then finds that the record does not match the `WHERE` condition, it releases that record lock — unless the transaction has itself modified the row.
+Releasing a lock on a non-matching row is a separate mechanism, with a different scope. It applies to a `DELETE` as much as to an `UPDATE`, it applies to unique searches, and it is unaffected by `innodb_snapshot_isolation`: if InnoDB locks a record at `READ COMMITTED` or `READ UNCOMMITTED` and then finds that the record does not match the `WHERE` condition, it releases that record lock — unless the transaction has itself modified the row.
+
+It does share one restriction with semi-consistent reads: the statement must be scanning the clustered index. A record lock taken while scanning a secondary index is held until the transaction ends, even though the row failed the `WHERE` condition.
 
 ### REPEATABLE READ
 


### PR DESCRIPTION
Fixes [DOCS-6526](https://mariadbcorp.atlassian.net/browse/DOCS-6526).

Follow-up to #961. Marko Mäkelä's review comment on that PR noted that the `innodb_snapshot_isolation` behaviour is guarded by the `DB_LOCK_WAIT` handling in `row_search_mvcc()`, not by `ha_innobase::try_semi_consistent_read()`. That is correct — and reading the block he named surfaced three conditions the new *Semi-Consistent Reads* section did not state, one of them a defect in the section as first written here.

Everything below was verified against `mariadb-server` at `main` and reproduced on a live 12.3.3 server at `READ COMMITTED` with `innodb_snapshot_isolation = OFF` and `innodb_lock_wait_timeout = 2`.

## Semi-consistent reads apply to UPDATE only, and that is deliberate

The section said "an `UPDATE` or `DELETE` statement skips a row that another transaction has locked". The engine-side contract does name both (`sql/handler.h:4606`, `storage/innobase/include/row0mysql.h:586`), but the only caller of `try_semi_consistent_read(1)` anywhere in the server is `sql/sql_update.cc`, at lines 816 and 925. `git log -S try_semi_consistent_read -- sql/sql_delete.cc` returns nothing, so the call has never existed there.

| Probe, with `id = 1` locked by another session | Result |
| --- | --- |
| `UPDATE t SET v = 9 WHERE v = 999` | 0 rows in 0.9 ms — locked row skipped |
| `DELETE FROM t WHERE v = 999` | `ERROR 1205` lock wait timeout |

Marko [confirmed on #961](https://github.com/mariadb-corporation/mariadb-docs/pull/961#discussion_r3853226366) that the asymmetry is intentional — the optimization was only ever implemented for `UPDATE` — so the page states it as deliberate rather than describing it neutrally.

## And not to unique searches, or off the clustered index

The same guard declines a semi-consistent read when `unique_search` is true, or when the scan is not on the clustered index (`storage/innobase/row/row0sel.cc:5395-5398`). `unique_search` means an exact match on all columns of a unique index (`row0sel.cc:4575`).

| Probe, `innodb_snapshot_isolation = OFF` | Result |
| --- | --- |
| `UPDATE t SET v = 9 WHERE id = 1 AND v = 999` (unique search) | `ERROR 1205` lock wait timeout |
| `UPDATE t SET v = 9 WHERE id >= 1 AND v = 999` (range) | 0 rows, instant |

## The lock-release paragraph was half right

The paragraph said releasing a lock on a non-matching row "is not restricted in either of those ways". Two of the three restrictions genuinely do not apply — it works for `DELETE`, and for unique searches — but the **clustered-index restriction is shared**, and the paragraph as first pushed here denied that.

`row_unlock_for_mysql()` releases only when `new_rec_locks == 1 && prebuilt->index->is_clust()` (`storage/innobase/row/row0mysql.cc:1780`). During a secondary-index scan neither half holds: `new_rec_locks` is set to `2` when the clustered record is locked behind the secondary one (`row0sel.cc:5683`), and where it is set to `1` (`row0sel.cc:5382`) the index in question is `prebuilt->index`, the secondary index. Nothing is released either way.

Reproduced with session B matching **0 rows** in every case, session C then trying to take a lock on the row B had scanned:

| Session B | Scan | Session C |
| --- | --- | --- |
| `UPDATE t SET w = w+1 WHERE w = 999` | clustered | succeeds — lock released |
| `DELETE FROM t WHERE w = 999` | clustered | succeeds |
| `UPDATE t SET w = w+1 WHERE id = 1 AND w = 999` | unique, clustered | succeeds |
| `DELETE FROM t WHERE id = 1 AND w = 999` | unique, clustered | succeeds |
| `UPDATE t SET w = w+1 WHERE v = 5 AND w = 999` | range on `idx_v` | `ERROR 1205` — lock held |
| `DELETE FROM t WHERE v = 5 AND w = 999` | range on `idx_v` | `ERROR 1205` — lock held |

`sql/sql_delete.cc:1008` does call `unlock_row()` ("Row failed selection, release lock on it"), which is what the first four rows show. Marko raised on #961 whether that call is redundant and concluded the status quo should stand; on the InnoDB side it is not a no-op — `ha_innobase::unlock_row()` reaches `row_unlock_for_mysql()` for `ROW_READ_WITH_LOCKS` at `READ COMMITTED` or below (`ha_innodb.cc:8946-8952`), which the `DELETE` rows above confirm from the outside.

## Unchanged, and confirmed

The `innodb_snapshot_isolation` hint holds: with the variable `ON` the first probe above times out, with it `OFF` the row is skipped.

## Checks

- `doc-lint.sh` on the changed file: exit 0, with both codespell and lychee present (no SKIPPED notice).
- `lychee` run directly on the page: 32 total, **0 errors**.
- `codespell --check-filenames --ignore-words .codespellignore`: clean.
- `fragcheck.py new main`: no new dead heading anchors, no new stolen ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6526]: https://mariadbcorp.atlassian.net/browse/DOCS-6526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
