### PR TITLE
DOCS-6476 Repoint 119 dead MaxScale links that CI cannot see

### DIFF
--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md
@@ -418,7 +418,7 @@ $EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
 Negative values disable this feature. For more information on monitor scripts,
-see [general monitor documentation](https://mariadb.com/kb/en/node:mariadb-maxscale-2302-common-monitor-parameters#script).
+see [general monitor documentation](mariadb-maxscale-2302-common-monitor-parameters.md#script).
 
 ### Cluster manipulation operations
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-protocols/mariadb-maxscale-2302-nosql-protocol-module.md
@@ -717,7 +717,7 @@ which means that only the `test` database can be accessed and modified.
 #### TLS/SSL
 
 Since `nosqlprotocol` is a regular protocol module used in a listener,
-the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)
+the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#tls-ssl-encryption)
 for details.
 
 ### NoSQL Account Database

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md
@@ -675,7 +675,7 @@ The ETL operations require that the MariaDB ODBC driver is installed on the\
 MaxScale server. This driver is often available in the package manager of your
 operating system but it can also be downloaded from the MariaDB
 website. Installation instructions for installing the driver manually can be
-found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-linux).
+found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
 
@@ -722,7 +722,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
+driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource.md
@@ -675,7 +675,7 @@ The ETL operations require that the MariaDB ODBC driver is installed on the\
 MaxScale server. This driver is often available in the package manager of your
 operating system but it can also be downloaded from the MariaDB
 website. Installation instructions for installing the driver manually can be
-found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
+found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
 
@@ -722,7 +722,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
+driver. The list of supported options can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-binlogrouter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-binlogrouter.md
@@ -195,7 +195,7 @@ This allows the Monitor to perform failover, and more importantly, switchover.\
 It also allows the user to manually redirect the Binlogrouter. The current
 primary is "sticky", meaning that the same primary will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](../mariadb-maxscale-23-02-monitors/mariadb-maxscale-2302-mariadb-monitor.md#configuration-parameters) if the monitor is
 monitoring a binlogrouter. The binlogrouter does not support all the SQL
 commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-kafkacdc.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-kafkacdc.md
@@ -233,7 +233,7 @@ password=maxpwd
 bootstrap_servers=127.0.0.1:9092
 topic=my-cdc-topic
 match=db1[.]
-exclude=db1 [.](accounts|users)
+exclude=db1[.](accounts|users)
 ```
 
 #### `exclude`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readconnroute.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readconnroute.md
@@ -122,7 +122,7 @@ type. With this configuration, the queries are load balanced across the
 replica servers.
 
 For more complex examples of the readconnroute router, take a look at the
-examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
+examples in the [Tutorials](../mariadb-maxscale-23-02-tutorials/README.md) folder.
 
 ### Router Diagnostics
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
@@ -712,7 +712,7 @@ exclusively to the primary server.
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
@@ -1060,7 +1060,7 @@ maxctrl call command readwritesplit reset-gtid My-RW-Router
 
 ### Examples
 
-Examples of the readwritesplit router in use can be found in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
+Examples of the readwritesplit router in use can be found in the [Tutorials](../mariadb-maxscale-23-02-tutorials/README.md) folder.
 
 ### Readwritesplit routing decisions
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-routers/mariadb-maxscale-2302-readwritesplit.md
@@ -712,7 +712,7 @@ exclusively to the primary server.
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-maxscale-2302-upgrading-mariadb-maxscale.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-maxscale-2302-upgrading-mariadb-maxscale.md
@@ -132,9 +132,6 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
-for details.
-
 ### New binlog router
 
 The binlog router delivered with MaxScale 2.5 is completely new and
@@ -330,7 +327,7 @@ add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -18,7 +18,7 @@ add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](../mariadb-maxscale-23-02-getting-started/mariadb-maxscale-2302-mariadb-maxscale-configuration-guide.md#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -48,9 +48,6 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
-for details.
-
 ### New binlog router
 
 The binlog router delivered with MaxScale 2.5 is completely new and

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-about-mariadb-maxscale.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-about/mariadb-maxscale-2308-about-mariadb-maxscale.md
@@ -36,7 +36,7 @@ through MariaDB MaxScale. Filter are often used for logging queries or modifying
 server responses.
 
 A Google Group exists for MariaDB MaxScale. The Group is used to discuss ideas,
-issues and communicate with the MariaDB MaxScale community. Send email to [maxscale@googlegroups.com](https://mariadb.com/kb/en/mailto:maxscale@googlegroups.com) or use the [forum](https://groups.google.com/forum/#!forum/maxscale) interface.
+issues and communicate with the MariaDB MaxScale community. Send email to [maxscale@googlegroups.com](mailto:maxscale@googlegroups.com) or use the [forum](https://groups.google.com/forum/#!forum/maxscale) interface.
 
 Bugs can be reported in the MariaDB Jira [jira.mariadb.org](https://jira.mariadb.org)
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules.md
@@ -80,7 +80,7 @@ There are two primary ways to deal with this:
 
 1. Duplicate user accounts. For every user account with a restricted hostname an
    equivalent user account for MaxScale is added (`'alice'@'maxscale-ip'`).
-2. Use [proxy protocol](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#proxy_protocol).
+2. Use [proxy protocol](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#proxy_protocol).
 
 Option 1 limits the passwords for user accounts with shared usernames. Such
 accounts must use the same password since they will effectively share the\

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-cache.md
@@ -1590,7 +1590,7 @@ If the rule is instead expressed using a regular expression
 
 then the statement will not be parsed.
 
-However, when the [query classifier cache](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#query_classifier_cache_size)
+However, when the [query classifier cache](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#query_classifier_cache_size)
 was introduced, the parsing cost was significantly reduced and
 currently the cost for parsing and regular expression matching
 is roughly the same.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-regex-filter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-filters/mariadb-maxscale-2308-regex-filter.md
@@ -134,7 +134,7 @@ The optional log\_trace parameter toggles the logging of non-matching and
 matching queries with their replacements into the log file on the _info_ level.\
 This is the preferred method of diagnosing the matching of queries since the log
 level can be changed at runtime. For more details about logging levels and
-session specific logging, please read the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#global-settings).
+session specific logging, please read the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#global-settings).
 
 ```
 log_trace=true

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-installation-guide.md
@@ -85,7 +85,7 @@ listed in the [Documentation Contents](../README.md#routers).
 
 ### Encrypting Passwords
 
-Read the [Encrypting Passwords](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#encrypting-passwords)
+Read the [Encrypting Passwords](mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encrypting-passwords)
 section of the configuration guide to set up password encryption for the
 configuration file.
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-common-monitor-parameters.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-common-monitor-parameters.md
@@ -147,7 +147,7 @@ backend_connect_attempts=1
 * Dynamic: Yes
 * Default: None
 
-This parameter duplicates the `disk_space_threshold`[server parameter](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#disk_space_threshold).\
+This parameter duplicates the `disk_space_threshold`[server parameter](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#disk_space_threshold).\
 If the parameter has _not_ been specified for a server, then the one specified\
 for the monitor is applied.
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md
@@ -436,7 +436,7 @@ $EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
 Negative values disable this feature. For more information on monitor scripts,
-see [general monitor documentation](https://mariadb.com/kb/en/node:mariadb-maxscale-2308-common-monitor-parameters#script).
+see [general monitor documentation](mariadb-maxscale-2308-common-monitor-parameters.md#script).
 
 ### Cluster manipulation operations
 
@@ -865,7 +865,7 @@ Enable automatic primary failover. When automatic failover is enabled, MaxScale
 will elect a new primary server for the cluster if the old primary goes down. A
 server is assumed _Down_ if it cannot be connected to, even if this is caused by
 incorrect credentials. Failover triggers if the primary stays down for [failcount](mariadb-maxscale-2308-mariadb-monitor.md#failcount) monitor intervals. Failover will not take place if\
-MaxScale is set [passive](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#passive).
+MaxScale is set [passive](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#passive).
 
 As failover alters replication, it requires more privileges than normal
 monitoring. See [here](mariadb-maxscale-2308-mariadb-monitor.md#cluster-manipulation-grants) for a list of grants.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-maxscale-2308-mariadb-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-maxscale-2308-mariadb-protocol-module.md
@@ -31,7 +31,7 @@ For the MariaDB protocol module, the prefix is always `mariadbprotocol`.
 
 #### `allow_replication`
 
-* Type: [boolean](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#booleans)
+* Type: [boolean](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#booleans)
 * Mandatory: No
 * Dynamic: Yes
 * Default: true

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-protocols/mariadb-maxscale-2308-nosql-protocol-module.md
@@ -721,7 +721,7 @@ which means that only the `test` database can be accessed and modified.
 #### TLS/SSL
 
 Since `nosqlprotocol` is a regular protocol module used in a listener,
-the TLS/SSL support of listeners is available. Please see [TSLSSL encryption](https://mariadb.com/kb/en/Getting-Started/Configuration-Guide#tsl-encryption)
+the TLS/SSL support of listeners is available. Please see [TLS/SSL encryption](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#tls-ssl-encryption)
 for details.
 
 ### NoSQL Account Database
@@ -1001,7 +1001,7 @@ MaxScale.
 
 ### `on_unknown_command`
 
-* Type: [enum](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#enumerations)
+* Type: [enum](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#enumerations)
 * Mandatory: No
 * Values: `return_error`, `return_empty`
 * Default: `return_error`
@@ -1077,7 +1077,7 @@ document) is used, has an impact on the performance. Please see the discussion a
 
 ### `cursor_timeout`
 
-* Type: [duration](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#durations)
+* Type: [duration](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#durations)
 * Mandatory: No
 * Default: `60s`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-monitor-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-monitor-resource.md
@@ -386,7 +386,7 @@ fields.
 * `data.attributes.module`
 * The monitor module to use
 * `data.attributes.parameters.user`
-* The [user](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#password) to use
+* The [user](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#password) to use
 * `data.attributes.parameters.password`
 * The [password](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#password) to use
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-rest-api.md
@@ -14,7 +14,7 @@ of the comment and extend to the end of the current line.
 
 ### Configuration
 
-Read the [REST API](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#rest-api-configuration)
+Read the [REST API](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#rest-api-configuration)
 section of the configuration guide for more details on how to configure the REST API.
 
 ### Authentication
@@ -25,7 +25,7 @@ user is `admin:mariadb`.
 
 It is highly recommended to enable HTTPS on the MaxScale REST API to make the
 communication between the client and MaxScale secure. Without it, the passwords
-can be intercepted from the network traffic. Refer to the [Configuration Guide](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#admin_ssl_key) for more
+can be intercepted from the network traffic. Refer to the [Configuration Guide](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#admin_ssl_key) for more
 details on how to enable HTTPS for the MaxScale REST API.
 
 For more details on how administrative interface users are created and managed,

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-server-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-server-resource.md
@@ -773,10 +773,10 @@ least the following fields.
 * `data.type`
 * Type of the object, must be `servers`
 * `data.attributes.parameters.address` OR `data.attributes.parameters.socket`
-* The [address](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#address) or [socket](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#socket) to use. Only
+* The [address](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#address) or [socket](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#socket) to use. Only
   one of the fields can be defined.
 * `data.attributes.parameters.port`
-* The [port](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#port) to use. Needs
+* The [port](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#port) to use. Needs
   to be defined if the `address` field is defined.
 
 The following is the minimal required JSON object for defining a new server.
@@ -860,7 +860,7 @@ server.
 
 #### Modifiable Fields
 
-In addition to the server [parameters](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#server-1), the _services_
+In addition to the server [parameters](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#server-1), the _services_
 and _monitors_ fields of the _relationships_ object can be modified. Removal,
 addition and modification of the links will change which service and monitors
 use this server.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-service-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-service-resource.md
@@ -754,10 +754,10 @@ relationships: `servers` and `filters` relationships.
 
 If the request body defines a valid `relationships` object, the service is
 linked to those resources. For servers, this is equivalent to adding the list of
-server names into the [servers](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#servers) parameter. For
-filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#filters) parameter in the
+server names into the [servers](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#servers) parameter. For
+filters, this is equivalent to adding the filters in the`data.relationships.filters.data` array to the [filters](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#filters) parameter in the
 order they appear. For other services, this is equivalent to adding the list of
-server names into the [targets](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#targets) parameter.
+server names into the [targets](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#targets) parameter.
 
 The following example defines a new service with both a server and a filter
 relationship.
@@ -840,7 +840,7 @@ PATCH /v1/services/:name
 The request body must be a JSON object which represents a set of new definitions
 for the service.
 
-All standard service parameters can be modified. Refer to the [service](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#service) documentation on
+All standard service parameters can be modified. Refer to the [service](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#service) documentation on
 the details of these parameters.
 
 In addition to the standard service parameters, router parameters can be updated

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md
@@ -679,7 +679,7 @@ The ETL operations require that the MariaDB ODBC driver is installed on the\
 MaxScale server. This driver is often available in the package manager of your
 operating system but it can also be downloaded from the MariaDB
 website. Installation instructions for installing the driver manually can be
-found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
+found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
 
@@ -726,7 +726,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
+driver. The list of supported options can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-rest-api/mariadb-maxscale-2308-sql-resource.md
@@ -679,7 +679,7 @@ The ETL operations require that the MariaDB ODBC driver is installed on the\
 MaxScale server. This driver is often available in the package manager of your
 operating system but it can also be downloaded from the MariaDB
 website. Installation instructions for installing the driver manually can be
-found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-linux).
+found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
 
@@ -726,7 +726,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
+driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-avrorouter.md
@@ -175,7 +175,7 @@ refer to the [Avro specification](https://avro.apache.org/docs/1.11.1/specificat
 * Dynamic: No
 * Default: `""`
 
-These [regular expression settings](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#standard-regular-expression-settings-for-filters)
+These [regular expression settings](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#regular-expressions)
 filter events for processing depending on table names. Avrorouter does not support the\_options\_-parameter for regular expressions.
 
 To prevent excessive matching of similarly named tables, surround each table

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-binlogrouter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-binlogrouter.md
@@ -199,7 +199,7 @@ This allows the Monitor to perform failover, and more importantly, switchover.\
 It also allows the user to manually redirect the Binlogrouter. The current
 primary is "sticky", meaning that the same primary will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](../mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-mariadb-monitor.md#configuration-parameters) if the monitor is
 monitoring a binlogrouter. The binlogrouter does not support all the SQL
 commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.
@@ -254,7 +254,7 @@ that has `ddl_only` enabled.
 * Default: `""`
 
 Encryption key ID used to encrypt the binary logs. If configured, an [Encryption\
-Key Manager](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#encryption-key-managers)
+Key Manager](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#encryption-key-managers)
 must also be configured and it must contain the key with the given ID. If the
 encryption key manager supports versioning, new binary logs will be encrypted
 using the latest encryption key. Old binlogs will remain encrypted with older

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-kafkacdc.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-kafkacdc.md
@@ -237,7 +237,7 @@ password=maxpwd
 bootstrap_servers=127.0.0.1:9092
 topic=my-cdc-topic
 match=db1[.]
-exclude=db1 [.](accounts|users)
+exclude=db1[.](accounts|users)
 ```
 
 #### `exclude`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readconnroute.md
@@ -134,7 +134,7 @@ type. With this configuration, the queries are load balanced across the
 replica servers.
 
 For more complex examples of the readconnroute router, take a look at the
-examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
+examples in the [Tutorials](../mariadb-maxscale-23-08-tutorials/README.md) folder.
 
 ### Router Diagnostics
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
@@ -458,7 +458,7 @@ will not be closed even if all backend connections for that session have
 failed. This is done in the hopes that before the next query from the idle
 session arrives, a reconnection to one of the replicas is made. However, this can
 leave idle connections around unless the client application actively closes
-them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#wait_timeout)
+them. To prevent this, use the [`wait_timeout`](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#wait_timeout)
 parameter.
 
 **Note:** If `master_failure_mode` is set to `error_on_write` and the connection

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
@@ -218,7 +218,7 @@ SELECT @myid; -- Might return 1 or 0
 #### `connection_keepalive`
 
 **Note:** This parameter has been moved into the MaxScale core. For the
-current documentation, read the [connection\_keepalive](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#connection_keepalive)
+current documentation, read the [connection\_keepalive](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#connection_keepalive)
 section in the configuration guide.
 
 Send keepalive pings to backend servers. This feature was introduced in MaxScale\
@@ -350,7 +350,7 @@ in MaxScale 6.0.
 
 #### `prune_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#prune_sescmd_history)
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#prune_sescmd_history)
 in MaxScale 6.0.
 
 #### `master_accept_reads`
@@ -458,7 +458,7 @@ will not be closed even if all backend connections for that session have
 failed. This is done in the hopes that before the next query from the idle
 session arrives, a reconnection to one of the replicas is made. However, this can
 leave idle connections around unless the client application actively closes
-them. To prevent this, use the [connection\_timeout](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#connection_timeout)
+them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#wait_timeout)
 parameter.
 
 **Note:** If `master_failure_mode` is set to `error_on_write` and the connection
@@ -563,7 +563,7 @@ transaction replay.
 
 #### `transaction_replay_max_size`
 
-* Type: [size](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#sizes)
+* Type: [size](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#sizes)
 * Mandatory: No
 * Dynamic: Yes
 * Default: 1 MiB
@@ -786,7 +786,7 @@ being routed almost exclusively to the primary server.
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
@@ -1155,7 +1155,7 @@ maxctrl call command readwritesplit reset-gtid My-RW-Router
 
 ### Examples
 
-Examples of the readwritesplit router in use can be found in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
+Examples of the readwritesplit router in use can be found in the [Tutorials](../mariadb-maxscale-23-08-tutorials/README.md) folder.
 
 ### Readwritesplit routing decisions
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-readwritesplit.md
@@ -786,7 +786,7 @@ being routed almost exclusively to the primary server.
 addition to this, the `session_track_system_variables` parameter must include`last_gtid` in its list of tracked system variables.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-schemarouter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-routers/mariadb-maxscale-2308-schemarouter.md
@@ -181,7 +181,7 @@ This parameter was once called `ignore_databases`.
 
 #### `ignore_tables_regex`
 
-* Type: [regex](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#regular-expressions)
+* Type: [regex](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#regular-expressions)
 * Mandatory: No
 * Dynamic: No
 * Default: `""`
@@ -207,12 +207,12 @@ This parameter was once called `ignore_databases_regex`.
 
 #### `max_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#max_sescmd_history)
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#max_sescmd_history)
 in MaxScale 6.0.
 
 #### `disable_sescmd_history`
 
-This parameter has been moved to [the MaxScale core](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#disable_sescmd_history)
+This parameter has been moved to [the MaxScale core](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#disable_sescmd_history)
 in MaxScale 6.0.
 
 #### `refresh_databases`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-encrypting-passwords.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-encrypting-passwords.md
@@ -47,7 +47,7 @@ user=maxscale
 password=96F99AA1315BDC3604B006F427DD9484
 ```
 
-If the key file is not in the default location, the [datadir](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#datadir) parameter must be
+If the key file is not in the default location, the [datadir](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#datadir) parameter must be
 set to the directory that contains it.
 
 CC BY-SA / Gnu FDL

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-mariadb-maxscale-administration-tutorial.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-mariadb-maxscale-administration-tutorial.md
@@ -12,7 +12,7 @@ reference to all the tasks that may be performed.
 ### Administration audit file
 
 The REST API calls that MaxCtrl and MaxGui issue to MaxScale can be logged
-by enabling [admin\_audit](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#admin_audit).
+by enabling [admin\_audit](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#admin_audit).
 
 The generated file is a csv file that can be opened in most spread sheet programs.
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-simple-sharding-with-two-servers.md
@@ -41,18 +41,18 @@ application will use.
 
 ```
 -- Create the user for the service
--- https://mariadb.com/kb/en/mariadb-maxscale-2308-authentication-modules/#required-grants
+-- https://mariadb.com/docs/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules#required-grants
 CREATE USER 'service_user'@'%' IDENTIFIED BY 'secret';
 GRANT SELECT ON mysql.* TO 'service_user'@'%';
 GRANT SHOW DATABASES ON *.* TO 'service_user'@'%';
 
 -- Create the user for the monitor
--- https://mariadb.com/kb/en/mariadb-maxscale-2308-galera-monitor/#required-grants
+-- https://mariadb.com/docs/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-monitors/mariadb-maxscale-2308-galera-monitor#required-grants
 CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'secret';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 
 -- Create the application user
--- https://mariadb.com/kb/en/mariadb-maxscale-2308-authentication-modules/#limitations-and-troubleshooting
+-- https://mariadb.com/docs/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-authenticators/mariadb-maxscale-2308-authentication-modules#limitations-and-troubleshooting
 CREATE USER app_user@'%' IDENTIFIED BY 'secret';
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO app_user@'%';
 ```

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-tutorials/mariadb-maxscale-2308-using-maxgui-tutorial.md
@@ -13,7 +13,7 @@ solution to [MaxCtrl](../mariadb-maxscale-23-08-reference/mariadb-maxscale-2308-
 
 ### Annotation
 
-1. [MaxScale object](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#objects). i.e.\
+1. [MaxScale object](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#objects). i.e.\
    Service, Server, Monitor, Filter, and Listener (Clicking on it will navigate
    to its detail page)
 2. Create a new MaxScale object.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-maxscale-2308-upgrading-mariadb-maxscale.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-maxscale-2308-upgrading-mariadb-maxscale.md
@@ -142,9 +142,6 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
-for details.
-
 ### New binlog router
 
 The binlog router delivered with MaxScale 2.5 is completely new and
@@ -340,7 +337,7 @@ add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-20-to-21.md
@@ -22,7 +22,7 @@ add `address=0.0.0.0` to the listener definition.
 
 ### Persisted Configuration Files
 
-Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](https://mariadb.com/kb/Reference/MaxAdmin#runtime-configuration-changes)
+Starting with MaxScale 2.1, any changes made with the newly added [runtime configuration change](../mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide.md#runtime-configuration-changes)
 will be persisted in a configuration file. These files are located in `/var/lib/maxscale/maxscale.cnf.d/`.
 
 ### MaxScale Log Files

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-upgrading/mariadb-maxscale-2308-upgrading-mariadb-maxscale-from-24-to-25.md
@@ -52,9 +52,6 @@ version=1.5
 ...
 ```
 
-Please see the [documentation](https://mariadb.com/kb/Monitors/ColumnStore-Monitor#master-selection)
-for details.
-
 ### New binlog router
 
 The binlog router delivered with MaxScale 2.5 is completely new and

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md
@@ -450,7 +450,7 @@ $EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
 Negative values disable this feature. For more information on monitor scripts,
-see [general monitor documentation](https://mariadb.com/kb/en/node:maxscale-24-02-common-monitor-parameters#script).
+see [general monitor documentation](mariadb-maxscale-2402-maxscale-2402-common-monitor-parameters.md#script).
 
 ### Cluster manipulation operations
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md
@@ -708,7 +708,7 @@ The ETL operations require that the MariaDB ODBC driver is installed on the\
 MaxScale server. This driver is often available in the package manager of your
 operating system but it can also be downloaded from the MariaDB
 website. Installation instructions for installing the driver manually can be
-found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
+found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
 
@@ -755,7 +755,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
+driver. The list of supported options can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02rest-api/mariadb-maxscale-2402-maxscale-2402-sql-resource.md
@@ -708,7 +708,7 @@ The ETL operations require that the MariaDB ODBC driver is installed on the\
 MaxScale server. This driver is often available in the package manager of your
 operating system but it can also be downloaded from the MariaDB
 website. Installation instructions for installing the driver manually can be
-found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-linux).
+found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#installing-mariadb-connector-odbc-on-linux).
 
 The request body must be a JSON object consisting of the following fields:
 
@@ -755,7 +755,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
+driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-binlogrouter.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-binlogrouter.md
@@ -288,7 +288,7 @@ This allows the Monitor to perform failover, and more importantly, switchover.\
 It also allows the user to manually redirect the Binlogrouter. The current
 primary is "sticky", meaning that the same primary will be chosen on reboot.
 
-**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](https://mariadb.com/kb/Monitor/MariaDB-Monitor#auto_rejoin) if the monitor is
+**NOTE:** Do not use the `mariadbmon` parameter [auto\_rejoin](../maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-mariadb-monitor.md#configuration-parameters) if the monitor is
 monitoring a binlogrouter. The binlogrouter does not support all the SQL
 commands that the monitor will send and the rejoin will fail. This restriction
 will be lifted in a future version.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-kafkacdc.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-kafkacdc.md
@@ -241,7 +241,7 @@ password=maxpwd
 bootstrap_servers=127.0.0.1:9092
 topic=my-cdc-topic
 match=db1[.]
-exclude=db1 [.](accounts|users)
+exclude=db1[.](accounts|users)
 ```
 
 #### `exclude`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readconnroute.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readconnroute.md
@@ -122,7 +122,7 @@ type. With this configuration, the queries are load balanced across the
 replica servers.
 
 For more complex examples of the readconnroute router, take a look at the
-examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
+examples in the [Tutorials](../maxscale-24-02tutorials/README.md) folder.
 
 ### Router Diagnostics
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
@@ -413,7 +413,7 @@ will not be closed even if all backend connections for that session have
 failed. This is done in the hopes that before the next query from the idle
 session arrives, a reconnection to one of the replicas is made. However, this can
 leave idle connections around unless the client application actively closes
-them. To prevent this, use the [connection\_timeout](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md)
+them. To prevent this, use the [`wait_timeout`](../maxscale-24-02getting-started/mariadb-maxscale-2402-maxscale-2402-mariadb-maxscale-configuration-guide.md#wait_timeout)
 parameter.
 
 **Note:** If `master_failure_mode` is set to `error_on_write` and the connection

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
@@ -730,7 +730,7 @@ writes. If used with a mixed or a write-heavy workload, the traffic will end up
 being routed almost exclusively to the primary server.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02routers/mariadb-maxscale-2402-maxscale-2402-readwritesplit.md
@@ -730,7 +730,7 @@ writes. If used with a mixed or a write-heavy workload, the traffic will end up
 being routed almost exclusively to the primary server.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.
@@ -1087,7 +1087,7 @@ maxctrl call command readwritesplit reset-gtid My-RW-Router
 
 ### Examples
 
-Examples of the readwritesplit router in use can be found in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
+Examples of the readwritesplit router in use can be found in the [Tutorials](../maxscale-24-02tutorials/README.md) folder.
 
 ### Readwritesplit routing decisions
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-simple-sharding-with-two-servers.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02tutorials/mariadb-maxscale-2402-maxscale-2402-simple-sharding-with-two-servers.md
@@ -37,18 +37,18 @@ application will use.
 
 ```
 -- Create the user for the service
--- https://mariadb.com/kb/en/mariadb-maxscale-2308-authentication-modules/#required-grants
+-- https://mariadb.com/docs/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules#required-grants
 CREATE USER 'service_user'@'%' IDENTIFIED BY 'secret';
 GRANT SELECT ON mysql.* TO 'service_user'@'%';
 GRANT SHOW DATABASES ON *.* TO 'service_user'@'%';
 
 -- Create the user for the monitor
--- https://mariadb.com/kb/en/mariadb-maxscale-2308-galera-monitor/#required-grants
+-- https://mariadb.com/docs/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02monitors/mariadb-maxscale-2402-maxscale-2402-galera-monitor#required-grants
 CREATE USER 'monitor_user'@'%' IDENTIFIED BY 'secret';
 GRANT REPLICATION CLIENT ON *.* TO 'monitor_user'@'%';
 
 -- Create the application user
--- https://mariadb.com/kb/en/mariadb-maxscale-2308-authentication-modules/#limitations-and-troubleshooting
+-- https://mariadb.com/docs/maxscale/maxscale-old-versions/mariadb-maxscale-24-02/maxscale-24-02authenticators/mariadb-maxscale-2402-maxscale-2402-authentication-modules#limitations-and-troubleshooting
 CREATE USER app_user@'%' IDENTIFIED BY 'secret';
 GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO app_user@'%';
 ```

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-configuration-settings.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-reference/mariadb-maxscale-2501-maxscale-2501-configuration-settings.md
@@ -1156,21 +1156,21 @@
 
 **Settings**
 
-[**lower\_case\_table\_names**](https://mariadb.com/kb/en/maxscale-25-01-authentication-modules/#lower_case_table_names)
+[**lower\_case\_table\_names**](../../../maxscale-security/authentication-modules.md#lower_case_table_names)
 
 * Type: number
 * Mandatory: No
 * Dynamic: No
 * Default: `0`
 
-[**match\_host**](https://mariadb.com/kb/en/maxscale-25-01-authentication-modules/#match_host)
+[**match\_host**](../../../maxscale-security/authentication-modules.md#match_host)
 
 * Type: [boolean](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 * Mandatory: No
 * Dynamic: No
 * Default: `true`
 
-[**skip\_authentication**](https://mariadb.com/kb/en/maxscale-25-01-authentication-modules/#skip_authentication)
+[**skip\_authentication**](../../../maxscale-security/authentication-modules.md#skip_authentication)
 
 * Type: [boolean](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
 * Mandatory: No

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md
@@ -756,7 +756,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
+driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-rest-api/mariadb-maxscale-2501-maxscale-2501-sql-resource.md
@@ -756,7 +756,7 @@ field. The `table` field defines the name of the table to be imported and the`sc
 
 Extra connection string that is appended to the destination server's
 connection string. This connection will always use the MariaDB ODBC
-driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
+driver. The list of supported options can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkacdc.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-kafkacdc.md
@@ -243,7 +243,7 @@ password=maxpwd
 bootstrap_servers=127.0.0.1:9092
 topic=my-cdc-topic
 match=db1[.]
-exclude=db1 [.](accounts|users)
+exclude=db1[.](accounts|users)
 ```
 
 #### `exclude`

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readconnroute.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readconnroute.md
@@ -124,7 +124,7 @@ type. With this configuration, the queries are load balanced across the
 replica servers.
 
 For more complex examples of the readconnroute router, take a look at the
-examples in the [Tutorials](https://mariadb.com/kb/Tutorials) folder.
+examples in the [Tutorials](../mariadb-maxscale-25-01-tutorials/README.md) folder.
 
 ### Router Diagnostics
 

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
@@ -415,7 +415,7 @@ will not be closed even if all backend connections for that session have
 failed. This is done in the hopes that before the next query from the idle
 session arrives, a reconnection to one of the replicas is made. However, this can
 leave idle connections around unless the client application actively closes
-them. To prevent this, use the [connection\_timeout](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md)
+them. To prevent this, use the [`wait_timeout`](../mariadb-maxscale-25-01-getting-started/mariadb-maxscale-2501-maxscale-2501-mariadb-maxscale-configuration-guide.md#wait_timeout)
 parameter.
 
 **Note:** If `master_failure_mode` is set to `error_on_write` and the connection

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
@@ -718,7 +718,7 @@ writes. If used with a mixed or a write-heavy workload, the traffic will end up
 being routed almost exclusively to the primary server.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-25-01-routers/mariadb-maxscale-2501-maxscale-2501-readwritesplit.md
@@ -718,7 +718,7 @@ writes. If used with a mixed or a write-heavy workload, the traffic will end up
 being routed almost exclusively to the primary server.
 
 **Note:** This feature also enables multi-statement execution of SQL in the
-protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries)
+protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries)
 or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the\
 Connector/C. The _Implementation of causal\_reads_ section explains why this is
 necessary.

--- a/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md
+++ b/maxscale/maxscale-old-versions/mariadb-maxscale-25-01/mariadb-maxscale-2501-maxscale-25-01-monitors/mariadb-maxscale-2501-maxscale-2501-mariadb-monitor.md
@@ -450,7 +450,7 @@ $EVENT-placeholder replaced by "rlag\_above". If the lag goes back below the
 limit, the script is ran again with replacement "rlag\_below".
 
 Negative values disable this feature. For more information on monitor scripts,
-see [general monitor documentation](https://mariadb.com/kb/en/node:maxscale-25-01-common-monitor-parameters#script).
+see [general monitor documentation](mariadb-maxscale-2501-maxscale-2501-common-monitor-parameters.md#script).
 
 ### Cluster manipulation operations
 

--- a/maxscale/reference/maxscale-rest-api/maxscale-sql-resource.md
+++ b/maxscale/reference/maxscale-rest-api/maxscale-sql-resource.md
@@ -677,7 +677,7 @@ An array of objects, each of which must define a `table` and a `schema` field. T
 
 * `connection_string`
 
-Extra connection string that is appended to the destination server's connection string. This connection will always use the MariaDB ODBC driver. The list of supported options can be found [here](https://mariadb.com/kb/en/about-mariadb-connector-odbc/#parameters).
+Extra connection string that is appended to the destination server's connection string. This connection will always use the MariaDB ODBC driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/reference/maxscale-rest-api/maxscale-sql-resource.md
+++ b/maxscale/reference/maxscale-rest-api/maxscale-sql-resource.md
@@ -677,7 +677,7 @@ An array of objects, each of which must define a `table` and a `schema` field. T
 
 * `connection_string`
 
-Extra connection string that is appended to the destination server's connection string. This connection will always use the MariaDB ODBC driver. The list of supported options can be found [here]({connectors}/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
+Extra connection string that is appended to the destination server's connection string. This connection will always use the MariaDB ODBC driver. The list of supported options can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-odbc/mariadb-connector-odbc-guide#parameters).
 
 * `threads`
 

--- a/maxscale/reference/maxscale-routers/maxscale-kafkacdc.md
+++ b/maxscale/reference/maxscale-routers/maxscale-kafkacdc.md
@@ -139,7 +139,7 @@ Enable idempotent producer mode. This feature requires Kafka version 0.11 or new
 
 When enabled, the Kafka producer enters a strict mode which avoids event duplication due to broker outages or other network errors. In HA scenarios where there are more than two MaxScale instances, event duplication can still happen as there is no synchronization between the MaxScale instances.
 
-The Kafka C library,[librdkafka](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION), describes the parameter as follows:
+The Kafka C library,[librdkafka](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md), describes the parameter as follows:
 
 When set to true, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must be less than or equal to 5), retries=INT32\_MAX (must be greater than 0), acks=all, queuing.strategy=fifo.
 
@@ -202,7 +202,7 @@ password=maxpwd
 bootstrap_servers=127.0.0.1:9092
 topic=my-cdc-topic
 match=db1[.]
-exclude=db1 [.](accounts|users)
+exclude=db1[.](accounts|users)
 ```
 
 ### `exclude`

--- a/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
+++ b/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
@@ -501,7 +501,7 @@ The following table contains a comparison of the modes. Read the [implementation
 
 The `fast`, `fast_global` and `fast_universal` modes should only be used when low latency is more important than proper distribution of reads. These modes should only be used when the workload is mostly read-only with only occasional writes. If used with a mixed or a write-heavy workload, the traffic will end up being routed almost exclusively to the primary server.
 
-**Note:** This feature also enables multi-statement execution of SQL in the protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://mariadb.com/kb/en/about-mariadb-connector-j/#allowmultiqueries) or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the Connector/C. The [implementation of `causal_reads`](maxscale-readwritesplit.md#implementation-of-causal_reads) section explains why this is necessary.
+**Note:** This feature also enables multi-statement execution of SQL in the protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries) or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the Connector/C. The [implementation of `causal_reads`](maxscale-readwritesplit.md#implementation-of-causal_reads) section explains why this is necessary.
 
 The possible values for this parameter are:
 

--- a/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
+++ b/maxscale/reference/maxscale-routers/maxscale-readwritesplit.md
@@ -501,7 +501,7 @@ The following table contains a comparison of the modes. Read the [implementation
 
 The `fast`, `fast_global` and `fast_universal` modes should only be used when low latency is more important than proper distribution of reads. These modes should only be used when the workload is mostly read-only with only occasional writes. If used with a mixed or a write-heavy workload, the traffic will end up being routed almost exclusively to the primary server.
 
-**Note:** This feature also enables multi-statement execution of SQL in the protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J]({connectors}/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries) or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the Connector/C. The [implementation of `causal_reads`](maxscale-readwritesplit.md#implementation-of-causal_reads) section explains why this is necessary.
+**Note:** This feature also enables multi-statement execution of SQL in the protocol. This is equivalent to using `allowMultiQueries=true` in [Connector/J](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/CjGYMsT2MVP4nd3IyW2L/mariadb-connector-j/about-mariadb-connector-j#allowmultiqueries) or using `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS` in the Connector/C. The [implementation of `causal_reads`](maxscale-readwritesplit.md#implementation-of-causal_reads) section explains why this is necessary.
 
 The possible values for this parameter are:
 

--- a/release-notes/maxscale/21.06/21.06.16.md
+++ b/release-notes/maxscale/21.06/21.06.16.md
@@ -14,7 +14,7 @@ MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have been releas
 
 This document describes the changes in release 21.06.16, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/21.06/21.06.16.md
+++ b/release-notes/maxscale/21.06/21.06.16.md
@@ -14,7 +14,7 @@ MaxScale 6.4 was renamed to 21.06 in May 2024. Thus, what would have been releas
 
 This document describes the changes in release 21.06.16, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-21) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/21.06/21.06.17.md
+++ b/release-notes/maxscale/21.06/21.06.17.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.17, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-21) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/21.06/21.06.17.md
+++ b/release-notes/maxscale/21.06/21.06.17.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.17, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/21.06/21.06.18.md
+++ b/release-notes/maxscale/21.06/21.06.18.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.18, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/21.06/21.06.18.md
+++ b/release-notes/maxscale/21.06/21.06.18.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.18, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-21) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/21.06/21.06.19.md
+++ b/release-notes/maxscale/21.06/21.06.19.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.19, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/21.06/21.06.19.md
+++ b/release-notes/maxscale/21.06/21.06.19.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 21.06.19, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-21) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-2.5-to-21.06) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.1.md
+++ b/release-notes/maxscale/22.08/22.08.1.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.1, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.1.md
+++ b/release-notes/maxscale/22.08/22.08.1.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.1, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.10.md
+++ b/release-notes/maxscale/22.08/22.08.10.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.10, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.10.md
+++ b/release-notes/maxscale/22.08/22.08.10.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.10, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.11.md
+++ b/release-notes/maxscale/22.08/22.08.11.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.11, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.11.md
+++ b/release-notes/maxscale/22.08/22.08.11.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.11, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.12.md
+++ b/release-notes/maxscale/22.08/22.08.12.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.12, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.12.md
+++ b/release-notes/maxscale/22.08/22.08.12.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.12, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.13.md
+++ b/release-notes/maxscale/22.08/22.08.13.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.13, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.13.md
+++ b/release-notes/maxscale/22.08/22.08.13.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.13, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.14.md
+++ b/release-notes/maxscale/22.08/22.08.14.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.14, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.14.md
+++ b/release-notes/maxscale/22.08/22.08.14.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.14, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.15.md
+++ b/release-notes/maxscale/22.08/22.08.15.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.15, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.15.md
+++ b/release-notes/maxscale/22.08/22.08.15.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.15, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.16.md
+++ b/release-notes/maxscale/22.08/22.08.16.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 22.08.16, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/22.08/22.08.16.md
+++ b/release-notes/maxscale/22.08/22.08.16.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 22.08.16, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/22.08/22.08.17.md
+++ b/release-notes/maxscale/22.08/22.08.17.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.17, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for this MaxScale version.
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
 

--- a/release-notes/maxscale/22.08/22.08.17.md
+++ b/release-notes/maxscale/22.08/22.08.17.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.17, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for this MaxScale version.
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).
 

--- a/release-notes/maxscale/22.08/22.08.2.md
+++ b/release-notes/maxscale/22.08/22.08.2.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.2, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.2.md
+++ b/release-notes/maxscale/22.08/22.08.2.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.2, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.3.md
+++ b/release-notes/maxscale/22.08/22.08.3.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.3, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.3.md
+++ b/release-notes/maxscale/22.08/22.08.3.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.3, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.4.md
+++ b/release-notes/maxscale/22.08/22.08.4.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.4, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.4.md
+++ b/release-notes/maxscale/22.08/22.08.4.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.4, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.5.md
+++ b/release-notes/maxscale/22.08/22.08.5.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 22.08.5, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/22.08/22.08.5.md
+++ b/release-notes/maxscale/22.08/22.08.5.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 22.08.5, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/22.08/22.08.6.md
+++ b/release-notes/maxscale/22.08/22.08.6.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.6, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.6.md
+++ b/release-notes/maxscale/22.08/22.08.6.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.6, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.7.md
+++ b/release-notes/maxscale/22.08/22.08.7.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.7, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.7.md
+++ b/release-notes/maxscale/22.08/22.08.7.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.7, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.8.md
+++ b/release-notes/maxscale/22.08/22.08.8.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.8, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.8.md
+++ b/release-notes/maxscale/22.08/22.08.8.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.8, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.9.md
+++ b/release-notes/maxscale/22.08/22.08.9.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.9, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/22.08/22.08.9.md
+++ b/release-notes/maxscale/22.08/22.08.9.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 22.08.9, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-upgrading/mariadb-maxscale-2302-upgrading-mariadb-maxscale-from-6-to-2208) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-21.06-to-22.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/23.02/23.02.0.md
+++ b/release-notes/maxscale/23.02/23.02.0.md
@@ -43,7 +43,7 @@ new endpoint for canceling active queries was added. The `POST /sql/:id/cancel`
 endpoint will interrupt the ongoing operation on the given connection.
 
 For more information on how ODBC type connections differ from native MariaDB
-connections, refer to the SQL resource [documentation](https://mariadb.com/kb/en/REST-API/Resources-SQL#open-sql-connection-to-server).
+connections, refer to the SQL resource [documentation]({maxscale}/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource#open-sql-connection-to-server).
 
 **Asynchronous Query API**
 
@@ -62,7 +62,7 @@ into MariaDB. The initial version supports MariaDB-to-MariaDB and\
 PostgreSQL-to-MariaDB migrations as well as generic migrations done via the ODBC
 catalog functions.
 
-For more information on the new API functions, refer to the SQL resource [documentation](https://mariadb.com/kb/en/REST-API/Resources-SQL#prepare-etl-operation).
+For more information on the new API functions, refer to the SQL resource [documentation]({maxscale}/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource#prepare-etl-operation).
 
 #### [MXS-3003](https://jira.mariadb.org/browse/MXS-3003) Support inbound proxy protocol
 

--- a/release-notes/maxscale/23.02/23.02.0.md
+++ b/release-notes/maxscale/23.02/23.02.0.md
@@ -43,7 +43,7 @@ new endpoint for canceling active queries was added. The `POST /sql/:id/cancel`
 endpoint will interrupt the ongoing operation on the given connection.
 
 For more information on how ODBC type connections differ from native MariaDB
-connections, refer to the SQL resource [documentation]({maxscale}/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource#open-sql-connection-to-server).
+connections, refer to the SQL resource [documentation](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource#open-sql-connection-to-server).
 
 **Asynchronous Query API**
 
@@ -62,7 +62,7 @@ into MariaDB. The initial version supports MariaDB-to-MariaDB and\
 PostgreSQL-to-MariaDB migrations as well as generic migrations done via the ODBC
 catalog functions.
 
-For more information on the new API functions, refer to the SQL resource [documentation]({maxscale}/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource#prepare-etl-operation).
+For more information on the new API functions, refer to the SQL resource [documentation](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-old-versions/mariadb-maxscale-23-02/mariadb-maxscale-23-02-rest-api/mariadb-maxscale-2302-sql-resource#prepare-etl-operation).
 
 #### [MXS-3003](https://jira.mariadb.org/browse/MXS-3003) Support inbound proxy protocol
 

--- a/release-notes/maxscale/23.08/23.08.0.md
+++ b/release-notes/maxscale/23.08/23.08.0.md
@@ -103,7 +103,7 @@ the client applications.
 When the service password is changed, MaxScale will remember and use the previous
 password if the new does not work. This makes it easier to manage the changing of
 the password, as the password in the backend and in MaxScale need not be changed
-simultaneously. More information about this functionality can be found [here](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#user-and-password).
+simultaneously. More information about this functionality can be found [here]({maxscale}/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide#password).
 
 #### [MXS-4277](https://jira.mariadb.org/browse/MXS-4277) Configurable `iss` field in JWTs
 
@@ -116,7 +116,7 @@ issued the token.
 It is now possible to specify options in an _include_-section, to be included
 by other sections. This is useful, for instance, if there are multiple monitors
 that otherwise are identically configured, but for their list of servers. More
-information about this functionality can be found [here](https://mariadb.com/kb/en/maxscale-2308-getting-started-mariadb-maxscale-configuration-guide/#include-1).
+information about this functionality can be found [here]({maxscale}/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide#include-1).
 
 #### [MXS-4505](https://jira.mariadb.org/browse/MXS-4505) Safer replaying of about-to-commit transactions
 

--- a/release-notes/maxscale/23.08/23.08.0.md
+++ b/release-notes/maxscale/23.08/23.08.0.md
@@ -103,7 +103,7 @@ the client applications.
 When the service password is changed, MaxScale will remember and use the previous
 password if the new does not work. This makes it easier to manage the changing of
 the password, as the password in the backend and in MaxScale need not be changed
-simultaneously. More information about this functionality can be found [here]({maxscale}/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide#password).
+simultaneously. More information about this functionality can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide#password).
 
 #### [MXS-4277](https://jira.mariadb.org/browse/MXS-4277) Configurable `iss` field in JWTs
 
@@ -116,7 +116,7 @@ issued the token.
 It is now possible to specify options in an _include_-section, to be included
 by other sections. This is useful, for instance, if there are multiple monitors
 that otherwise are identically configured, but for their list of servers. More
-information about this functionality can be found [here]({maxscale}/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide#include-1).
+information about this functionality can be found [here](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-old-versions/mariadb-maxscale-23.08/mariadb-maxscale-23-08-getting-started/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide#include-1).
 
 #### [MXS-4505](https://jira.mariadb.org/browse/MXS-4505) Safer replaying of about-to-commit transactions
 

--- a/release-notes/maxscale/23.08/23.08.1.md
+++ b/release-notes/maxscale/23.08/23.08.1.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.1, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.1.md
+++ b/release-notes/maxscale/23.08/23.08.1.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.1, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.2.md
+++ b/release-notes/maxscale/23.08/23.08.2.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.2, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.2.md
+++ b/release-notes/maxscale/23.08/23.08.2.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.2, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.3.md
+++ b/release-notes/maxscale/23.08/23.08.3.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.3, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.3.md
+++ b/release-notes/maxscale/23.08/23.08.3.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.3, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.4.md
+++ b/release-notes/maxscale/23.08/23.08.4.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.4, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.4.md
+++ b/release-notes/maxscale/23.08/23.08.4.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.4, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.5.md
+++ b/release-notes/maxscale/23.08/23.08.5.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.5, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.5.md
+++ b/release-notes/maxscale/23.08/23.08.5.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.5, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.6.md
+++ b/release-notes/maxscale/23.08/23.08.6.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.6, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.6.md
+++ b/release-notes/maxscale/23.08/23.08.6.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.6, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.7.md
+++ b/release-notes/maxscale/23.08/23.08.7.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.7, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.7.md
+++ b/release-notes/maxscale/23.08/23.08.7.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.7, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.8.md
+++ b/release-notes/maxscale/23.08/23.08.8.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.8, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.8.md
+++ b/release-notes/maxscale/23.08/23.08.8.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.8, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.9.md
+++ b/release-notes/maxscale/23.08/23.08.9.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.9, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/docs/maxscale/maxscale-versions/mariadb-maxscale-24-02/maxscale-24-02upgrading/mariadb-maxscale-2402-maxscale-2402-upgrading-mariadb-maxscale-from-2302-to-2308) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/23.08/23.08.9.md
+++ b/release-notes/maxscale/23.08/23.08.9.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 23.08.9, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.02-to-23.08) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.1.md
+++ b/release-notes/maxscale/24.02/24.02.1.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.1, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.1.md
+++ b/release-notes/maxscale/24.02/24.02.1.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.1, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.2.md
+++ b/release-notes/maxscale/24.02/24.02.2.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.2, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.2.md
+++ b/release-notes/maxscale/24.02/24.02.2.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.2, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.3.md
+++ b/release-notes/maxscale/24.02/24.02.3.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.3, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.3.md
+++ b/release-notes/maxscale/24.02/24.02.3.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.3, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.4.md
+++ b/release-notes/maxscale/24.02/24.02.4.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.4, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.4.md
+++ b/release-notes/maxscale/24.02/24.02.4.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.4, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.5.md
+++ b/release-notes/maxscale/24.02/24.02.5.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.5, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.5.md
+++ b/release-notes/maxscale/24.02/24.02.5.md
@@ -9,7 +9,7 @@ description: >-
 This document describes the changes in release 24.02.5, when compared to the
 previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug

--- a/release-notes/maxscale/24.02/24.02.6.md
+++ b/release-notes/maxscale/24.02/24.02.6.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 24.02.6, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).

--- a/release-notes/maxscale/24.02/24.02.6.md
+++ b/release-notes/maxscale/24.02/24.02.6.md
@@ -8,7 +8,7 @@ description: >-
 
 This document describes the changes in release 24.02.6, when compared to the previous release in the same series.
 
-If you are upgrading from an older major version of MaxScale, please read the [upgrading document](https://mariadb.com/kb/Upgrading/Upgrading-To-MaxScale-24.02) for
+If you are upgrading from an older major version of MaxScale, please read the [upgrading document]({maxscale}/maxscale-management/deployment/upgrading-maxscale#upgrading-mariadb-maxscale-from-23.08-to-24.02) for
 this MaxScale version.
 
 For any problems you encounter, please consider submitting a bug report on [our Jira](https://jira.mariadb.org/projects/MXS).


### PR DESCRIPTION
Closes [DOCS-6476](https://mariadbcorp.atlassian.net/browse/DOCS-6476).

The external-link half of DOCS-6381: `https://mariadb.com/kb/...` links in `maxscale/` and `release-notes/maxscale/` that return **HTTP 200** and redirect to `https://mariadb.com/docs?q=<slug>` — the docs search page. lychee sees the 200 and passes, so nothing has ever gated these and nothing stops more appearing.

## Re-baselined scope

The ticket says **166 / 113 / 87**. Measured on `main` today: **93 occurrences / 57 distinct URLs / 60 files**. The difference is not drift — `git grep` at the commit the ticket was filed against already reads 93. DOCS-6435 retired the MaxScale 21.06 and 22.08 archives the same day and took 73 of them with it. The ticket's directory names are stale too: the tree is `maxscale/maxscale-old-versions/`, not `maxscale/maxscale-archive/archive/`.

**All 93 resolve.** Nothing was unlinked for want of a target except the one group that genuinely has none.

| n | Group | Resolution |
|---|---|---|
| 34 | 23.08 Configuration Guide, anchored | relative path + anchor (2 cross-space) |
| 13 | Connector/J and Connector/ODBC | `{connectors}` |
| 10 | release-note "upgrading document" | `{maxscale}` consolidated page + version anchor |
| 7 | `Tutorials` folder | version-matched tutorials README |
| 6 | SQL comments inside code fences | absolute published URL, version-matched |
| 4 | `Monitors/ColumnStore-Monitor` | **no target** — sentence dropped |
| 4 | `Reference/MaxAdmin#runtime-configuration-changes` | version guide, same anchor name |
| 4 | `node:...common-monitor-parameters#script` | version-matched, `node:` debris stripped |
| 3 | `auto_rejoin` on MariaDB Monitor | enclosing `#configuration-parameters` |
| 3 | 25.01 authenticator settings | current Authentication Modules page |
| 2 | `Configuration-Guide#tsl-encryption` | `#tls-ssl-encryption` |
| 2 | `REST-API/Resources-SQL` | `{maxscale}` 23.02 SQL Resource |
| 1 | `kb/en/mailto:...@googlegroups.com` | `mailto:` |

## The ones that needed a decision

**Three anchors had moved on the 23.08 Configuration Guide.**

- `#connection_timeout` — the parameter was renamed `wait_timeout` in 23.08, with `connection_timeout` kept as a deprecated alias. Retargeted to `#wait_timeout`, and the link text corrected with it — see below.
- `#user-and-password` → `#password`. Confirmed by content, not by name similarity: the citing release note is MXS-4232 "Remember old service password", and `#password` is the section that says "From 23.08.0 onwards, MaxScale will remember the previous password".
- `#standard-regular-expression-settings-for-filters` is a **bold pseudo-heading**, and it sits under an `####`, so promoting it would produce an `#####` — which GitBook publishes no id for. Retargeted to the enclosing `#regular-expressions`, which is what the line directly above it in the same file already links to.

**`#auto_rejoin`** is the same shape: `**`auto_rejoin`**` under `#### Configuration parameters` on all three MariaDB Monitor pages. Retargeted to the enclosing h4.

**The four ColumnStore Monitor links have no destination anywhere.** `csmon` was removed in 23.02 and no page in any space documents it. Each sat in "Please see the [documentation] for details.", a sentence that exists only to carry the link, so the sentence is dropped rather than left as a dangling instruction.

**Six were SQL comments inside code fences** — `-- https://mariadb.com/kb/...` above a `CREATE USER` in the sharding tutorials. A relative path is useless there, so these became absolute published URLs. They were also version-inconsistent: the 24.02 tutorial pointed at 23.08 pages. Now version-matched.

**Mangled forms fixed along the way**, all of them the reason the link was dead rather than merely stale: a `node:` prefix on four monitor links, `mailto:` wrapped inside a KB URL, and the link text `TSLSSL encryption` (from `TLS/SSL`).

## `connection_timeout` → `wait_timeout` on three readwritesplit pages

Chasing that one anchor turned up a wider defect. The readwritesplit pages for **23.08, 24.02 and 25.01** all say "To prevent this, use the `connection_timeout` parameter" — a spelling their own Configuration Guide deprecates, since the rename landed in 23.08 and `connection_timeout` survives only as an alias.

No wording had to be invented: **the current readwritesplit page already carries the corrected sentence word for word**, code span and anchor included. The three archived copies now match their live twin.

24.02 and 25.01 were also linking the Configuration Guide with **no fragment at all**, landing the reader at the top of a 4,000-line page. Both now carry `#wait_timeout`.

**23.02 is deliberately untouched** — the rename is later than that series, so its `#connection_timeout` link is correct as written. It is the control case that shows the other three are wrong rather than merely old.

## Drive-by fixes

- **26 links using the retired `maxscale-versions/` container name** — the ticket's first side finding, re-measured as still 26 across 26 files. Its "degraded, not broken" reading is half right: the 23.02 URL (17×) redirects to the exact page, but the 24.02 URL (9×) redirects to a section landing that is now a 12-line "This page has moved" stub. All 26 now use the consolidated Upgrading MaxScale page with the version-matched anchor, which also makes the release-note upgrading links uniform across 21.06, 22.08, 23.08 and 24.02.
- **KafkaCDC regex example**: `exclude=db1 [.](accounts|users)` against an adjacent `match=db1[.]` in 5 files (the ticket says 7 — again, 21.06/22.08 retirement). Inside a code fence, so no linter sees it.
- **`maxscale-kafkacdc.md`**: `github.com/edenhill/librdkafka/blob/master/CONFIGURATION` 301s to `confluentinc` and then 404s (the file gained a `.md`). Pre-existing on `main` — identical line at `origin/main:142` — but CI scans changed files, so it had to be cleared for this PR to pass.

## Verification

- `doc-lint.sh` on all 91 changed files: **exit 0**, 3029 links / 1042 unique / 0 errors. Canary-confirmed live — the librdkafka 404 above is what the first run reported.
- `codespell` CI-exact invocation: **0**.
- `fragcheck.py new main`: **no new dead heading anchors** (20 pre-existing, unchanged), **no new stolen ids**.
- **The 53 alias occurrences are checked by nothing** — fragcheck follows only repo-relative links and lychee's CI args exclude `.*\{.*`. All **11 distinct alias targets** were verified by hand: the page exists at that nav path in the target space's `SUMMARY.md`, the anchor is on an h2–h4 heading, and `curl` of the live published page finds `id="<anchor>"` exactly once. The 6 absolute published URLs were checked the same way, by response body rather than status code.
- Reconciliation: acted-on 93 = measured 93, and **0** `mariadb.com/kb/` links remain in either tree.

## Not in this PR

Two of the ticket's four side findings are left:

- **The two empty archive changelog stubs are gone** — DOCS-6435 deleted them. No longer applicable.
- **The MaxScale 23.08 CDC Connector page is still missing**, and `maxscale/SUMMARY.md:339-340` still has two differently-labelled nav entries pointing at the same section README (the DOCS-6445 signature). Worse than the ticket says: after the 21.06/22.08 retirement only three archived series carry the page, and **the current MaxScale docs have no connectors section at all** — the topic survives only in the archive. That needs pages written, not a nav edit, so it stays open. Filed separately as [DOCS-6528](https://mariadbcorp.atlassian.net/browse/DOCS-6528).

One thing found but out of scope: `server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage.md` carries two raw `app.gitbook.com` links into a **MaxScale 2.3** installation guide in a different space. Server space, different defect, not touched here.


[DOCS-6476]: https://mariadbcorp.atlassian.net/browse/DOCS-6476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-6528]: https://mariadbcorp.atlassian.net/browse/DOCS-6528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ