### PR TITLE
DOCS-6546 Document the release-note title convention and fix five MaxScale H1s

### DIFF
--- a/dev-docs/style-guide.md
+++ b/dev-docs/style-guide.md
@@ -120,9 +120,11 @@ Other products do **not** split parent from child, so don't generalize the MaxSc
 - **Community Server** — varies the word order between levels, not the brand form:
   `Release Notes - MariaDB 12.3 Series` over `MariaDB 12.3.3 Release Notes`.
 
-The MaxScale release notes are generated — `release-notes/maxscale/script/generate_release_notes.sh`
-emits the point-release form. If this convention changes, change the template too, or the next
-generated page reintroduces the old form.
+MaxScale point releases are **generated**, by
+`release-notes/maxscale/script/generate_release_notes.sh`, so its template must emit the
+point-release form. If this convention ever changes, change the template with it — otherwise the
+next generated page silently reintroduces the old form. (The template used the series form until
+DOCS-6545; that is what made the split look accidental in the first place.)
 
 ## Spelling check
 

--- a/dev-docs/style-guide.md
+++ b/dev-docs/style-guide.md
@@ -87,6 +87,43 @@ Cluster**, **ColumnStore**, **MariaDB Enterprise Platform**. Note: "MariaDB serv
 common noun — "the MariaDB server process") and "Galera cluster" (a cluster instance) are often
 correct; only the branded product is title-cased.
 
+In **running prose**, use the full product name on first mention; a short form on subsequent
+mentions in the same page is fine and normal ("If you are upgrading from an older major version
+of MaxScale…").
+
+### Release-note page titles
+
+Release-note H1s follow a **per-product** convention that is not derivable from the rule above.
+Match the sibling pages in the same directory rather than applying the full product name
+everywhere. Check before you edit, and don't "correct" a page into disagreeing with its
+neighbours.
+
+**MariaDB MaxScale** is the one product where the parent and child titles deliberately differ:
+
+| Page role | H1 form |
+|-----------|---------|
+| Series page — `release-notes/maxscale/<series>/README.md` | `MariaDB MaxScale 25.10 Release Notes` |
+| Point release nested under it | `MaxScale 25.10.3 Release Notes` |
+
+The short form on children avoids repeating the brand at every level of a nav tree whose parent
+already carries it. `SUMMARY.md` nav labels mirror the page's own H1, so the two must agree.
+Changelog pages (`<series>-changelog.md`) use the short form — they are not parents of release
+notes. The `old-releases/2.4` and `old-releases/2.5` archives predate this convention and use
+the full name throughout; they are self-consistent, so leave them alone.
+
+Other products do **not** split parent from child, so don't generalize the MaxScale pattern:
+
+- **ColumnStore** — same form at both levels: `MariaDB ColumnStore 6 Release Notes` over
+  `MariaDB ColumnStore 6.4.8 Release Notes`.
+- **Connectors** — same form at both levels, and **without** the MariaDB prefix in titles:
+  `Connector/J 3.5 Release Notes` over `Connector/J 3.5.9 Release Notes`.
+- **Community Server** — varies the word order between levels, not the brand form:
+  `Release Notes - MariaDB 12.3 Series` over `MariaDB 12.3.3 Release Notes`.
+
+The MaxScale release notes are generated — `release-notes/maxscale/script/generate_release_notes.sh`
+emits the point-release form. If this convention changes, change the template too, or the next
+generated page reintroduces the old form.
+
 ## Spelling check
 
 CI runs **codespell** (`.codespellignore`). If a flagged word is a real term, add it to

--- a/release-notes/maxscale/23.02/23.02.17.md
+++ b/release-notes/maxscale/23.02/23.02.17.md
@@ -1,4 +1,4 @@
-# MariaDB MaxScale 23.02.17 Release Notes
+# MaxScale 23.02.17 Release Notes
 
 Release 23.02.17 is a GA release.
 

--- a/release-notes/maxscale/23.08/23.08.13.md
+++ b/release-notes/maxscale/23.08/23.08.13.md
@@ -1,4 +1,4 @@
-# MariaDB MaxScale 23.08.13 Release Notes
+# MaxScale 23.08.13 Release Notes
 
 Release 23.08.13 is a GA release.
 

--- a/release-notes/maxscale/24.02/24.02.9.md
+++ b/release-notes/maxscale/24.02/24.02.9.md
@@ -1,4 +1,4 @@
-# MariaDB MaxScale 24.02.9 Release Notes
+# MaxScale 24.02.9 Release Notes
 
 Release 24.02.9 is a GA release.
 

--- a/release-notes/maxscale/25.01/25.01.6.md
+++ b/release-notes/maxscale/25.01/25.01.6.md
@@ -1,4 +1,4 @@
-# MariaDB MaxScale 25.01.6 Release Notes
+# MaxScale 25.01.6 Release Notes
 
 Release 25.01.6 is a GA release.
 

--- a/release-notes/maxscale/25.10/25.10.2.md
+++ b/release-notes/maxscale/25.10/25.10.2.md
@@ -1,4 +1,4 @@
-# MariaDB MaxScale 25.10.2 Release Notes
+# MaxScale 25.10.2 Release Notes
 
 Release 25.10.2 is a GA release.
 


### PR DESCRIPTION
Documents the release-note title convention, and fixes the five pages that break it.

DOCS-6546

## Why

The style guide's Naming section stated the product name flatly as **MariaDB MaxScale** with no page-role distinction. Read literally, that makes the short form on point-release pages look like drift — which is how I read it while reviewing #834, leading to a ruling to "fix" 77 pages before it became clear the split is deliberate.

Series pages carry the brand; the point releases nested under them do not. The short form avoids repeating the brand at every level of a nav tree whose parent already carries it.

## What changed

**1. `dev-docs/style-guide.md`** — a new `### Release-note page titles` subsection recording:

- Release-note H1s are a **per-product** convention, not derivable from the general naming rule. Match the siblings in the directory; don't "correct" a page into disagreeing with its neighbours.
- MaxScale's parent/child table, with the reasoning.
- Three adjacent facts that are easy to trip on: `SUMMARY.md` nav labels mirror the page's H1 so the two must agree; changelog pages use the short form; the `old-releases/2.4` and `old-releases/2.5` archives predate the convention, are self-consistent, and should be left alone.
- An explicit **don't generalize** list, because MaxScale is the only product that splits parent from child.
- That MaxScale point releases are generated, so the template must emit the point-release form or the next generated page silently reintroduces the old one.

**2. Five point-release H1s** corrected from the series form to the point-release form:

| Page | H1 |
|---|---|
| `maxscale/25.10/25.10.2.md` | `MariaDB MaxScale 25.10.2 …` → `MaxScale 25.10.2 …` |
| `maxscale/25.01/25.01.6.md` | `MariaDB MaxScale 25.01.6 …` → `MaxScale 25.01.6 …` |
| `maxscale/24.02/24.02.9.md` | `MariaDB MaxScale 24.02.9 …` → `MaxScale 24.02.9 …` |
| `maxscale/23.08/23.08.13.md` | `MariaDB MaxScale 23.08.13 …` → `MaxScale 23.08.13 …` |
| `maxscale/23.02/23.02.17.md` | `MariaDB MaxScale 23.02.17 …` → `MaxScale 23.02.17 …` |

One line each, nothing else touched. **No `SUMMARY.md` change** — all five already had the correct short-form nav label, so the H1 was the only thing out of step. That mismatch is how they were found.

## Verification

Every title cited in the new text is a real page on `main`, checked programmatically rather than written from memory:

| Cited title | Source |
|---|---|
| `MariaDB MaxScale 25.10 Release Notes` | `release-notes/maxscale/25.10/README.md` |
| `MaxScale 25.10.3 Release Notes` | `release-notes/maxscale/25.10/25.10.3.md` |
| `MariaDB ColumnStore 6 Release Notes` | `release-notes/columnstore/old-releases/mariadb-columnstore-6-release-notes/README.md` |
| `MariaDB ColumnStore 6.4.8 Release Notes` | same directory |
| `Connector/J 3.5 Release Notes` | `release-notes/connectors/java/3.5/README.md` |
| `Connector/J 3.5.9 Release Notes` | `release-notes/connectors/java/3.5/3.5.9.md` |
| `Release Notes - MariaDB 12.3 Series` | `release-notes/community-server/12.3/README.md` |
| `MariaDB 12.3.3 Release Notes` | `release-notes/community-server/12.3/12.3.3.md` |

Claims about other products were measured against `main`, not assumed:

- **MaxScale** — all 7 series READMEs long-form; point releases short-form with the 5 exceptions this PR fixes.
- **ColumnStore**, **Connectors** — identical form at parent and child.
- **Community Server** — varies word order between levels, not brand form.
- Changelogs — uniformly short.
- `old-releases/2.4` + `2.5` — long form on all 50 pages *and* all 50 nav labels, i.e. internally consistent.

After the fix, all five pages' H1 and nav label agree, and this returns nothing:

```bash
git grep -n '^# MariaDB MaxScale .* Release Notes' -- \
  'release-notes/maxscale/' \
  ':(exclude)release-notes/maxscale/old-releases/' \
  ':(exclude)release-notes/maxscale/*/README.md' \
  ':(exclude)release-notes/maxscale/script/'
```

codespell and `.claude/hooks/doc-lint.sh` pass on all six files.

## Reviewer notes

- **The generator still emits the series form on `main`.** `release-notes/maxscale/script/generate_release_notes.sh` is corrected by #834 (DOCS-6545), not here. Until that merges, the next generated point release will arrive with the wrong H1. The style-guide text is therefore worded as a requirement on the template, not as a statement about its current state — deliberately, so it does not go stale depending on merge order.
- **Frontmatter is untouched.** All five pages lack it, but so do 65 of 152 MaxScale release-note pages, including correct siblings like `25.10.3.md`. Adding it to just these five would make them the anomaly. Separate issue.
- **The 2.x archive is out of scope on purpose.** `old-releases/2.4` and `2.5` use the long form throughout and are self-consistent; aligning them would be 50 H1s plus 50 GitBook-owned nav labels on MaxScale 2.x docs. DOCS-6546 records a recommendation not to, so the inconsistency is not later read as an oversight.
- One added line is 102 chars — a Markdown table row, which cannot be wrapped without breaking the table.
- `###` uses sentence case, matching this file's own headings (`## Core conventions`, `## Spelling check`). Title Case applies to published pages, not `dev-docs/` playbooks.
- `dev-docs/` is excluded from CI's alias and link gates, so the local checks above are the meaningful ones for that file.
- This is the local digest; per its own header the canonical published style guide and the Confluence Documentation Guidelines win if they disagree. Propagating this there is a separate follow-up.
