### PR TITLE
⚠️ WIP ⚠️: MariaDB Enterprise Operator 26.06.2 release notes and update guide

### DIFF
--- a/release-notes/SUMMARY.md
+++ b/release-notes/SUMMARY.md
@@ -2783,6 +2783,7 @@
     * [MariaDB Enterprise Kubernetes Operator 26.03.3](enterprise-operator/26.03.3.md)
   * [MariaDB Enterprise Kubernetes Operator 26.06](enterprise-operator/26.06.md)
     * [MariaDB Enterprise Kubernetes Operator 26.06.1](enterprise-operator/26.06.1.md)
+    * [MariaDB Enterprise Kubernetes Operator 26.06.2](enterprise-operator/26.06.2.md)
   * [All Releases](enterprise-operator/all-releases.md)
 * [Enterprise Manager Release Notes](enterprise-manager/README.md)
   * [All Releases](enterprise-manager/all-releases.md)

--- a/release-notes/enterprise-operator/26.06.2.md
+++ b/release-notes/enterprise-operator/26.06.2.md
@@ -1,0 +1,47 @@
+---
+description: >-
+  MariaDB Enterprise Operator 26.06.2 is a maintenance release of MariaDB
+  Enterprise Operator, released on 2026-08-27
+---
+
+# MariaDB Enterprise Kubernetes Operator 26.06.2
+
+**Release date**: 27 August 2026
+
+MariaDB Enterprise Kubernetes Operator 26.06.2 is a maintenance release for the 26.06 series. It focuses on the reliability of replication topologies during switchovers and updates.
+
+If you are updating from a previous version, **please follow the** [**UPDATE GUIDE**](https://mariadb.com/docs/tools/mariadb-enterprise-operator/updates/update-26.06.2) to ensure a safe transition.
+
+### New features
+
+* __K8SDKR-177__: OpenShift `4.20` and `4.22` are now supported. The operator is certified and published in the `4.22`, `4.20`, `4.18` and `4.16` certified operator catalogs.
+* __K8SDKR-301__: Custom MariaDB Enterprise Server image builds are now multi-architecture, covering `linux/amd64`, `linux/arm64` and `linux/ppc64le`, just like regular release builds.
+
+### Bug fixes
+
+* __K8SDKR-304__: Multiple fixes in the native (non-MaxScale) failover and switchover path:
+  * `RESET MASTER;` is no longer issued when configuring a replica in **any** replication topology. In `26.6.1` this only applied to topologies fronted by MaxScale. As a result, binary logs and GTID positions are preserved when a primary is demoted, which keeps point-in-time recovery archival consistent and surfaces errant transactions instead of silently erasing them.
+  * A switchover no longer leaves the promoted primary half configured. Previously, two consecutive switchovers could abort and leave **both** nodes in `read_only` while the `MariaDB` resource still reported the `Ready` condition.
+  * `User`, `Grant` and `Database` resources are no longer reconciled while the `MariaDB` is in a transient state, such as an ongoing switchover. Previously they could be applied as `root` to the node being demoted, producing errant transactions that broke replication with `Error 1236 ... slave has diverged`.
+* __K8SDKR-307__: `read_only` is now enforced on the replicas of clusters that do not use MaxScale even when the `MariaDB` resource is not `Ready`. Since `read_only` is runtime state only and is not persisted in the MariaDB configuration, a replica that restarted while unhealthy could stay writable indefinitely. Clusters with `spec.maxScaleRef` set are unaffected and behave exactly as before.
+* __K8SDKR-297__: A rolling update no longer gets stuck on a MaxScale switchover when the promoted primary has an empty `gtid_binlog_pos`. The operator now forces the primary configuration in this scenario, which populates the binary log position and makes the node a valid demotion target for `mariadbmon`.
+* __K8SDKR-303__: The `copy-agent` init container image now honors `updateStrategy.autoUpdateDataPlane`, like the rest of the [data-plane](https://mariadb.com/docs/tools/mariadb-enterprise-operator/topologies/data-plane) containers. Previously it was taken directly from the running operator image, so updating the operator triggered an unsolicited rolling restart of every `MariaDB` with replication enabled, even when `autoUpdateDataPlane` was `false`.
+
+### Notes
+
+* __K8SDKR-296__: Clients connected through MaxScale can observe a brief connectivity window during a primary switchover, as no server holds the `Master` state while the handover is in progress. This is inherent to the way MaxScale performs switchovers rather than an operator defect, and it is shortened by [MXS-6859](https://jira.mariadb.org/browse/MXS-6859). The MaxScale build that includes it is not the operator default, so it must be set explicitly in `spec.image` of the `MaxScale` resource.
+
+### Platform and component versions
+
+The current release has been tested with the following versions:
+
+| Platform/Component        | Version    |
+| ------------------------- | ---------- |
+| Kubernetes                | 1.36       |
+| OpenShift                 | 4.20       |
+| MariaDB Enterprise Server | 11.8.8-5   |
+| MaxScale                  | 25.10.3    |
+
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
+
+{% @marketo/form formid="4316" formId="4316" %}

--- a/tools/SUMMARY.md
+++ b/tools/SUMMARY.md
@@ -72,6 +72,7 @@
     * [26.03 version update guide](mariadb-enterprise-operator/updates/update-26.03.md)
     * [26.06 version update guide](mariadb-enterprise-operator/updates/update-26.06.md)
     * [26.06.1 version update guide](mariadb-enterprise-operator/updates/update-26.06.1.md)
+    * [26.06.2 version update guide](mariadb-enterprise-operator/updates/update-26.06.2.md)
   * [Metrics](mariadb-enterprise-operator/metrics.md)
   * [SQL Resources](mariadb-enterprise-operator/sql-resources.md)
   * [External MariaDB](mariadb-enterprise-operator/external-mariadb.md)

--- a/tools/mariadb-enterprise-operator/updates/update-26.06.2.md
+++ b/tools/mariadb-enterprise-operator/updates/update-26.06.2.md
@@ -1,0 +1,70 @@
+---
+description: >-
+  Step-by-step guide for updating MariaDB Enterprise Kubernetes Operator to
+  26.06.2 from a previous version.
+---
+
+# 26.06.2 update guide
+
+This guide illustrates, step by step, how to update to `26.6.2` from `26.6.1`. If you are updating from a version prior to `26.6.x`, follow the [26.06 update guide](https://mariadb.com/docs/tools/mariadb-enterprise-operator/updates/update-26.06) and the [26.06.1 update guide](https://mariadb.com/docs/tools/mariadb-enterprise-operator/updates/update-26.06.1) first, and apply the changes described there before continuing with this one.
+
+## Updating the data-plane is optional
+
+{% hint style="info" %}
+**Unlike previous releases, updating the** [**data-plane**](../topologies/data-plane.md) **to `26.6.2` is optional.** All the fixes delivered in `26.6.2` live in the operator itself, so updating the operator is enough to get all of them.
+
+You may leave `updateStrategy.autoUpdateDataPlane` set to `false` (the default) and keep your current data-plane version. This avoids a rolling restart of your `MariaDB` instances.
+{% endhint %}
+
+If you still prefer to keep the data-plane aligned with the operator version, set `updateStrategy.autoUpdateDataPlane=true` in your `MariaDB` resources **before** updating the operator. Then, once updated, the operator will also update the data-plane based on its version. Bear in mind that this triggers a rolling update of your `MariaDB` instances:
+
+```diff
+apiVersion: enterprise.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-repl
+spec:
+  updateStrategy:
++   autoUpdateDataPlane: true
+```
+
+## Updating the operator
+
+- First of all, the CRDs must be updated to `26.6.2`:
+
+```bash
+helm repo update mariadb-enterprise-operator
+helm upgrade --install mariadb-enterprise-operator-crds mariadb-enterprise-operator/mariadb-enterprise-operator-crds --version 26.6.2
+```
+
+- At this point, the operator can be updated to `26.6.2`:
+
+```bash
+helm repo update mariadb-enterprise-operator
+helm upgrade --install mariadb-enterprise-operator mariadb-enterprise-operator/mariadb-enterprise-operator --version 26.6.2
+```
+
+{% hint style="warning" %}
+`26.6.2` fixes the `copy-agent` init container image, which is injected in `MariaDB` resources that have replication enabled and `replication.primary.autoSwitchoverOnGracefulShutdown` set to `true` (the default). It is now taken from the pinned data-plane image (`spec.replication.initContainer.image`) instead of the running operator image, so that it honors `updateStrategy.autoUpdateDataPlane` like the rest of the data-plane containers.
+
+If the pinned data-plane image of a given `MariaDB` differs from the operator version you are updating from, this results in a **one-off rolling update** of that instance in the first reconciliation after the operator has been updated. From that point on, updating the operator no longer restarts your `MariaDB` instances unless `updateStrategy.autoUpdateDataPlane` is enabled.
+{% endhint %}
+
+- If you enabled `updateStrategy.autoUpdateDataPlane`, wait until the data-plane update has completed: all `MariaDB` Pods must be ready and the `MariaDB` resources must report the `Ready` condition before proceeding.
+
+- Consider reverting `updateStrategy.autoUpdateDataPlane` back to `false` in your `MariaDB` objects to avoid unexpected updates:
+
+```diff
+apiVersion: enterprise.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-repl
+spec:
+  updateStrategy:
+-   autoUpdateDataPlane: true
++   autoUpdateDataPlane: false
+```
+
+<sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
+
+{% @marketo/form formId="4316" %}


### PR DESCRIPTION
> [!WARNING]
> **Not ready to merge.** This should be a draft PR, but the token used to open it cannot toggle draft state, hence the `WIP` title. Please convert it to a draft, and do not merge until the follow-ups below are resolved and `26.6.2` is actually released.

Documentation for the MariaDB Enterprise Kubernetes Operator `26.6.2` release.

Companion to https://github.com/mariadb-corporation/mariadb-enterprise-operator/pull/216, based on the [26.6.2 JIRA version](https://jira.mariadb.org/projects/K8SDKR/versions/30615).

## Release notes

`release-notes/enterprise-operator/26.06.2.md`: brief release notes in the same style as the [MaxScale ones](https://mariadb.com/docs/release-notes/maxscale/25.10/25.10.3), listing one JIRA identifier per item without extensive explanations.

- **New features**: K8SDKR-177 (OpenShift 4.20 and 4.22), K8SDKR-301 (multi-arch custom builds).
- **Bug fixes**: K8SDKR-304 (`RESET MASTER;` removal, half configured primary on switchover, SQL resources reconciled during transient states), K8SDKR-307 (`read_only` on replicas of non-MaxScale clusters), K8SDKR-297 (rolling update stuck on MaxScale switchover with an empty `gtid_binlog_pos`), K8SDKR-303 (`copy-agent` image not gated by `autoUpdateDataPlane`).
- **Notes**: K8SDKR-296 (MaxScale switchover connectivity window, shortened by MXS-6859).

K8SDKR-298 is left out, as it was closed as *Cannot Reproduce*, and so is K8SDKR-299, which is an internal umbrella epic.

## Update guide

`tools/mariadb-enterprise-operator/updates/update-26.06.2.md`, linked from the release notes.

**Updating the data-plane is optional in this release**, and the guide makes that explicit up front: every fix in `26.6.2` lands in the operator itself, so updating the operator alone delivers all of them and `updateStrategy.autoUpdateDataPlane` can stay `false`, avoiding a rolling restart. The rest of the steps are the standard CRDs-then-operator Helm upgrade.

It also warns that a one-off rolling update may happen on the first reconciliation after the update for `MariaDB` resources whose pinned data-plane image differs from the operator version being updated from, as a consequence of the `copy-agent` fix (K8SDKR-303).

## Follow-ups, not included here

- The release date is set to **27 August 2026**; it needs adjusting if the release slips.
- The K8SDKR-296 note does not name the MaxScale image tag that carries MXS-6859, pending confirmation that `maxscale-25.10.3-2-todo-6236` is the final tag.
- `tools/mariadb-enterprise-operator/installation/openshift.md` still advertises `4.18, 4.16` in its release channels table, while `deploy/olm/ci.yaml` now certifies `4.22, 4.20, 4.18, 4.16`. Out of scope for this PR.
- Overlaps with the WIP draft #901, which also adds `update-26.06.2.md`. See the comment there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)