### PR TITLE
DOCS-6538 Fix the person shift in /standup group headings

### DIFF
--- a/.claude/commands/standup.md
+++ b/.claude/commands/standup.md
@@ -1,5 +1,5 @@
 ---
-description: Start-of-day briefing — what's waiting on whom across my DOCS tickets and open PRs (read-only).
+description: Start-of-day briefing — what's waiting on whom across your DOCS tickets and open PRs (read-only).
 argument-hint: "(nothing — takes no arguments)"
 allowed-tools: Bash, Read, Grep, Glob, mcp__atlassian-mariadb__atlassianUserInfo, mcp__claude_ai_Atlassian_Rovo__atlassianUserInfo, mcp__atlassian-mariadb__searchJiraIssuesUsingJql, mcp__claude_ai_Atlassian_Rovo__searchJiraIssuesUsingJql, mcp__atlassian-mariadb__getJiraIssue, mcp__claude_ai_Atlassian_Rovo__getJiraIssue, mcp__atlassian-mariadb__getAccessibleAtlassianResources, mcp__claude_ai_Atlassian_Rovo__getAccessibleAtlassianResources
 ---
@@ -55,7 +55,7 @@ them seen in practice:
 - **A merged PR need not close its ticket.** A ticket can be held open purely for a review that
   hasn't happened yet.
 - **"In Review" does not create a reviewer.** A ticket can sit for weeks with no reviewer named
-  and no review requested. That is a "waiting on me to ask", not a "waiting on them".
+  and no review requested. That is a "waiting on you to ask", not a "waiting on them".
 
 ## Don't sort on `updated`
 
@@ -67,10 +67,10 @@ date of the last real comment.
 
 Four groups, in this order, one line per item — key, one-phrase state, next action:
 
-- **Waiting on me** — PRs in review with their CI state, findings to act on.
+- **Waiting on you** — PRs in review with their CI state, findings to act on.
 - **Waiting on someone else** — name the person and what was asked, and how long it has been
   waiting. This is usually the group the user wants to chase; `/jira-chase` does that.
-- **Mine to pick up** — open tickets not yet started, with anything already known about scope.
+- **Ready to pick up** — open tickets not yet started, with anything already known about scope.
 - **Post-merge chores** — redirects to load, branches to delete, timesheet lines, follow-up tickets
   to file. These get forgotten precisely because they outlive their ticket.
 


### PR DESCRIPTION
Follow-up to #977. One file, `.claude/commands/standup.md`, 4 lines.

The group headings were written in the first person of whoever types `/standup`. But Claude is what reads the briefing back, so they invert: in the file "Waiting on me" means the user, spoken aloud it means Claude. Stefan hit this in a live run this morning and asked which one "Mine to pick up" referred to — a fair question, because the text supports both readings.

Second person is consistent, since the briefing always addresses the person who ran it:

| Before | After |
|---|---|
| **Waiting on me** | **Waiting on you** |
| **Mine to pick up** | **Ready to pick up** |

**Why "Ready to pick up" and not "Ready to document".** That was the first suggestion and it reads better, but it under-covers the queue: a real slice of these tickets involve no documenting at all. From one live run — DOCS-6524 (run fragcheck in CI), DOCS-6471 (CI coverage for `doc-lint.sh`), DOCS-6400 (MCP registry registration), DOCS-6398 (crawler work). Four of nineteen would have sat under a heading saying the opposite of what they are. A pronoun-free label is correct from either side and for either kind of ticket.

Also updated for consistency: the frontmatter `description`, and the `"waiting on me to ask"` phrasing in the traps section, which names the same group.

The literal `--author @me` flags are `gh` syntax, not prose, and are left alone — 3 occurrences, unchanged.

`.claude/` only; nothing published changes, so no redirects and no GitBook verification. `doc-lint.sh` exit 0, codespell clean.