### PR TITLE
DOCS-6549 Restore stripped URL placeholders and fix galeracluster.com links

### DIFF
--- a/release-notes/galera-cluster/25.3/25.3.10.md
+++ b/release-notes/galera-cluster/25.3/25.3.10.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.10,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.9):
 

--- a/release-notes/galera-cluster/25.3/25.3.12.md
+++ b/release-notes/galera-cluster/25.3/25.3.12.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.12,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.10):
 

--- a/release-notes/galera-cluster/25.3/25.3.13.md
+++ b/release-notes/galera-cluster/25.3/25.3.13.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.13,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.12):
 

--- a/release-notes/galera-cluster/25.3/25.3.14.md
+++ b/release-notes/galera-cluster/25.3/25.3.14.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.14,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.13):
 

--- a/release-notes/galera-cluster/25.3/25.3.15.md
+++ b/release-notes/galera-cluster/25.3/25.3.15.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.14,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.14):
 

--- a/release-notes/galera-cluster/25.3/25.3.16.md
+++ b/release-notes/galera-cluster/25.3/25.3.16.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.16,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.15):
 

--- a/release-notes/galera-cluster/25.3/25.3.17.md
+++ b/release-notes/galera-cluster/25.3/25.3.17.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.17,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.16):
 

--- a/release-notes/galera-cluster/25.3/25.3.18.md
+++ b/release-notes/galera-cluster/25.3/25.3.18.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.18,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.17):
 

--- a/release-notes/galera-cluster/25.3/25.3.19.md
+++ b/release-notes/galera-cluster/25.3/25.3.19.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.19,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.18):
 

--- a/release-notes/galera-cluster/25.3/25.3.20.md
+++ b/release-notes/galera-cluster/25.3/25.3.20.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.20,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE, SLES and FreeBSD. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.19):
 

--- a/release-notes/galera-cluster/25.3/25.3.21.md
+++ b/release-notes/galera-cluster/25.3/25.3.21.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.21,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE, SLES and FreeBSD. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 New features and notable fixes in Galera replication since last binary release by Codership (3.20):
 
@@ -19,7 +19,7 @@ New features and notable fixes in Galera replication since last binary release b
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 The latest version of Galera for FreeBSD is available in FreeBSD Ports Collection.
 

--- a/release-notes/galera-cluster/25.3/25.3.22.md
+++ b/release-notes/galera-cluster/25.3/25.3.22.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.22,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of Galera for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -18,7 +18,7 @@ New features and notable fixes in Galera replication since last binary release b
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/25.3/25.3.23.md
+++ b/release-notes/galera-cluster/25.3/25.3.23.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.23,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of Galera for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -14,7 +14,7 @@ New features and notable fixes in Galera replication since last binary release b
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/25.3/25.3.24.md
+++ b/release-notes/galera-cluster/25.3/25.3.24.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.24,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of Galera for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -24,7 +24,7 @@ New features and notable fixes in Galera replication since last binary release b
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/25.3/25.3.25.md
+++ b/release-notes/galera-cluster/25.3/25.3.25.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.25,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of Galera for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -16,7 +16,7 @@ New features and notable fixes in Galera replication since last binary release b
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/25.3/25.3.26.md
+++ b/release-notes/galera-cluster/25.3/25.3.26.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.26,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of Galera for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -17,7 +17,7 @@ New features and notable fixes in Galera replication since last binary release b
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/25.3/25.3.27.md
+++ b/release-notes/galera-cluster/25.3/25.3.27.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.27,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of Galera for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -19,7 +19,7 @@ End of Life:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/25.3/25.3.28.md
+++ b/release-notes/galera-cluster/25.3/25.3.28.md
@@ -4,7 +4,7 @@ Codership is pleased to announce the release of Galera Replication library 3.28,
 
 The library is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of Galera for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -19,7 +19,7 @@ End of Life notice:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/25.3/25.3.29.md
+++ b/release-notes/galera-cluster/25.3/25.3.29.md
@@ -22,7 +22,7 @@ Notable fixes in Galera replication since last binary release by Codership (3.28
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. https://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. https://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux distribution (Ubuntu, Centos, ...) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.42-25.11.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.42-25.11.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.42.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.5.37):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.45-25.12.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.45-25.12.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.45.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.5.42):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.46-25.13.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.46-25.13.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.46.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.5.45):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.47-25.14.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.47-25.14.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.47.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep 5.5.47:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.48-25.15.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.48-25.15.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.48.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable fixes in MySQL 5.5.48:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.49-25.16.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.49-25.16.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.49.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable fixes in MySQL 5.5.49:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.50-25.17.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.50-25.17.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.50.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.5.49):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.52-25.18.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.52-25.18.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.52, including the fix for 
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable fixes in Oracle MySQL Community Edition 5.5.51, 5.5.52:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.53-25.19.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.53-25.19.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.53.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable fixes in Oracle MySQL Community Edition 5.5.53:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.54-25.20.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.54-25.20.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.54.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE, SLES and FreeBSD. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.55-25.21.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.55-25.21.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.55.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE, SLES and FreeBSD. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep:
 
@@ -15,7 +15,7 @@ Notable bug fixes in MySQL-wsrep:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.58-25.22.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.58-25.22.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.58.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
 
 Notable bug fixes in MySQL-wsrep:
 
@@ -17,7 +17,7 @@ Notable bug fixes in MySQL-wsrep:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.59-25.23.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.59-25.23.md
@@ -6,13 +6,13 @@ This release incorporates all changes up to MySQL 5.5.59.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
 
 Notable bug fixes in MySQL-wsrep:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.61-25.24.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.61-25.24.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.61.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
 
 Notable bug fixes in MySQL-wsrep:
 
@@ -16,7 +16,7 @@ Notable bug fixes in MySQL-wsrep:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.62-25.25.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.5/5.5.62-25.25.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.5.62.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership.
 
 Note that Galera Cluster for MySQL 5.5.62 will be the last release of 5.5 series.
 
@@ -16,7 +16,7 @@ Notable bug fixes in MySQL-wsrep:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.21-25.9.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.21-25.9.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.21 and numerous fixes and 
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.6.16):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.23-25.10.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.23-25.10.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.23.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep since last binary release by Codership (5.6.21):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.25-25.11.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.25-25.11.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.25.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.6.23):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.27-25.12.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.27-25.12.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.27.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com, while previous releases remain available on LaunchPad. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.6.25):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.28-25.13.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.28-25.13.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.28.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.6.27):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.29-25.14.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.29-25.14.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.29.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.6.28):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.30-25.15.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.30-25.15.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.30.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.6.29):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.31-25.16.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.31-25.16.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.31.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 New features and notable changes in MySQL-wsrep since last binary release by Codership (5.6.30):
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.33-25.17.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.33-25.17.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.33, including the fix for 
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.34-25.18.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.34-25.18.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.34.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, Fedora, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.35-25.19.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.35-25.19.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.35.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE, SLES and FreeBSD. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.36-25.20.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.36-25.20.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.36.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE, SLES and FreeBSD. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
+This and future releases will be available from https://www.galeracluster.com. The source repositories and bug tracking are now on http://www.github.com/codership .
 
 Notable bug fixes in MySQL-wsrep:
 
@@ -26,7 +26,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.38-25.21.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.38-25.21.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.38.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -29,7 +29,7 @@ Known issues with this release:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.39-25.22.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.39-25.22.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.39.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -23,7 +23,7 @@ Known issues with this release:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.41-25.23.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.41-25.23.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.41.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -25,7 +25,7 @@ Known issues with this release:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.42-25.24.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.42-25.24.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.42.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -31,7 +31,7 @@ Known issues with this release:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.43-25.25.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.43-25.25.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.43.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -19,7 +19,7 @@ Known issues with this release:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.44-25.26.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.44-25.26.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.44.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -23,7 +23,7 @@ End of Life:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.45-25.27.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.45-25.27.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.45.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -23,7 +23,7 @@ End of Life:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.46-25.28.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.46-25.28.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.6.46.
 
 Galera Cluster is now available as targeted packages and package repositories for a number of Linux distributions, including Ubuntu, Debian, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.6 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -23,7 +23,7 @@ End of Life:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.47-25.29.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.47-25.29.md
@@ -19,7 +19,7 @@ Known issues with this release:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. https://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. https://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.48-25.30.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.48-25.30.md
@@ -29,7 +29,7 @@ Known issues with this release:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. https://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. https://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.49-25.31.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.49-25.31.md
@@ -30,7 +30,7 @@ This is the last release for Debian Jessie.
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. https://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. https://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.50-25.32.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.50-25.32.md
@@ -28,7 +28,7 @@ End of Life Notice:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. https://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. https://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.6, 5.7 or 8.0
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.6, 5.7 or 8.0
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.51-25.33.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.51-25.33.md
@@ -30,7 +30,7 @@ End of Life Notice:
 
 ## Reminder: Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. https://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. https://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.6, 5.7 or 8.0
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.6, 5.7 or 8.0
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.15-25.10.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.15-25.10.md
@@ -14,7 +14,7 @@ This release incorporates all changes up to MySQL 5.7.15.
 
 Galera Cluster 5.7 beta is now available as targeted packages and package repositories for Ubuntu 16.06 and CentOS 7. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 Notable changes in this release:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.17-25.11.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.17-25.11.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.17.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu and CentOS. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 Notable changes in this release:
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.18-25.12.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.18-25.12.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.18.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu and CentOS. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 Notable bug fixes in MySQL-wsrep:
 
@@ -29,7 +29,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.20-25.13.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.20-25.13.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.20.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -33,7 +33,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.21-25.14.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.21-25.14.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.21.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -26,7 +26,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.23-25.15.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.23-25.15.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.23.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -30,7 +30,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.24-25.16.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.24-25.16.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.24.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -36,7 +36,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.25-25.17.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.25-25.17.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.25.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -25,7 +25,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.26-25.18.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.26-25.18.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.26.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -28,7 +28,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.27-25.19.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.27-25.19.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.27.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -25,7 +25,7 @@ Known issues with this release:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 

--- a/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.28-25.20.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.7/5.7.28-25.20.md
@@ -6,7 +6,7 @@ This release incorporates all changes up to MySQL 5.7.28.
 
 Galera Cluster 5.7 is now available as targeted packages and package repositories for Debian, Ubuntu, CentOS, RHEL, OpenSUSE and SLES. Obtaining packages using a package repository removes the need to download individual files and facilitates the deployment and upgrade of Galera nodes.
 
-This and future releases will be available from http://www.galeracluster.com.
+This and future releases will be available from https://www.galeracluster.com.
 
 The latest version of MySQL-wsrep 5.7 for FreeBSD is available in the FreeBSD Ports Collection.
 
@@ -25,7 +25,7 @@ End of Life:
 
 ## Changes to Repositories Structure
 
-With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. http://releases.galeracluster.com/galera-3// 2. Corresponding mysql-wsrep repository: e.g. http://releases.galeracluster.com/mysql-wsrep-/ here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
+With the new release the repository structure is changed to allow for existence of all of the wsrep-patched mysql versions currently supported: 5.5 through 5.7. Thus the repository layout requires from the user to adjust his or her repository configuration to accommodate those changes. In order to have the WSREP and Galera library installed, one would need to add the following repositories: 1. Galera-3 repository for galera library: e.g. `http://releases.galeracluster.com/galera-3/<ldist>/` 2. Corresponding mysql-wsrep repository: e.g. `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` here: _ldist_ is Linux or BSD distribution (Ubuntu, Centos) and _mversion_ is MySQL version, i.e. 5.5, 5.6, 5.7
 
 ### How To Install
 


### PR DESCRIPTION
Fixes the broken and silently-wrong links in the Galera Cluster release notes. **This should merge before the DOCS-6541 frontmatter PR**, which is blocked by these links.

Ticket: [DOCS-6549](https://mariadbcorp.atlassian.net/browse/DOCS-6549)

## The problem

Upstream's plain-text release notes document the package-repository layout with angle-bracket placeholders. The Markdown migration ate them as HTML tags, while the prose that *explains* them survived — so 37 published pages explained two variables that no longer appeared in the example above them, and the install instructions could not be followed as written.

The two halves failed differently, which is why only half was ever visible:

| In our pages | Status | Why |
| --- | --- | --- |
| `http://releases.galeracluster.com/mysql-wsrep-/` | **404** | lychee catches it |
| `http://releases.galeracluster.com/galera-3//` | **200** | the double slash collapses — no link checker can see it |

The second is the same "resolves, but wrong" class as the mislinked table rows in DOCS-6541. It was found only by tracing the cause of the 404.

Separately, `http://www.galeracluster.com` has been returning **522** (the `https://` and bare-domain forms both return 200).

## The change

70 files, 101 insertions / 101 deletions — every change is a line-for-line substitution. No content added or removed.

| Fix | Count |
| --- | --- |
| `.../mysql-wsrep-/` → `` `http://releases.galeracluster.com/mysql-wsrep-<mversion>/<ldist>` `` | 37 |
| `.../galera-3//` → `` `http://releases.galeracluster.com/galera-3/<ldist>/` `` | 37 |
| `http://www.galeracluster.com` → `https://www.galeracluster.com` | 64 |

The placeholder examples are wrapped in **code spans**. That is load-bearing, not cosmetic: it stops GitBook re-reading `<ldist>` / `<mversion>` as HTML tags (the original failure mode), and stops any link checker treating a template string as a URL to fetch.

## Verification

Placeholder forms verified against the upstream `codership-documentation` repo @ `d7d6a11ebf7efbc39aa3adbf18accfb850975339`, which contains 43 occurrences of each correct form and **zero** of the stripped forms — confirming the loss happened on our side, not upstream.

- `.claude/hooks/doc-lint.sh` over all 70 files → **exit 0**
- All three broken forms are now at zero occurrences across all 160 files in the space
- Occurrence counts match the predicted scope exactly (37 / 37 / 64)
- **No replacement fell inside a fenced or `{% code %}` block** — checked explicitly, 0 hits
- The fix was piloted on one file and linted before the other 69, to confirm the code-span form actually stops lychee flagging the URL rather than assuming it would

## Not changed

`http://www.github.com/codership` appears in the same sentence on many of these pages. lychee does not flag it (GitHub redirects http→https cleanly) and it is outside this ticket's scope, so it was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6549]: https://mariadbcorp.atlassian.net/browse/DOCS-6549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ