### PR TITLE
DOCS-6506 Document pc.bootstrap on the wsrep_provider_options page

### DIFF
--- a/galera-cluster/reference/wsrep-variable-details/wsrep_provider_options.md
+++ b/galera-cluster/reference/wsrep-variable-details/wsrep_provider_options.md
@@ -388,6 +388,16 @@ Note that before Galera 3, the `repl` tag was named `replicator`.
 * Dynamic: No
 * Default: `PT3S`
 
+#### `pc.bootstrap`
+
+* Description: Makes the node bootstrap a new Primary Component from the component it currently sees. This is how a cluster that has lost its Primary Component is brought back into service. For example: `SET GLOBAL wsrep_provider_options='pc.bootstrap=YES';`
+  * The option is a trigger rather than a stored setting. It only takes effect while the node is in a non-primary state; on a node that is already part of a Primary Component the provider writes `ignoring 'pc.bootstrap' in state <state>` to the error log and nothing changes.
+  * Because the value is only a trigger, it is not interpreted: `YES`, `true` and `1` all bootstrap the node — and so do `0` and `false`.
+  * Setting it does not change the value the node reports for [wsrep\_provider\_options](../galera-cluster-system-variables.md#wsrep_provider_options), and it can be set again on each subsequent loss of quorum.
+  * See [Resetting the Quorum (Cluster Bootstrap)](../../high-availability/resetting-the-quorum-cluster-bootstrap.md) for the full procedure, including how to choose the node to bootstrap from.
+* Dynamic: Yes
+* Default: None
+
 #### `pc.checksum`
 
 * Description: For debug purposes, by default `false` (`true` in earlier releases), indicates whether to checksum replicated messages on PC level. Safe to turn off.
@@ -432,13 +442,13 @@ Note that before Galera 3, the `repl` tag was named `replicator`.
 
 #### `pc.wait_prim`
 
-* Description: When set to `true`, the default, the node will wait for a primary component for the period of time specified by [pc.wait\_prim\_timeout](wsrep_provider_options.md#pc.wait_prim_timeout). Used to bring up non-primary components and make them primary using [pc.bootstrap](../../high-availability/resetting-the-quorum-cluster-bootstrap.md).
+* Description: When set to `true`, the default, the node will wait for a primary component for the period of time specified by [pc.wait\_prim\_timeout](wsrep_provider_options.md#pc.wait_prim_timeout). Used to bring up non-primary components and make them primary using [pc.bootstrap](wsrep_provider_options.md#pc.bootstrap).
 * Dynamic: No
 * Default: `true`
 
 #### `pc.wait_prim_timeout`
 
-* Description: Ttime to wait for a primary component. See [pc.wait\_prim](wsrep_provider_options.md#pc.wait_prim).
+* Description: Time to wait for a primary component. See [pc.wait\_prim](wsrep_provider_options.md#pc.wait_prim).
 * Dynamic: No
 * Default: `PT30S`
 
@@ -562,6 +572,15 @@ Note that before Galera 3, the `repl` tag was named `replicator`.
 
 * Description: Path to password file to use in TLS connections. Implicitly enables the [socket.ssl](wsrep_provider_options.md#socket.ssl) option.
 * Dynamic: No
+
+#### `socket.ssl_reload`
+
+* Description: Makes the provider re-initialize its TLS context, so that a certificate can be replaced without restarting the server. For example: `SET GLOBAL wsrep_provider_options='socket.ssl_reload=1';`
+  * Like [pc.bootstrap](wsrep_provider_options.md#pc.bootstrap), this is a trigger rather than a stored setting, and the value is not interpreted.
+  * The certificate and key paths cannot be changed at runtime, so the replacement files must be in place at the paths the TLS options already point to. If TLS is not in use on the node, setting this option does nothing.
+  * See [Reloading TLS Certificates Without Downtime](../../galera-security/reloading-tls-certificates-without-downtime.md) for the full procedure.
+* Dynamic: Yes
+* Default: None
 
 ## See Also
 


### PR DESCRIPTION
[DOCS-6506](https://mariadbcorp.atlassian.net/browse/DOCS-6506)

`pc.bootstrap` had no section on `galera-cluster/reference/wsrep-variable-details/wsrep_provider_options.md`, even though five other pages in the Galera space tell the reader to set it to recover a cluster that has lost its Primary Component — and those pages disagree on the value spelling (`=YES` on two, `=true` on three). A reader arriving at the reference page to settle that found nothing.

## What the source says

Verified against `MariaDB/galera` @ `4cadb3c2ce3eaf95e5baf74c97b216414a77b803` (tag `mariadb-26.4.28`). The Galera provider is not one of the repos in `.claude/doc-sources.local.json`, so it was cloned fresh at that SHA; the full claim-by-claim table goes on the ticket at handoff.

| Claim | Evidence |
|-------|----------|
| No default; absent from the value a node reports for `wsrep_provider_options` | `gcomm/src/conf.cpp:180` registers it with `GCOMM_CONF_ADD`, not `GCOMM_CONF_ADD_DEFAULT`; `galerautils/src/gu_config.cpp:219` prints a param only `if (p.is_set() \|\| notset)` |
| Dynamic | `gcomm/src/defaults.hpp:139` — `type_bool` with **no** `read_only`, unlike `PcWaitPrim` and `PcRecovery` two lines down |
| Only acts while the node is non-primary | `gcomm/src/pc_proto.cpp:1706` — `if (state() != S_NON_PRIM)` logs `ignoring 'pc.bootstrap' in state <state>` and returns |
| The value is not interpreted | The `PcBootstrap` branch (`pc_proto.cpp:1704-1717`) never reads `value`, and every layer of the set path is a pass-through: `replicator_smm_params.cpp:197`, `gcs.cpp:2800`, `gcs_gcomm.cpp` (`gcomm_param_set`), `protonet.cpp:51`, `protostack.cpp:66` |

The last row is why the entry says so explicitly: `YES`, `true`, `1` — **and `0` and `false`** — all bootstrap the node. `pc.bootstrap=0` reads like a no-op and is not one. That also settles the spelling question the other pages left open.

## Drive-by fixes

* **`socket.ssl_reload` added.** Missing from this page for exactly the same reason as `pc.bootstrap` — a trigger registered without a default (`galerautils/src/gu_asio.cpp:572`), so it never appears in a live options dump. It is already documented as a table row on `galera-cluster/galera-security/mariadb-enterprise-cluster-security.md` (Dynamic: Yes, Default: N/A) and has its own procedure page; this brings the reference page in line rather than inventing anything. Behavior confirmed at `gu_asio.cpp:579-600` (rebuilds the TLS context, signals `S_CONFIG_RELOAD_CERTIFICATE`; silently does nothing when TLS is not in use, `:584`).
* **`pc.bootstrap` link in the `pc.wait_prim` entry repointed** at the new section. DOCS-6499 (#947) had sent it to the quorum-reset procedure page because there was nothing on this page to point at; the procedure page is still linked, from the new entry.
* **"Ttime" → "Time"** in the `pc.wait_prim_timeout` description.

## The registry diff the ticket asked for

I diffed all 92 `####` sections against every parameter the provider registers (`gcomm/src/conf.cpp:123-188`, `gcs/src/gcs_params.cpp`, `gcs/src/gcs_group.cpp`, `gcs/src/gcs_gcomm.cpp:911`, `gcache/src/gcache_params.cpp`, `galera/src/replicator_smm_params.cpp`, `replicator.cpp`, `certification.cpp`, `ist.cpp`, `galerautils/src/gu_asio.cpp`).

No page section lacks a registered counterpart, and `evs.*` (20), `gcs.*`, `repl.*`, `protonet.*` and the `socket.ssl*` family are complete. Two options were missing and are fixed here. **Ten more are registered and undocumented** (`gcs.stateless`, `gcs.vote_policy`, `gcs.check_appl_proto`, `gcache.keep_plaintext_size`, `gcache.debug`, `socket.non_blocking`, `gmcast.group`, `gmcast.mcast_port`, `gmcast.mira`, `gmcast.peer_addr`) — each needs its own source-verified description and default, so they are filed as **DOCS-6539** with the evidence table rather than guessed at here. Three further options (`cert.max_length`, `cert.length_check`, `ist.keep_keys`) carry the provider's `hidden` flag with a source comment saying they are deliberately undisclosed, and stay undocumented.

## Checks

`.claude/hooks/doc-lint.sh` on the changed file: rc=0 (codespell CI-exact + lychee CI-exact). `fragcheck.py check` 27 fragment links / 0 dead; `fragcheck.py new origin/main` reports no new dead anchors and confirms `pc.bootstrap` now publishes an anchor, so the link repair above resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6506]: https://mariadbcorp.atlassian.net/browse/DOCS-6506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
