### PR TITLE
DOCS-6550 Retitle MySQL-wsrep 5.6.21-25.9 release notes to match its siblings

### DIFF
--- a/release-notes/SUMMARY.md
+++ b/release-notes/SUMMARY.md
@@ -1860,7 +1860,7 @@
       * [MySQL-wsrep 5.6.27-25.12 Release Notes](galera-cluster/mysql-wsrep/5.6/5.6.27-25.12.md)
       * [MySQL-wsrep 5.6.25-25.11 Release Notes](galera-cluster/mysql-wsrep/5.6/5.6.25-25.11.md)
       * [MySQL-wsrep 5.6.23-25.10 Release Notes](galera-cluster/mysql-wsrep/5.6/5.6.23-25.10.md)
-      * [Galera Cluster 5.6.21-25.9 Release Notes](galera-cluster/mysql-wsrep/5.6/5.6.21-25.9.md)
+      * [MySQL-wsrep 5.6.21-25.9 Release Notes](galera-cluster/mysql-wsrep/5.6/5.6.21-25.9.md)
     * [MySQL-wsrep 5.5 Release Notes](galera-cluster/mysql-wsrep/5.5/README.md)
       * [MySQL-wsrep 5.5.62-25.25 Release Notes](galera-cluster/mysql-wsrep/5.5/5.5.62-25.25.md)
       * [MySQL-wsrep 5.5.61-25.24 Release Notes](galera-cluster/mysql-wsrep/5.5/5.5.61-25.24.md)

--- a/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.21-25.9.md
+++ b/release-notes/galera-cluster/mysql-wsrep/5.6/5.6.21-25.9.md
@@ -4,7 +4,7 @@ description: >-
   MySQL 5.6.
 ---
 
-# Galera Cluster 5.6.21-25.9 Release Notes
+# MySQL-wsrep 5.6.21-25.9 Release Notes
 
 Codership is pleased to announce a new release of Galera Cluster for MySQL consisting of MySQL-wsrep 5.6.21 and Galera 3.9, wsrep API version 25.
 


### PR DESCRIPTION
Retitles the one MySQL-wsrep release-notes page whose H1 named the product "Galera Cluster", and updates its `SUMMARY.md` nav label to match.

Resolves [DOCS-6550](https://mariadbcorp.atlassian.net/browse/DOCS-6550).

## Changes

- `release-notes/galera-cluster/mysql-wsrep/5.6/5.6.21-25.9.md:7` — `# Galera Cluster 5.6.21-25.9 Release Notes` → `# MySQL-wsrep 5.6.21-25.9 Release Notes`
- `release-notes/SUMMARY.md:1863` — nav label updated to match the new H1

No redirect needed: the published URL derives from the file path, which is unchanged.

## Why this page was the odd one out

Not a typo — a pre-convention artifact.

MySQL-wsrep 5.6.21-25.9 is the **oldest** release in the line. Upstream `codership-documentation` shows the same anomaly independently: of the ~160 files in its `release-notes/` directory, every one is prefixed `release-notes-mysql-wsrep-*` or `release-notes-galera-*` — except `release-notes-5.6.21-25.9.txt`, which carries no product prefix at all. Upstream adopted the `mysql-wsrep` prefix from the very next release (5.6.23-25.10) onward, and this repo standardized on the matching H1. This page was simply left behind when both naming schemes settled around it.

Upstream can't arbitrate the wording directly — its release-note `.txt` files carry no title line, opening straight on body prose. The page body and frontmatter here already use "MySQL-wsrep", so this change also makes the H1 agree with the description on its own page.

## Verification

- Pre-edit: 106 H1s under `mysql-wsrep/` = 104 versioned conformers + 1 unversioned index + this page (the ticket's "99 siblings" was an undercount)
- Post-edit: 105 versioned conformers + the index, **zero** non-conformers
- `SUMMARY.md` label == page H1 holds at **161/161** galera-cluster entries, before and after
- `.claude/hooks/doc-lint.sh` on both changed files — exit 0

Source checked: `codership-documentation` @ `d7d6a11ebf7efbc39aa3adbf18accfb850975339`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6550]: https://mariadbcorp.atlassian.net/browse/DOCS-6550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ