### PR TITLE
DOCS-5444 Document Galera Black Box feature

### DIFF
--- a/galera-cluster/SUMMARY.md
+++ b/galera-cluster/SUMMARY.md
@@ -28,6 +28,7 @@
     * [Performing Schema Upgrades in Galera Cluster](galera-management/general-operations/performing-schema-upgrades-in-galera-cluster.md)
     * [Managing Sequences in Galera Cluster](galera-management/general-operations/managing-sequences-in-galera-cluster.md)
     * [Backing Up a MariaDB Galera Cluster](galera-management/general-operations/backing-up-a-mariadb-galera-cluster.md)
+    * [Galera Black Box](galera-management/general-operations/galera-black-box.md)
   * [Upgrading Galera Cluster](galera-management/upgrading-galera-cluster/README.md)
     * [Upgrading from MariaDB 10.3 to MariaDB 10.4 with Galera Cluster](galera-management/upgrading-galera-cluster/upgrading-from-mariadb-10-3-to-mariadb-10-4-with-galera-cluster.md)
     * [Upgrading from MariaDB 10.4 to MariaDB 10.5 with Galera Cluster](galera-management/upgrading-galera-cluster/upgrading-from-mariadb-10-4-to-mariadb-10-5-with-galera-cluster.md)

--- a/galera-cluster/galera-management/general-operations/galera-black-box.md
+++ b/galera-cluster/galera-management/general-operations/galera-black-box.md
@@ -1,0 +1,64 @@
+---
+description: >-
+  The Galera Black Box is a MariaDB Enterprise Server feature that keeps recent
+  debug log messages in a shared-memory ring buffer so they survive a crash and
+  can be analyzed with mariadb-bbtool.
+---
+
+# Galera Black Box
+
+{% hint style="info" %}
+The Black Box is a **MariaDB Enterprise Server** feature. It is not available in community MariaDB Server, nor on Windows, macOS, or the embedded server.
+{% endhint %}
+
+## Overview
+
+The Black Box is an in-memory (shared-memory) ring buffer that continuously records debug log messages. Because it lives in shared memory rather than in the server process, its contents survive a server crash and can be examined afterwards, which helps support and developers diagnose hard-to-reproduce failures, including in Galera Cluster.
+
+It is disabled by default. To enable it, set a non-zero [wsrep\_black\_box\_size](../../reference/galera-cluster-system-variables.md#wsrep_black_box_size).
+
+## Enabling the Black Box
+
+Configure the size (in bytes) and, optionally, the name in an options file:
+
+```ini
+[mariadb]
+wsrep_black_box_size = 10485760
+wsrep_black_box_name = bb-mariadb
+```
+
+* [wsrep\_black\_box\_size](../../reference/galera-cluster-system-variables.md#wsrep_black_box_size) — size in bytes. `0` (default) means no Black Box is created. It is dynamic: changing it at runtime re-creates the Black Box at the new size.
+* [wsrep\_black\_box\_name](../../reference/galera-cluster-system-variables.md#wsrep_black_box_name) — the name of the shared-memory object (default `bb-mariadb`). Read-only; set at startup only.
+
+When the server starts, it opens the Black Box in the data directory. If a Black Box with the same name already exists (for example, left behind by a crashed server), its contents are first written to a dump file in the data directory and then it is re-created empty.
+
+## Inspecting the Black Box with mariadb-bbtool
+
+The `mariadb-bbtool` utility, installed alongside the server, operates on a Black Box by name:
+
+```bash
+mariadb-bbtool <name> <command>
+```
+
+| Command   | Action                                          |
+| --------- | ----------------------------------------------- |
+| `dump`    | Print the Black Box contents to standard output |
+| `status`  | Report the Black Box state                      |
+| `enable`  | Put the Black Box into the operational state    |
+| `disable` | Put the Black Box into the disabled state       |
+| `delete`  | Remove the active Black Box                     |
+
+Run `mariadb-bbtool --help` for usage. A Black Box is in one of three states: Closed, Disabled, or Operational.
+
+For example, to dump the running server's Black Box:
+
+```bash
+mariadb-bbtool bb-mariadb dump
+```
+
+## See Also
+
+* [Galera Cluster System Variables: wsrep\_black\_box\_size](../../reference/galera-cluster-system-variables.md#wsrep_black_box_size)
+* [Galera Cluster System Variables: wsrep\_black\_box\_name](../../reference/galera-cluster-system-variables.md#wsrep_black_box_name)
+
+<sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/galera-cluster/reference/galera-cluster-system-variables.md
+++ b/galera-cluster/reference/galera-cluster-system-variables.md
@@ -40,6 +40,24 @@ This page documents system variables related to Galera Cluster. For options that
 * Data Type: Boolean
 * Default Value: `ON`
 
+#### `wsrep_black_box_name`
+
+* Description: The name of the [Galera Black Box](../galera-management/general-operations/galera-black-box.md) shared-memory object, a **MariaDB Enterprise Server** feature. This name identifies the Black Box to the `mariadb-bbtool` utility and to any dump files written to the data directory. Read-only; can only be set at server startup.
+* Command line: `--wsrep-black-box-name=name`
+* Scope: Global
+* Dynamic: No
+* Data Type: String
+* Default Value: `bb-mariadb`
+
+#### `wsrep_black_box_size`
+
+* Description: The size in bytes of the [Galera Black Box](../galera-management/general-operations/galera-black-box.md) in-memory debug ring buffer, a **MariaDB Enterprise Server** feature. A value of `0` (the default) means no Black Box is created, so the feature is inactive. The variable is dynamic: changing it at runtime deletes the current Black Box and re-creates it at the new size. If re-creation fails, the size is reset to `0` and an error is raised.
+* Command line: `--wsrep-black-box-size=#`
+* Scope: Global
+* Dynamic: Yes
+* Data Type: Numeric (bytes)
+* Default Value: `0`
+
 #### `wsrep_causal_reads`
 
 * Description: If set to `ON` (`OFF` is default), enforces [read-committed](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/transactions/transactions-read-committed) characteristics across the cluster. In the case that a primary applies an event more quickly than a replica, the two could briefly be out-of-sync. With this variable set to `ON`, the replica will wait for the event to be applied before processing further queries. Setting to `ON` also results in larger read latencies. Deprecated by [wsrep\_sync\_wait=1](galera-cluster-system-variables.md#wsrep_sync_wait).


### PR DESCRIPTION
Add a Galera Black Box concept page under General Operations covering the in-memory shared-memory ring buffer, enabling it via wsrep_black_box_size and wsrep_black_box_name, and the mariadb-bbtool utility. Document both system variables inline on the Galera Cluster system variables page, and add a SUMMARY.md navigation entry.

MariaDB Enterprise Server only; verified against mariadb-enterprise @ 074b26bf (branch 10.6-enterprise).


<html>
<body>
<!--StartFragment--><p dir="ltr">Documents the Galera Black Box feature, which was previously undocumented beyond two auto-generated CLI stub pages (<code>--wsrep-black-box-size</code>, <code>--wsrep-black-box-name</code>) and a one-line mention in the MariaDB Enterprise Server 10.5 "What's New" page.</p>
<p dir="ltr"><strong>Jira ticket:</strong> <a href="https://mariadbcorp.atlassian.net/browse/DOCS-5444">DOCS-5444</a></p>
<h4 dir="ltr">Background</h4>
<p dir="ltr">The Black Box is a MariaDB <strong>Enterprise Server-only</strong> feature — an in-memory (shared-memory) ring buffer that holds debug log messages so they survive a server crash and can be analyzed afterward with <code>mariadb-bbtool</code>. <a href="https://jira.mariadb.org/projects/MDEV/issues/MDEV-34229">MDEV-34229</a>, which proposed porting it to community MariaDB Server, is <strong>Closed / Won't Do</strong>, so this documentation is scoped to Enterprise Server only.</p>
<h4 dir="ltr">What changed</h4>
<div dir="ltr">
File | Change
-- | --
galera-cluster/reference/galera-cluster-system-variables.md | Added two inline entries — wsrep_black_box_name and wsrep_black_box_size — between wsrep_auto_increment_control and wsrep_causal_reads, styled to match the existing wsrep_allowlist entry
galera-cluster/galera-management/general-operations/galera-black-box.md | New concept page: Overview → Enabling → mariadb-bbtool usage → See Also
galera-cluster/SUMMARY.md | New nav entry for the concept page under General Operations

</div>
<h4 dir="ltr">Verification</h4>
<p dir="ltr">All claims were verified directly against source in <code>mariadb-enterprise</code> @ <code>074b26bff3d2</code> (branch <code>10.6-enterprise</code>), including:</p>
<ul dir="ltr">
<li>Enterprise-only scoping (confirmed absent from community <code>server</code>@<code>5818146a</code> and <code>galera</code>@<code>a8b6b4c3</code>)</li>
<li><code>wsrep_black_box_size</code> / <code>wsrep_black_box_name</code> variable definitions, defaults, and dynamic/read-only behavior (<code>sql/sys_vars.cc</code>)</li>
<li>Black Box open/dump-on-crash behavior at startup (<code>sql/mysqld.cc</code>, <code>blackbox/include/blackbox/blackbox.h</code>)</li>
<li><code>mariadb-bbtool</code> commands and states (<code>blackbox/src/mariadb-bbtool.c</code>)</li>
<li>Platform restrictions — unavailable on Windows, macOS, and embedded server (<code>CMakeLists.txt</code>)</li>
</ul>
<p dir="ltr">Full fact-check report (17 verified claims): <code>/home/uday3927/maria-doc-reports/galera-cluster/DOCS-5444/report.md</code></p>
<h4 dir="ltr">Notes for reviewers</h4>
<ul dir="ltr">
<li>No separate <code>wsrep-variable-details/</code> pages were created for these two variables — they're documented inline on the system variables page instead, consistent with how simpler variables like <code>wsrep_allowlist</code> are already handled there.</li>
<li>No existing troubleshooting/logs page was found under <code>galera-management/</code> to cross-link.</li>
<li>⚠️ Link-check (<code>lychee</code>) timed out locally on the variables file due to network — recommend running the full docs-check in CI before merge.</li></ul><!--EndFragment-->
</body>
</html>Documents the Galera Black Box feature, which was previously undocumented beyond two auto-generated CLI stub pages (--wsrep-black-box-size, --wsrep-black-box-name) and a one-line mention in the MariaDB Enterprise Server 10.5 "What's New" page.

Jira ticket: [DOCS-5444](https://mariadbcorp.atlassian.net/browse/DOCS-5444)

Background

The Black Box is a MariaDB Enterprise Server-only feature — an in-memory (shared-memory) ring buffer that holds debug log messages so they survive a server crash and can be analyzed afterward with mariadb-bbtool. [MDEV-34229](https://jira.mariadb.org/projects/MDEV/issues/MDEV-34229), which proposed porting it to community MariaDB Server, is Closed / Won't Do, so this documentation is scoped to Enterprise Server only.

What changed
File	Change
galera-cluster/reference/galera-cluster-system-variables.md	Added two inline entries — wsrep_black_box_name and wsrep_black_box_size — between wsrep_auto_increment_control and wsrep_causal_reads, styled to match the existing wsrep_allowlist entry
galera-cluster/galera-management/general-operations/galera-black-box.md	New concept page: Overview → Enabling → mariadb-bbtool usage → See Also
galera-cluster/SUMMARY.md	New nav entry for the concept page under General Operations
Verification

All claims were verified directly against source in mariadb-enterprise @ 074b26bff3d2 (branch 10.6-enterprise), including:

Enterprise-only scoping (confirmed absent from community server@5818146a and galera@a8b6b4c3)
wsrep_black_box_size / wsrep_black_box_name variable definitions, defaults, and dynamic/read-only behavior (sql/sys_vars.cc)
Black Box open/dump-on-crash behavior at startup (sql/mysqld.cc, blackbox/include/blackbox/blackbox.h)
mariadb-bbtool commands and states (blackbox/src/mariadb-bbtool.c)
Platform restrictions — unavailable on Windows, macOS, and embedded server (CMakeLists.txt)

Full fact-check report (17 verified claims): /home/uday3927/maria-doc-reports/galera-cluster/DOCS-5444/report.md

Notes for reviewers
No separate wsrep-variable-details/ pages were created for these two variables — they're documented inline on the system variables page instead, consistent with how simpler variables like wsrep_allowlist are already handled there.
No existing troubleshooting/logs page was found under galera-management/ to cross-link.
⚠️ Link-check (lychee) timed out locally on the variables file due to network — recommend running the full docs-check in CI before merge.

[DOCS-5444]: https://mariadbcorp.atlassian.net/browse/DOCS-5444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ