### PR TITLE
DOCS-6218 Document the REVOKE DENY ... FROM PUBLIC bypass (MDEV-40656)

### DIFF
--- a/server/reference/sql-statements/account-management-sql-statements/deny.md
+++ b/server/reference/sql-statements/account-management-sql-statements/deny.md
@@ -117,6 +117,15 @@ matches the database being accessed, only the **most specific** entry applies â€
 pattern matches the fewest database names â€” and only that entry's grants and denies are consulted.
 A deny recorded on a broader pattern is not added to a narrower entry that also matches.
 
+```sql
+DENY SELECT ON `h%`.* TO alice;
+GRANT SELECT ON hr.* TO alice;
+```
+
+Both entries match the `hr` database, but `hr` is the more specific one, so it is the only entry
+consulted: `alice` can read `hr` tables, and the deny never applies there. The deny does still
+apply to every other database matching `h%`, such as `helpdesk`.
+
 `DENY` follows the same matching rule as `GRANT` here; it is not privileged over it. Entries held
 through a [role](../../../security/user-account-management/roles/) or through `PUBLIC` are resolved
 the same way but separately, and then combined, so a deny that reaches the account by either route

--- a/server/reference/sql-statements/account-management-sql-statements/deny.md
+++ b/server/reference/sql-statements/account-management-sql-statements/deny.md
@@ -109,6 +109,21 @@ Two rules cover every case:
 A deny also propagates downwards: a global deny masks database, table, and column grants; a
 database deny masks table and column grants; a table deny masks column grants.
 
+{% hint style="info" %}
+**Database patterns are an exception to "a deny beats a grant".** The database name in a
+database-level `GRANT` or `DENY` is a pattern: `_` matches any single character, `%` any sequence
+of characters, and `\` escapes either. When more than one database-level entry for an account
+matches the database being accessed, only the **most specific** entry applies — the one whose
+pattern matches the fewest database names — and only that entry's grants and denies are consulted.
+A deny recorded on a broader pattern is not added to a narrower entry that also matches.
+
+`DENY` follows the same matching rule as `GRANT` here; it is not privileged over it. Entries held
+through a [role](../../../security/user-account-management/roles/) or through `PUBLIC` are resolved
+the same way but separately, and then combined, so a deny that reaches the account by either route
+still applies. Patterns apply at database level only — table, column and routine names are matched
+literally, so denies at those levels are never affected.
+{% endhint %}
+
 ```sql
 DENY SELECT ON hr.* TO alice;
 GRANT SELECT ON hr.staff TO alice;

--- a/server/reference/sql-statements/account-management-sql-statements/deny.md
+++ b/server/reference/sql-statements/account-management-sql-statements/deny.md
@@ -57,7 +57,8 @@ Use `REVOKE DENY` to remove a deny. Nothing else restores the privilege — ther
 that lets an account bypass a deny, and a later `GRANT` does not cancel one.
 
 To issue `DENY` or `REVOKE DENY`, you need the `GRANT OPTION` privilege plus the privileges you
-are denying, exactly as you would to `GRANT` them.
+are denying, exactly as you would to `GRANT` them. `REVOKE DENY ... FROM PUBLIC` is the one
+exception — see [Removing a Deny on PUBLIC](#removing-a-deny-on-public).
 
 `DENY` applies to privileges only. It cannot be used to deny a role or proxy access, so there is
 no `DENY role` or `DENY PROXY` form.
@@ -157,6 +158,16 @@ Denying to [PUBLIC](grant.md#to-public) blocks a privilege for every account on 
 DENY SELECT ON hr.staff TO PUBLIC;
 ```
 
+{% hint style="warning" %}
+`PUBLIC` includes every account, `root` among them, so a deny on `PUBLIC` also takes the
+privilege away from the administrator who created it. `REVOKE DENY ... FROM PUBLIC` has a
+dedicated escape hatch for this — see [Removing a Deny on PUBLIC](#removing-a-deny-on-public) —
+but denying `UPDATE` disables that escape hatch too.
+{% endhint %}
+
+The lockout is not visible in the session that issued the `DENY`, because an account's global
+privileges are read when its connection is established. It applies from the next connection on.
+
 ## Removing a Deny
 
 `REVOKE DENY` removes the named privileges from an existing deny entry at that exact level. It
@@ -186,6 +197,43 @@ REVOKE ALL PRIVILEGES, GRANT OPTION FROM alice;
 
 Dropping the object a deny points at also removes the deny. Dropping a stored procedure, for
 example, deletes the deny entries recorded against it.
+
+### Removing a Deny on PUBLIC
+
+Because `PUBLIC` covers every account, a deny on `PUBLIC` also denies the privilege to whoever
+would otherwise be entitled to revoke it. So that such a deny stays recoverable,
+`REVOKE DENY ... FROM PUBLIC` accepts the `UPDATE` privilege on
+[mysql.global\_priv](../../system-tables/the-mysql-database-tables/mysql-global_priv-table.md)
+in place of the usual requirement — an account that can edit that table by hand could undo the
+deny anyway:
+
+```sql
+GRANT UPDATE ON mysql.global_priv TO admin@localhost;
+```
+
+`admin` can then issue `REVOKE DENY ... FROM PUBLIC` at any level — global, database, table,
+column or routine — without holding `GRANT OPTION` or the denied privilege itself. Two limits
+apply:
+
+* The statement must name `PUBLIC` and nothing else. `REVOKE DENY ... FROM PUBLIC, alice` is
+  checked normally, and so is a revoke aimed at a role, even a role every account holds.
+* Privileges are read when a connection is established, so reconnect after granting `UPDATE`.
+
+{% hint style="danger" %}
+`DENY UPDATE ON *.* TO PUBLIC` cannot be undone this way, because it denies the very privilege
+the escape hatch depends on. Every account, `root` included, is then refused `UPDATE` on
+`mysql.global_priv`, and `REVOKE DENY UPDATE ON *.* FROM PUBLIC` fails with
+`ERROR 28000: Access denied`. Recovery means deleting the entry directly and reloading the grant
+tables:
+
+```sql
+DELETE FROM mysql.global_priv WHERE User = 'PUBLIC';
+FLUSH PRIVILEGES;
+```
+
+This removes **every** deny recorded against `PUBLIC`, not only the one that caused the lockout.
+Reconnect afterwards for the change to take effect.
+{% endhint %}
 
 ## Viewing Denies
 

--- a/server/reference/sql-statements/account-management-sql-statements/deny.md
+++ b/server/reference/sql-statements/account-management-sql-statements/deny.md
@@ -312,9 +312,7 @@ Denies survive [FLUSH PRIVILEGES](../administrative-sql-statements/flush-command
 server restart, and replicate to replicas like any other account management statement.
 
 Column names and routine names in denies are matched case insensitively. Database and table names
-follow [lower\_case\_table\_names](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#lower_case_table_names):
-with the default `0` on Linux, `DENY SELECT ON DbCase.T` and `DENY SELECT ON dbcase.t` are two
-distinct denies.
+follow [lower\_case\_table\_names](../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#lower_case_table_names).
 
 {% hint style="warning" %}
 Editing the `denies` array directly with `UPDATE` is not supported. A malformed entry is skipped at


### PR DESCRIPTION
Follow-up to #832, which merged on 2026-08-03. [MDEV-40656](https://jira.mariadb.org/browse/MDEV-40656) landed three days later, on 2026-08-06, so `deny.md` never picked it up. Ramesh Sivaraman's review on DOCS-6218 asked for exactly this before the ticket is finalized, and the MDEV is now `Closed`/`Fixed`, fixVersion 13.1.1.

One file, `server/reference/sql-statements/account-management-sql-statements/deny.md`.

## What the server change does

`Sql_cmd_grant::should_bypass_revoke_deny()` — server `5818146a1d0`, `sql/sql_acl.cc:14363-14400` — skips the normal privilege check when all three hold:

1. the statement is `REVOKE DENY`;
2. **every** grantee named is `PUBLIC` with an empty host;
3. the revoker passes `check_access`/`check_grant` for `UPDATE` on `mysql.global_priv`.

Applied at four call sites, covering all five scopes: global, db, table, column, routine.

The table the check targets is written `MYSQL_TABLE_NAME[USER_TABLE]`, which reads as `mysql.user`. It is not — `sql/sql_acl.cc:813-821` resolves that entry to **`global_priv`**, matching the commit message. Worth stating because the constant's name points the wrong way.

## Changes

- **Line 59** — the "you need `GRANT OPTION` plus the privileges you are denying" sentence gains its exception and links to the new section. It was unqualified, and is now wrong for this case.
- **Line 154** — a warning where the reader is first shown `DENY SELECT ON hr.staff TO PUBLIC`. The page previously demonstrated the statement with no caveat at all. Plus a note that the lockout is invisible in the issuing session, because privileges are read at connect.
- **New `### Removing a Deny on PUBLIC`** — the bypass, its two limits, and the unrecoverable case.

## Sourcing

Verified against server `5818146a1d0` and `mysql-test/main/deny_revoke_public.{test,result}`. The MTR result file is the oracle here rather than a live server: `DENY` is 13.1 and the local instance is 12.3.3, so the examples cannot be executed. Facts taken from it:

- **A role is not `PUBLIC`** — `REVOKE DENY ... FROM r1` still fails with `ERROR 42000: SELECT, GRANT command denied`, even holding `UPDATE` on `mysql.global_priv`.
- **Same session is unaffected**; the deny bites on the next connection, and the recovery likewise needs a reconnect.
- **`DENY UPDATE ON *.* TO PUBLIC` denies the bypass's own prerequisite.** Even `root` is then refused `UPDATE` on `mysql.global_priv`, and `REVOKE DENY UPDATE ON *.* FROM PUBLIC` fails with `ERROR 28000`. Recovery is `DELETE FROM mysql.global_priv WHERE User = 'PUBLIC'` plus `FLUSH PRIVILEGES` — which drops *every* deny on `PUBLIC`, noted in the hint.

## No version annotation

Deliberate. `DENY` is new in 13.1 (MDEV-14443) and the fix ships in the same series, with 13.1.0 still alpha — no released MariaDB ever had the un-escapable behavior. "Since 13.1.1" would imply a released version that behaves the other way.

## Checks

`doc-lint.sh` (with the file as an argument) exit 0 · codespell CI-exact invocation clean · lychee 27 OK / 0 errors · fragcheck 7 fragment links, 0 dead, and the new `#removing-a-deny-on-public` h3 anchor publishes, so both in-page links to it resolve.

No redirects needed — sections added to an existing URL, nothing renamed or retired.

---

## Review round 2 — Vladislav Vaintroub (DOCS-6218, 2026-08-31)

Three points on the ticket. One was already covered by this PR; the other two are the two commits added on top.

### 1. Remove the Linux / `lower_case_table_names` detail — done

`DENY` is not OS-dependent, the `lower_case_table_names` default can change, and documentation should not advertise objects differing only in case. The paragraph now keeps the link and drops the rest, including the `DbCase.T` / `dbcase.t` example.

### 2. `REVOKE DENY ... FROM PUBLIC` needs `UPDATE` on `mysql.global_priv` — already in this PR

That is what the original commit here documents: the requirement, the `GRANT UPDATE ON mysql.global_priv` example, the `PUBLIC`-only and reconnect limits, and the unrecoverable `DENY UPDATE ON *.*` case. No change needed.

### 3. Database wildcard matching needs a footnote — done

Added under **Precedence**, where the page previously stated "a deny beats a grant" unqualified — which is exactly the reading Vlad flagged as wrong for database pattern matches.

Verified against server `5818146a1d0`:

| Claim | Evidence |
| --- | --- |
| Database names in database-level `GRANT`/`DENY` are patterns; `_`, `%`, `\` | `match_db()` uses `wild_compare()`; `sql/init.cc:38` sets `wild_many='%'`, `wild_one='_'`, `wild_prefix='\'` |
| Only the single most specific matching entry applies | `acl_dbs` sorted by `get_magic_sort()`; `acl_db_find()` returns the first match; `acl_get()` takes that one entry's `access` |
| "Most specific" = matches the fewest names | `sql/sql_acl_getsort.inl:20-39` — "a pattern A is more specific than pattern B if the set of strings that match the pattern A is smaller" |
| The losing entry's *denies* are dropped too, not just its grants | `ACL_DB` carries allow and deny bits in one `access_t` (`sql/sql_acl.cc:322-331`) |
| A deny via a role or `PUBLIC` still applies | `acl_get_all3()` resolves user, role and `PUBLIC` separately, then `merge_same_level()` |
| Patterns are database-level only | table/column/routine privileges are keyed by literal name in `column_priv_hash` (`name_hash_search()`); only the host part is pattern-matched |

**Deliberately not documented:** the tie-breaking algorithm itself. Vlad noted the detailed rules are Sergei's territory, and the reader only needs "most specific wins, and `DENY` is not privileged over `GRANT` here".

**Coverage gap, stated plainly:** no `deny_*.result` file exercises two competing database patterns, so this note rests on the mechanism above plus Vlad's review — not on a test. Worth a server-side test if anyone agrees.

## Checks (round 2)

`doc-lint.sh` (file as argument) exit 0 · codespell CI-exact clean · lychee 28 OK / 0 errors · fragcheck 16,247 links / 20 dead / 1 unresolvable — both unchanged from `main`, so nothing introduced. No new headings, so no anchors moved and no redirects needed.
