### PR TITLE
DOCS-6523 Fix escaped Markdown that prints literal backslashes

### DIFF
--- a/analytics/mariadb-columnstore/high-availability/mariadb-columnstore-performance-related-configuration-settings.md
+++ b/analytics/mariadb-columnstore/high-availability/mariadb-columnstore-performance-related-configuration-settings.md
@@ -102,7 +102,7 @@ AND n.n_nationkey = c.c_nationkey
 ```
 
 {% hint style="danger" %}
-Note: `INFINIDB\_ORDERED` is deprecated and does not work anymore for ColumnStore 1.2 and above.
+Note: `INFINIDB_ORDERED` is deprecated and does not work anymore for ColumnStore 1.2 and above.
 {% endhint %}
 
 use `set infinidb_ordered_only=ON;`

--- a/analytics/mariadb-columnstore/management/columnstore-system-variables.md
+++ b/analytics/mariadb-columnstore/management/columnstore-system-variables.md
@@ -216,7 +216,7 @@ In typical mathematical and scientific applications, the ability to avoid overfl
 
 ### Enable/Disable Decimal-to-Double Math
 
-The `infinidb\_double\_for\_decimal\_math` variable is used to control the data type for intermediate decimal results. This decimal for double math may be set as a default for the instance, set at the session level, or at the statement level by toggling this variable on and off.
+The `infinidb_double_for_decimal_math` variable is used to control the data type for intermediate decimal results. This decimal for double math may be set as a default for the instance, set at the session level, or at the statement level by toggling this variable on and off.
 
 To enable/disable the use of the decimal to double math at the session level, the following command is used. Once the session has ended, any subsequent session will return to the default for the instance:
 

--- a/connectors/connectors-quickstart-guides/mariadb-connector-net-guide.md
+++ b/connectors/connectors-quickstart-guides/mariadb-connector-net-guide.md
@@ -30,14 +30,15 @@ Install-Package MySqlConnector -Version 2.4.0 # Use the latest stable version
 
 **b. Using PackageReference (in your `.csproj` file):**
 
-````xml
-<PackageReference Include="MySqlConnector" Version="2.4.0" /> ```
+```xml
+<PackageReference Include="MySqlConnector" Version="2.4.0" />
+```
 
 **c. Using .NET CLI:**
 
 ```bash
 dotnet add package MySqlConnector --version 2.4.0 # Use the latest stable version
-````
+```
 
 #### 3. Basic Usage
 

--- a/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/binarylog-backup-examples.md
+++ b/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/binarylog-backup-examples.md
@@ -51,7 +51,7 @@ curl --location 'https://api.skysql.com/skybackup/v1/backups/schedules' \
 * SERVICE\_ID : MariaDB Cloud service identifier, format dbtxxxxxx
 
 {% hint style="info" %}
-Backup status can be fetch using 'https://api.skysql.com/skybackup/v1/backups'. See the 'Backup Status' section for an example.
+Backup status can be fetched using `https://api.skysql.com/skybackup/v1/backups`. See the 'Backup Status' section for an example.
 {% endhint %}
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>

--- a/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/binarylog-backup-examples.md
+++ b/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/binarylog-backup-examples.md
@@ -15,7 +15,6 @@ description: >-
 
 To set up an one-time _binary log_ backup:
 
-````
 ```bash
 curl --location 'https://api.skysql.com/skybackup/v1/backups/schedules' \
 --header 'Content-Type: application/json' \
@@ -26,7 +25,7 @@ curl --location 'https://api.skysql.com/skybackup/v1/backups/schedules' \
     "schedule": "once",
     "service_id": "$SERVICE_ID"
 }'
-````
+```
 
 * API\_KEY : SKYSQL API KEY, see [MariaDB Cloud API Keys](https://app.skysql.com/user-profile/api-keys/)
 * SERVICE\_ID : MariaDB Cloud service identifier, format dbtxxxxxx. You can fetch the service ID from the Fully qualified domain name(FQDN) of your service. E.g: in dbpgf17106534.sysp0000.db2.skysql.com, 'dbpgf17106534' is the service ID.You will find the FQDN in the [Connect window](https://app.skysql.com/dashboard)

--- a/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/incremental-backup-examples.md
+++ b/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/incremental-backup-examples.md
@@ -53,7 +53,7 @@ curl --location 'https://api.skysql.com/skybackup/v1/backups/schedules' \
 * SERVICE\_ID : MariaDB Cloud service identifier, format dbtxxxxxx
 
 {% hint style="info" %}
-Backup status can be fetched using 'https://api.skysql.com/skybackup/v1/backups'. See the 'Backup Status' section for an example.
+Backup status can be fetched using `https://api.skysql.com/skybackup/v1/backups`. See the 'Backup Status' section for an example.
 {% endhint %}
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>

--- a/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/logical-backup-examples.md
+++ b/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/logical-backup-examples.md
@@ -47,7 +47,7 @@ curl --location 'https://api.skysql.com/skybackup/v1/backups/schedules' \
 * SERVICE\_ID : MariaDB Cloud service identifier, format dbtxxxxxx
 
 {% hint style="info" %}
-Backup status can be fetched using 'https://api.skysql.com/skybackup/v1/backups'. See the 'Backup Status' section for an example.
+Backup status can be fetched using `https://api.skysql.com/skybackup/v1/backups`. See the 'Backup Status' section for an example.
 {% endhint %}
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>

--- a/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/physical-backup-examples.md
+++ b/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/physical-backup-examples.md
@@ -46,7 +46,7 @@ curl --location 'https://api.skysql.com/skybackup/v1/backups/schedules' \
 * SERVICE\_ID : MariaDB Cloud service identifier, format `dbtxxxxxx`
 
 {% hint style="info" %}
-Backup status can be fetched using 'https://api.skysql.com/skybackup/v1/backups'. \
+Backup status can be fetched using `https://api.skysql.com/skybackup/v1/backups`. \
 See the 'Backup Status' section for an example.
 {% endhint %}
 

--- a/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/snapshot-backup-examples.md
+++ b/mariadb-cloud/cloud-data-handling/backup-and-restore/backup-examples/snapshot-backup-examples.md
@@ -55,7 +55,7 @@ curl --location 'https://api.skysql.com/skybackup/v1/backups/schedules' \
 * SERVICE\_ID : MariaDB Cloud service identifier, format dbxxxxxx
 
 {% hint style="info" %}
-Backup status can be fetched using 'https://api.skysql.com/skybackup/v1/backups'. See the 'Backup Status' section for an example.
+Backup status can be fetched using `https://api.skysql.com/skybackup/v1/backups`. See the 'Backup Status' section for an example.
 {% endhint %}
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>

--- a/maxscale/maxscale-management/administrative-tools-for-mariadb-maxscale-maxctrl/connecting-to-maxscale-using-tls-with-maxctrl.md
+++ b/maxscale/maxscale-management/administrative-tools-for-mariadb-maxscale-maxctrl/connecting-to-maxscale-using-tls-with-maxctrl.md
@@ -19,7 +19,7 @@ description: >-
 $ maxctrl create user "maxscale_rest_admin" "maxscale_rest_admin_password" --type=admin
 ```
 
-Replace `maxscale\_rest\_admin` and `maxscale\_rest\_admin\_password` with the desired user and password.
+Replace `maxscale_rest_admin` and `maxscale_rest_admin_password` with the desired user and password.
 
 2. If you want to use MaxCtrl remotely, [configure the REST API for remote connections](../configuring-maxscales-rest-api.md#configuring-maxscales-rest-api-for-remote-connections). Several global parameters must be configured in maxscale.cnf.
 

--- a/maxscale/maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md
+++ b/maxscale/maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md
@@ -1823,7 +1823,7 @@ event.X.level=LOG_ERR
 
 The above means that if event _X_ occurs, then that is logged using the facility `LOG_LOCAL0` and the level `LOG_ERR`.
 
-The valid values of `facility` are the facility values reported by`man syslog`, e.g.`LOG\_AUTH`,`LOG\_LOCAL0`and`LOG\_USER`. Likewise, the valid values for `level`are the ones also reported by`man syslog`, e.g.`LOG\_WARNING`,`LOG\_ERR`and`LOG\_CRIT\`.
+The valid values of `facility` are the facility values reported by`man syslog`, e.g.`LOG_AUTH`,`LOG_LOCAL0`and`LOG_USER`. Likewise, the valid values for `level`are the ones also reported by`man syslog`, e.g.`LOG_WARNING`,`LOG_ERR`and`LOG\_CRIT\`.
 
 Note that MaxScale does not act upon the level, that is, even if the level of a particular event is defined to be `LOG_EMERG`, MaxScale will not shut down if that event occurs.
 
@@ -2067,7 +2067,7 @@ By default MaxScale uses the first server labeled as `Master` as the source of t
 
 **Note:** This parameter has been deprecated in MaxScale 23.08. The stripping of escape characters is in all known cases the correct thing to do.
 
-This setting controls whether escape characters (`\`) are removed from database names when loading user grants from a backend server. When enabled, a grant such as ``grant select on` `test\_`.* to 'user'@'%';`` is read as ``grant select on` `test\_`.* to 'user'@'%';``
+This setting controls whether escape characters (`\`) are removed from database names when loading user grants from a backend server. When enabled, a grant such as ``grant select on `test\_`.* to 'user'@'%';`` is read as ``grant select on `test_`.* to 'user'@'%';``
 
 This setting has no effect on database-level grants fetched from a MariaDB Server. The database names of a MariaDB Server are compared using the LIKE operator to properly handle wildcards and escaped wildcards. This setting may affect database names in table and column level grants, although these typically do not contain backlashes.
 

--- a/maxscale/maxscale-management/maxscale-troubleshooting.md
+++ b/maxscale/maxscale-management/maxscale-troubleshooting.md
@@ -9,19 +9,19 @@ description: >-
 
 ## SystemD Watchdog Kills MaxScale
 
-This can occur if a reverse DNS name lookup takes a long time. To disable reverse name lookups of client IPs to client hostnames, add `skip\_name\_resolve=true` under the `[maxscale]` section.
+This can occur if a reverse DNS name lookup takes a long time. To disable reverse name lookups of client IPs to client hostnames, add `skip_name_resolve=true` under the `[maxscale]` section.
 
 ## High Memory Usage
 
 **MaxScale starting with 22.08.4**
 
-The default value of `writeq\_high\_water` was lowered to 64KiB to reduce excessive memory usage. This change should result in a net decrease in memory usage and possibly a small improvement in performance.
+The default value of `writeq_high_water` was lowered to 64KiB to reduce excessive memory usage. This change should result in a net decrease in memory usage and possibly a small improvement in performance.
 
-Set `writeq\_high\_water` and `writeq\_low\_water` to lower values, for example `writeq_high_water=512` and `writeq_low_water=128`. The default is to buffer a maximum of 16MB in memory before network throttling begins which under intensive loads can result in a large amount of memory being used per client.
+Set `writeq_high_water` and `writeq_low_water` to lower values, for example `writeq_high_water=512` and `writeq_low_water=128`. The default is to buffer a maximum of 16MB in memory before network throttling begins which under intensive loads can result in a large amount of memory being used per client.
 
-The query classifier cache in MaxScale by default takes up to 15% of memory to cache query classification data. This value can be lowered using the `query\_classifier\_cache\_size` parameter.
+The query classifier cache in MaxScale by default takes up to 15% of memory to cache query classification data. This value can be lowered using the `query_classifier_cache_size` parameter.
 
-The `retain\_last\_statements` and `session\_trace` debugging parameters can cause memory usage to increase. Disabling them under intensive loads is recommended if they are not needed. Note that the `maxctrl list queries` requires that `retain_last_statements=1` is set.
+The `retain_last_statements` and `session_trace` debugging parameters can cause memory usage to increase. Disabling them under intensive loads is recommended if they are not needed. Note that the `maxctrl list queries` requires that `retain_last_statements=1` is set.
 
 ### Profiling Memory Usage
 
@@ -66,7 +66,7 @@ ERROR 1045 (28000): Access denied for user 'bob'@'office' (using password: YES)
 
 Make sure you create users for both `'bob'@'office'` and `'bob'@'maxscale'`. The host `'office'` is where the client is attempting to connect from and `'maxscale'` is the host where MaxScale is installed.
 
-If you do not want to create a second set of users, you can enable `proxy\_protocol` in MaxScale and configure the MariaDB server to [allow proxied connections](../../server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#proxy_protocol_networks) from the MaxScale host.
+If you do not want to create a second set of users, you can enable `proxy_protocol` in MaxScale and configure the MariaDB server to [allow proxied connections](../../server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#proxy_protocol_networks) from the MaxScale host.
 
 #### Verifying that a user is allowed to connect
 
@@ -105,12 +105,12 @@ If you want to connect as root, you'll need to add [enable\_root\_user=true](dep
 There seems to be a bug for databases containing underscores. Connect as root and use "SHOW GRANTS FOR user".
 
 ```sql
-GRANT SELECT ON `my\_database`.\* TO 'user'@'%' <-- bad
+GRANT SELECT ON `my\_database`.* TO 'user'@'%' <-- bad
 
-GRANT SELECT ON `my_database`.\* TO 'user'@'%' <-- good
+GRANT SELECT ON `my_database`.* TO 'user'@'%' <-- good
 ```
 
-If you got a grant containing a escaped underscore, you can add the `strip\_db\_esc=true` parameter to the service to automatically strip escape characters or just replace the grant with a unescaped one.
+If you got a grant containing a escaped underscore, you can add the `strip_db_esc=true` parameter to the service to automatically strip escape characters or just replace the grant with a unescaped one.
 
 ## System Errors
 

--- a/maxscale/maxscale-security/authentication-modules.md
+++ b/maxscale/maxscale-security/authentication-modules.md
@@ -64,7 +64,7 @@ See [MaxScale Troubleshooting](../maxscale-management/maxscale-troubleshooting.m
 
 ### Wildcard database grants
 
-MaxScale supports wildcards `_` and `%` for database-level grants. As with MariaDB Server, `grant select on test_.* to 'alice'@'%';` gives access to _test\__ as well as _test1_, _test2_ and so on. If the GRANT command escapes the wildcard (`grant select on \`test\_\`.\* to 'alice'@'%';`) both MaxScale and the MariaDB Server interpret it as only allowing access to _test\__.` \_`and`%`are only interpreted as wildcards when the grant is to a database:`grant select on \`test\_\`.t1 to 'alice'@'%';\` only grants access to the _test\_.t1_-table, not to _test1.t1_.
+MaxScale supports wildcards `_` and `%` for database-level grants. As with MariaDB Server, `grant select on test_.* to 'alice'@'%';` gives access to _test\__ as well as _test1_, _test2_ and so on. If the GRANT command escapes the wildcard (``grant select on `test\_`.* to 'alice'@'%';``) both MaxScale and the MariaDB Server interpret it as only allowing access to _test\__. `_` and `%` are only interpreted as wildcards when the grant is to a database: ``grant select on `test\_`.t1 to 'alice'@'%';`` only grants access to the _test\_.t1_ table, not to _test1.t1_.
 
 ## Settings
 

--- a/maxscale/reference/maxscale-routers/maxscale-exasolrouter.md
+++ b/maxscale/reference/maxscale-routers/maxscale-exasolrouter.md
@@ -199,7 +199,7 @@ In the latter case, currently it only affects whether 'USE db' becomes
 
 ### `COM_INIT_DB`
 
-The MariaDB `COM\_INIT\_DB` protocol packet, using which the default database
+The MariaDB `COM_INIT_DB` protocol packet, using which the default database
 is changed, is transformed into the statement `OPEN SCHEMA <db>`.
 
 ### SQL
@@ -212,10 +212,10 @@ Currently a transformation will be made _only_ if there is an **exact** match
 
 | MariaDb                           | Exasol                                                                                                              |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `SELECT @@VERSION\_COMMENT LIMIT 1` | `SELECT 'Exasol' AS '@@version\_comment' LIMIT 1`                                                                     |
-| `SELECT DATABASE()`                 | `SELECT TABLE\_NAME AS 'Database()' FROM EXA\_ALL\_TABLES WHERE TABLE\_SCHEMA = CURRENT\_SCHEMA`                      |
-| `SHOW DATABASES`                    | `SELECT SCHEMA\_NAME AS 'Database' FROM EXA\_SCHEMAS ORDER BY SCHEMA\_NAME`                                           |
-| `SHOW TABLES`                       | `SELECT TABLE\_NAME AS 'Tables' FROM SYS.EXA\_ALL\_TABLES WHERE TABLE\_SCHEMA = CURRENT\_SCHEMA ORDER BY TABLE\_NAME` |
+| `SELECT @@VERSION_COMMENT LIMIT 1` | `SELECT 'Exasol' AS '@@version_comment' LIMIT 1`                                                                     |
+| `SELECT DATABASE()`                 | `SELECT TABLE_NAME AS 'Database()' FROM EXA_ALL_TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA`                      |
+| `SHOW DATABASES`                    | `SELECT SCHEMA_NAME AS 'Database' FROM EXA_SCHEMAS ORDER BY SCHEMA_NAME`                                           |
+| `SHOW TABLES`                       | `SELECT TABLE_NAME AS 'Tables' FROM SYS.EXA_ALL_TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA ORDER BY TABLE_NAME` |
 
 ## ODBC
 

--- a/release-notes/community-server/changelogs/10.11/10.11.19.md
+++ b/release-notes/community-server/changelogs/10.11/10.11.19.md
@@ -43,11 +43,11 @@ The revision number links will take you to the revision's page on GitHub. On [Gi
 * [Revision #52a2bc27cc](https://github.com/MariaDB/server/commit/52a2bc27cc) <sup>_<mark style="color:$info;">2026-08-06 20:46:58 -0600</mark>_</sup>
   * MDEV-40647 OOB read in IO Thread if the FDEv does not support Rotate Events
 * [Revision #cd51639e4a](https://github.com/MariaDB/server/commit/cd51639e4a) <sup>_<mark style="color:$info;">2026-07-21 00:16:15 -0600</mark>_</sup>
-  * MDEV-39485 Heap-buffer-overflow upon read in `Rows\_log\_event` constructor
+  * MDEV-39485 Heap-buffer-overflow upon read in `Rows_log_event` constructor
 * [Revision #c61b1a2ef7](https://github.com/MariaDB/server/commit/c61b1a2ef7) <sup>_<mark style="color:$info;">2026-08-11 14:21:52 -0600</mark>_</sup>
-  * MDEV-40366 OOB read on malformed `Format\_description\_log\_event`
+  * MDEV-40366 OOB read on malformed `Format_description_log_event`
 * [Revision #e491a1e880](https://github.com/MariaDB/server/commit/e491a1e880) <sup>_<mark style="color:$info;">2026-08-11 14:07:52 -0600</mark>_</sup>
-  * MDEV-40365 OOB read on malformed `Format\_description\_log\_event`
+  * MDEV-40365 OOB read on malformed `Format_description_log_event`
 * [Revision #edef9f2fd3](https://github.com/MariaDB/server/commit/edef9f2fd3) <sup>_<mark style="color:$info;">2026-08-11 09:57:49 -0600</mark>_</sup>
   * MDEV-40648 Fix rpl.rpl_corruption
 * [Revision #080480c52d](https://github.com/MariaDB/server/commit/080480c52d) <sup>_<mark style="color:$info;">2026-08-10 11:03:35 -0600</mark>_</sup>
@@ -230,7 +230,7 @@ The revision number links will take you to the revision's page on GitHub. On [Gi
 * [Revision #ecf1555da7](https://github.com/MariaDB/server/commit/ecf1555da7) <sup>_<mark style="color:$info;">2026-06-26 12:30:59 +1000</mark>_</sup>
   * MDEV-40147 MSAN: use-of-uninitialized-value in my_time_compare
 * [Revision #113630fdfa](https://github.com/MariaDB/server/commit/113630fdfa) <sup>_<mark style="color:$info;">2026-07-17 12:58:32 +0530</mark>_</sup>
-  * MDEV-40099: MSAN: use-of-uninitialized-value in `TABLE::delete\_row\<true\>(bool)`
+  * MDEV-40099: MSAN: use-of-uninitialized-value in `TABLE::delete_row<true>(bool)`
 * [Revision #1dd7b96429](https://github.com/MariaDB/server/commit/1dd7b96429) <sup>_<mark style="color:$info;">2026-06-01 17:35:42 +1000</mark>_</sup>
   * MDEV-26813 UBSAN: bool wkbByteOrder via Geometry::wkbByteOrder (multi_line_string)
 * [Revision #46b2f83702](https://github.com/MariaDB/server/commit/46b2f83702) <sup>_<mark style="color:$info;">2026-05-03 16:24:54 +1000</mark>_</sup>

--- a/release-notes/community-server/changelogs/changelogs-mariadb-100-series/mariadb-1001-changelog.md
+++ b/release-notes/community-server/changelogs/changelogs-mariadb-100-series/mariadb-1001-changelog.md
@@ -556,7 +556,6 @@ Fri 2012-08-17 21:13:20 +0400
 * Initial commit for Cassandra storage engine.
 ```
 
-```
 
 * [Revision #3492](https://bazaar.launchpad.net/~maria-captains/maria/10.0/revision/3492)\
   Fri 2013-01-11 16:33:51 +0100
@@ -855,10 +854,10 @@ Fri 2012-08-17 21:13:20 +0400
 ```
 
 revno: 3768.1.1
-committer: Christopher Powers [chris.powers@oracle.com](mailto:chris.powers@oracle.com)
+committer: Christopher Powers <chris.powers@oracle.com>
 timestamp: Wed 2012-05-02 22:16:40 -0500
-message:\
-Bug#11766342 INITIAL DB CREATION FAILS ON WINDOWS WITH AN ASSERT IN SQL\_ERROR.CC\
+message:
+Bug#11766342 INITIAL DB CREATION FAILS ON WINDOWS WITH AN ASSERT IN SQL_ERROR.CC
 Improved bootstrap error handling:
 
 * Detect and report file i/o errors
@@ -880,27 +879,27 @@ Improved bootstrap error handling:
 
 revno: 3383
 revision-id: georgi.kodinov@oracle.com-20110818083108-qa3h3ufqu4zne80a
-committer: Georgi Kodinov [Georgi.Kodinov@Oracle.com](mailto:Georgi.Kodinov@Oracle.com)
+committer: Georgi Kodinov <Georgi.Kodinov@Oracle.com>
 timestamp: Thu 2011-08-18 11:31:08 +0300
-message:\
-.\
-Bug #11766001: 59026: ALLOW MULTIPLE --PLUGIN-LOAD OPTIONS\
-.\
-Implemented support for a new command line option :\
-\--plugin-load-add=\
+message:
+.
+Bug #11766001: 59026: ALLOW MULTIPLE --PLUGIN-LOAD OPTIONS
+.
+Implemented support for a new command line option :
+--plugin-load-add=
 This option takes the same type of arguments that --plugin-load does
 and complements --plugin-load (that continues to operate as before) by
-appending its argument to the list specified by --plugin-load.\
+appending its argument to the list specified by --plugin-load.
 So --plugin-load can be considered a composite option consisting of
 resetting the plugin load list and then calling --plugin-load-add to process
-the argument.\
+the argument.
 Note that the order in which you specify --plugin-load and --plugin-load-add
-is important : "--plugin-load=x --plugin-load-add=y" will be equivalent to\
+is important : "--plugin-load=x --plugin-load-add=y" will be equivalent to
 "--plugin-load=x,y" whereas "--plugin-load-add=y --plugin-load=x" will be
-equivalent to "plugin-load=x".\
-.\
-Incompatible change : the --help --verbose command will no longer print the\
-\--plugin-load variable's values (as it doesn't have one). Otherwise both --plugin-load
+equivalent to "plugin-load=x".
+.
+Incompatible change : the --help --verbose command will no longer print the
+--plugin-load variable's values (as it doesn't have one). Otherwise both --plugin-load
 and --plugin-load-add are mentioned in it.
 
 ```
@@ -924,7 +923,6 @@ and --plugin-load-add are mentioned in it.
   Thu 2012-11-15 12:54:50 +0200
   * [MDEV-3858](https://jira.mariadb.org/browse/MDEV-3858) Change JOIN\_TAB::records\_read from ha\_rows to double
   * Currently JOIN\_TAB::records\_read is of type ha\_rows. This is an integer type, which prevents proper selectivity and rows estimates.
-```
 
 {% include "../../../.gitbook/includes/announce.md" %}
 

--- a/release-notes/enterprise-server/10.6/10.6.8-4.md
+++ b/release-notes/enterprise-server/10.6/10.6.8-4.md
@@ -206,7 +206,7 @@ InnoDB: Allocated tablespace ID TABLESPACE_ID for DATABASE_NAME/TABLE_NAME, old 
   * When performing minor upgrades on CentOS, RHEL, Rocky Linux, and SUSE, a logical backup can be taken before or after upgrading the server package. When the old packages are upgraded, a message about plugin incompatibility is printed, and the server package is upgraded, but the plugin package is not. The old plugin package must be manually removed, and then the new plugin package can be installed.
   * When performing major upgrades on CentOS, RHEL, Rocky Linux, and SUSE, a logical backup must be taken before upgrading the server and plugin packages. The old server and plugin packages must be manually removed, and then the new server and plugin packages can be installed.
   * When the plugin package is manually removed, the plugin configuration file can also be removed, so it is recommended to backup the file.
-* On Windows, error during upgrade from 10.6.5 to 10.6.7: `Installation directory ''C:\Program Files\[MariaDB 10.6](../../community-server/10.6/what-is-mariadb-106.md)\'' exists and is not empty`. ([MDEV-27828](https://jira.mariadb.org/browse/MDEV-27828))
+* On Windows, error during upgrade from 10.6.5 to 10.6.7: `Installation directory ''C:\Program Files\MariaDB 10.6\'' exists and is not empty`. ([MDEV-27828](https://jira.mariadb.org/browse/MDEV-27828))
 * On Windows, error during installation: `InnoDB: innodb_page_size=65536 requires innodb_buffer_pool_size >= 20MiB current 10MiB` ([MDEV-28471](https://jira.mariadb.org/browse/MDEV-28471))
 
 ## Changes in Storage Engines

--- a/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-hotcopy.md
+++ b/server/clients-and-utilities/backup-restore-and-import-clients/mariadb-hotcopy.md
@@ -100,7 +100,7 @@ The TCP/IP _port number_ to use when connecting to the local server.
 
 Be silent except for errors.
 
-#### `--record\_log\_pos`=_db\_name_._tbl\_name_
+#### `--record_log_pos`=_db\_name_._tbl\_name_
 
 Record master and slave status in the specified database _db\_name_ and table _tbl\_name_.
 

--- a/server/clients-and-utilities/logging-tools/mariadb-binlog/mariadb-binlog-options.md
+++ b/server/clients-and-utilities/logging-tools/mariadb-binlog/mariadb-binlog-options.md
@@ -49,7 +49,7 @@ Output entries from the binary log (local log only) that occur while the name ha
 
 #### ## \[options], --debug\[=options]
 
-In a debug build, write a debugging log. A typical debug options string is `d:t:o,file\_name`. Default value: `d:t:o,/tmp/mariadb-binlog.trace`
+In a debug build, write a debugging log. A typical debug options string is `d:t:o,file_name`. Default value: `d:t:o,/tmp/mariadb-binlog.trace`
 
 #### --debug-check
 
@@ -73,7 +73,7 @@ Only read default options from the given file name, which can be the full path o
 
 #### --defaults-group-suffix=_str_
 
-Also read groups with a suffix of _str_. For example, since `mariadb-binlog` normally reads the `[client]` and `[mysqlbinlog]` groups, `--defaults-group-suffix=`_`x`_ would cause it to also read the groups `\[mysqlbinlog\_x]` and `\[client\_x]`.
+Also read groups with a suffix of _str_. For example, since `mariadb-binlog` normally reads the `[client]` and `[mysqlbinlog]` groups, `--defaults-group-suffix=`_`x`_ would cause it to also read the groups `[mysqlbinlog_x]` and `[client_x]`.
 
 #### -D, --disable-log-bin
 

--- a/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/dbt3-automation-scripts.md
+++ b/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/dbt3-automation-scripts.md
@@ -269,29 +269,29 @@ the value of `-s` parameter
 * ```
   ```
 
-cd $PROJECT\_HOME/dbt3-1.9/src/dbgen\
-./qgen -s 30 1 > $PROJECT\_HOME/gen\_query/s30-m/1.sql\
-./qgen -s 30 2 > $PROJECT\_HOME/gen\_query/s30-m/2.sql\
-./qgen -s 30 3 > $PROJECT\_HOME/gen\_query/s30-m/3.sql\
-./qgen -s 30 4 > $PROJECT\_HOME/gen\_query/s30-m/4.sql\
-./qgen -s 30 5 > $PROJECT\_HOME/gen\_query/s30-m/5.sql\
-./qgen -s 30 6 > $PROJECT\_HOME/gen\_query/s30-m/6.sql\
-./qgen -s 30 7 > $PROJECT\_HOME/gen\_query/s30-m/7.sql\
-./qgen -s 30 8 > $PROJECT\_HOME/gen\_query/s30-m/8.sql\
-./qgen -s 30 9 > $PROJECT\_HOME/gen\_query/s30-m/9.sql\
-./qgen -s 30 10 > $PROJECT\_HOME/gen\_query/s30-m/10.sql\
-./qgen -s 30 11 > $PROJECT\_HOME/gen\_query/s30-m/11.sql\
-./qgen -s 30 12 > $PROJECT\_HOME/gen\_query/s30-m/12.sql\
-./qgen -s 30 13 > $PROJECT\_HOME/gen\_query/s30-m/13.sql\
-./qgen -s 30 14 > $PROJECT\_HOME/gen\_query/s30-m/14.sql\
-./qgen -s 30 15 > $PROJECT\_HOME/gen\_query/s30-m/15.sql\
-./qgen -s 30 16 > $PROJECT\_HOME/gen\_query/s30-m/16.sql\
-./qgen -s 30 17 > $PROJECT\_HOME/gen\_query/s30-m/17.sql\
-./qgen -s 30 18 > $PROJECT\_HOME/gen\_query/s30-m/18.sql\
-./qgen -s 30 19 > $PROJECT\_HOME/gen\_query/s30-m/19.sql\
-./qgen -s 30 20 > $PROJECT\_HOME/gen\_query/s30-m/20.sql\
-./qgen -s 30 21 > $PROJECT\_HOME/gen\_query/s30-m/21.sql\
-./qgen -s 30 22 > $PROJECT\_HOME/gen\_query/s30-m/22.sql
+cd $PROJECT_HOME/dbt3-1.9/src/dbgen
+./qgen -s 30 1 > $PROJECT_HOME/gen_query/s30-m/1.sql
+./qgen -s 30 2 > $PROJECT_HOME/gen_query/s30-m/2.sql
+./qgen -s 30 3 > $PROJECT_HOME/gen_query/s30-m/3.sql
+./qgen -s 30 4 > $PROJECT_HOME/gen_query/s30-m/4.sql
+./qgen -s 30 5 > $PROJECT_HOME/gen_query/s30-m/5.sql
+./qgen -s 30 6 > $PROJECT_HOME/gen_query/s30-m/6.sql
+./qgen -s 30 7 > $PROJECT_HOME/gen_query/s30-m/7.sql
+./qgen -s 30 8 > $PROJECT_HOME/gen_query/s30-m/8.sql
+./qgen -s 30 9 > $PROJECT_HOME/gen_query/s30-m/9.sql
+./qgen -s 30 10 > $PROJECT_HOME/gen_query/s30-m/10.sql
+./qgen -s 30 11 > $PROJECT_HOME/gen_query/s30-m/11.sql
+./qgen -s 30 12 > $PROJECT_HOME/gen_query/s30-m/12.sql
+./qgen -s 30 13 > $PROJECT_HOME/gen_query/s30-m/13.sql
+./qgen -s 30 14 > $PROJECT_HOME/gen_query/s30-m/14.sql
+./qgen -s 30 15 > $PROJECT_HOME/gen_query/s30-m/15.sql
+./qgen -s 30 16 > $PROJECT_HOME/gen_query/s30-m/16.sql
+./qgen -s 30 17 > $PROJECT_HOME/gen_query/s30-m/17.sql
+./qgen -s 30 18 > $PROJECT_HOME/gen_query/s30-m/18.sql
+./qgen -s 30 19 > $PROJECT_HOME/gen_query/s30-m/19.sql
+./qgen -s 30 20 > $PROJECT_HOME/gen_query/s30-m/20.sql
+./qgen -s 30 21 > $PROJECT_HOME/gen_query/s30-m/21.sql
+./qgen -s 30 22 > $PROJECT_HOME/gen_query/s30-m/22.sql
 
 ```
 
@@ -299,28 +299,28 @@ cd $PROJECT\_HOME/dbt3-1.9/src/dbgen\
 1. Generate the explain queries
 ```
 
-./qgen -s 30 -x 1 > $PROJECT\_HOME/gen\_query/s30-m/1\_explain.sql\
-./qgen -s 30 -x 2 > $PROJECT\_HOME/gen\_query/s30-m/2\_explain.sql\
-./qgen -s 30 -x 3 > $PROJECT\_HOME/gen\_query/s30-m/3\_explain.sql\
-./qgen -s 30 -x 4 > $PROJECT\_HOME/gen\_query/s30-m/4\_explain.sql\
-./qgen -s 30 -x 5 > $PROJECT\_HOME/gen\_query/s30-m/5\_explain.sql\
-./qgen -s 30 -x 6 > $PROJECT\_HOME/gen\_query/s30-m/6\_explain.sql\
-./qgen -s 30 -x 7 > $PROJECT\_HOME/gen\_query/s30-m/7\_explain.sql\
-./qgen -s 30 -x 8 > $PROJECT\_HOME/gen\_query/s30-m/8\_explain.sql\
-./qgen -s 30 -x 9 > $PROJECT\_HOME/gen\_query/s30-m/9\_explain.sql\
-./qgen -s 30 -x 10 > $PROJECT\_HOME/gen\_query/s30-m/10\_explain.sql\
-./qgen -s 30 -x 11 > $PROJECT\_HOME/gen\_query/s30-m/11\_explain.sql\
-./qgen -s 30 -x 12 > $PROJECT\_HOME/gen\_query/s30-m/12\_explain.sql\
-./qgen -s 30 -x 13 > $PROJECT\_HOME/gen\_query/s30-m/13\_explain.sql\
-./qgen -s 30 -x 14 > $PROJECT\_HOME/gen\_query/s30-m/14\_explain.sql\
-./qgen -s 30 -x 15 > $PROJECT\_HOME/gen\_query/s30-m/15\_explain.sql\
-./qgen -s 30 -x 16 > $PROJECT\_HOME/gen\_query/s30-m/16\_explain.sql\
-./qgen -s 30 -x 17 > $PROJECT\_HOME/gen\_query/s30-m/17\_explain.sql\
-./qgen -s 30 -x 18 > $PROJECT\_HOME/gen\_query/s30-m/18\_explain.sql\
-./qgen -s 30 -x 19 > $PROJECT\_HOME/gen\_query/s30-m/19\_explain.sql\
-./qgen -s 30 -x 20 > $PROJECT\_HOME/gen\_query/s30-m/20\_explain.sql\
-./qgen -s 30 -x 21 > $PROJECT\_HOME/gen\_query/s30-m/21\_explain.sql\
-./qgen -s 30 -x 22 > $PROJECT\_HOME/gen\_query/s30-m/22\_explain.sql
+./qgen -s 30 -x 1 > $PROJECT_HOME/gen_query/s30-m/1_explain.sql
+./qgen -s 30 -x 2 > $PROJECT_HOME/gen_query/s30-m/2_explain.sql
+./qgen -s 30 -x 3 > $PROJECT_HOME/gen_query/s30-m/3_explain.sql
+./qgen -s 30 -x 4 > $PROJECT_HOME/gen_query/s30-m/4_explain.sql
+./qgen -s 30 -x 5 > $PROJECT_HOME/gen_query/s30-m/5_explain.sql
+./qgen -s 30 -x 6 > $PROJECT_HOME/gen_query/s30-m/6_explain.sql
+./qgen -s 30 -x 7 > $PROJECT_HOME/gen_query/s30-m/7_explain.sql
+./qgen -s 30 -x 8 > $PROJECT_HOME/gen_query/s30-m/8_explain.sql
+./qgen -s 30 -x 9 > $PROJECT_HOME/gen_query/s30-m/9_explain.sql
+./qgen -s 30 -x 10 > $PROJECT_HOME/gen_query/s30-m/10_explain.sql
+./qgen -s 30 -x 11 > $PROJECT_HOME/gen_query/s30-m/11_explain.sql
+./qgen -s 30 -x 12 > $PROJECT_HOME/gen_query/s30-m/12_explain.sql
+./qgen -s 30 -x 13 > $PROJECT_HOME/gen_query/s30-m/13_explain.sql
+./qgen -s 30 -x 14 > $PROJECT_HOME/gen_query/s30-m/14_explain.sql
+./qgen -s 30 -x 15 > $PROJECT_HOME/gen_query/s30-m/15_explain.sql
+./qgen -s 30 -x 16 > $PROJECT_HOME/gen_query/s30-m/16_explain.sql
+./qgen -s 30 -x 17 > $PROJECT_HOME/gen_query/s30-m/17_explain.sql
+./qgen -s 30 -x 18 > $PROJECT_HOME/gen_query/s30-m/18_explain.sql
+./qgen -s 30 -x 19 > $PROJECT_HOME/gen_query/s30-m/19_explain.sql
+./qgen -s 30 -x 20 > $PROJECT_HOME/gen_query/s30-m/20_explain.sql
+./qgen -s 30 -x 21 > $PROJECT_HOME/gen_query/s30-m/21_explain.sql
+./qgen -s 30 -x 22 > $PROJECT_HOME/gen_query/s30-m/22_explain.sql
 
 ```
 
@@ -335,7 +335,7 @@ Additional reorganization of directories is up to the user.
 1. Create a directory for the generated workload
 ```
 
-mkdir $PROJECT\_HOME/gen\_data/s30
+mkdir $PROJECT_HOME/gen_data/s30
 
 ```
 
@@ -343,7 +343,7 @@ mkdir $PROJECT\_HOME/gen\_data/s30
 1. Set the variable DSS_PATH to the folder with the generated table data. The generated workload for the test will be generated there.
 ```
 
-export DSS\_PATH=$PROJECT\_HOME/gen\_data/s30/
+export DSS_PATH=$PROJECT_HOME/gen_data/s30/
 
 ```
 
@@ -384,7 +384,7 @@ prepare the databases for the test.
 1. Unzip the archive with the following command:
 ```
 
-gunzip < mysql-5.5.x-linux2.6-x86\_64.tar.gz |tar xf -
+gunzip < mysql-5.5.x-linux2.6-x86_64.tar.gz |tar xf -
 
 ```
 
@@ -393,7 +393,7 @@ Now the server could be started with the following command:
 
 ```
 
-$PROJECT\_HOME/bin/mysql-5.5.x-linux2.6-x86\_64/bin/mysqld\_safe --datadir=some/data/dir &
+$PROJECT_HOME/bin/mysql-5.5.x-linux2.6-x86_64/bin/mysqld_safe --datadir=some/data/dir &
 
 ```
 
@@ -407,7 +407,7 @@ $PROJECT\_HOME/bin/mysql-5.5.x-linux2.6-x86\_64/bin/mysqld\_safe --datadir=some/
 1. Unzip the archive with the following command:
 ```
 
-gunzip < mysql-5.6.x-m5-linux2.6-x86\_64.tar.gz |tar xf -
+gunzip < mysql-5.6.x-m5-linux2.6-x86_64.tar.gz |tar xf -
 
 ```
 
@@ -417,7 +417,7 @@ Now the server could be started with the following command:
 
 ```
 
-$PROJECT\_HOME/bin/mysql-5.6.x-m5-linux2.6-x86\_64/bin/mysqld\_safe --datadir=some/data/dir &
+$PROJECT_HOME/bin/mysql-5.6.x-m5-linux2.6-x86_64/bin/mysqld_safe --datadir=some/data/dir &
 
 ```
 
@@ -431,7 +431,7 @@ version numbers
 1. Download with Bazaar the [mariadb 5.3](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/5.3/changes-improvements-in-mariadb-5-3) project
 ```
 
-bzr branch lp:maria/5.3\
+bzr branch lp:maria/5.3
 mv 5.3/ mariadb-5.3
 
 ```
@@ -440,7 +440,7 @@ mv 5.3/ mariadb-5.3
 1. Build MariaDB
 ```
 
-cd mariadb-5.3/\
+cd mariadb-5.3/
 ./BUILD/compile-amd64-max
 
 ```
@@ -449,7 +449,7 @@ cd mariadb-5.3/\
 1. Build a binary distribution tar.gz file
 ```
 
-./scripts/make\_binary\_distribution
+./scripts/make_binary_distribution
 
 ```
 
@@ -458,9 +458,9 @@ cd mariadb-5.3/\
  it will be used by the automation script
 ```
 
-mv mariadb-5.3.x-beta-linux-x86\_64.tar.gz $PROJECT\_HOME/bin/\
-cd $PROJECT\_HOME/bin/\
-tar -xf mariadb-5.3.x-beta-linux-x86\_64.tar.gz
+mv mariadb-5.3.x-beta-linux-x86_64.tar.gz $PROJECT_HOME/bin/
+cd $PROJECT_HOME/bin/
+tar -xf mariadb-5.3.x-beta-linux-x86_64.tar.gz
 
 ```
 
@@ -469,7 +469,7 @@ Now the server could be started with the following command:
 
 ```
 
-$PROJECT\_HOME/bin/mariadb-5.3.x-beta-linux-x86\_64/bin/mysqld\_safe --datadir=some/data/dir &
+$PROJECT_HOME/bin/mariadb-5.3.x-beta-linux-x86_64/bin/mysqld_safe --datadir=some/data/dir &
 
 ```
 
@@ -489,7 +489,7 @@ on this page.
 1. Open the file `$PROJECT_HOME/mariadb-tools/dbt3_benchmark/dbt3_mysql/make-dbt3-db_innodb.sql` and edit the values for the call of the sql commands that look like this one:
 ```
 
-LOAD DATA INFILE '/some/path/to/gen\_data/nation.tbl' into table nation fields terminated by '|';
+LOAD DATA INFILE '/some/path/to/gen_data/nation.tbl' into table nation fields terminated by '|';
 
 ```
 
@@ -502,7 +502,7 @@ LOAD DATA INFILE '/some/path/to/gen\_data/nation.tbl' into table nation fields t
  this:
 ```
 
-LOAD DATA INFILE '\~/benchmark/dbt3/gen\_data/s30/nation.tbl' into table nation fields terminated by '|';
+LOAD DATA INFILE '~/benchmark/dbt3/gen_data/s30/nation.tbl' into table nation fields terminated by '|';
 
 ```
 
@@ -510,8 +510,8 @@ LOAD DATA INFILE '\~/benchmark/dbt3/gen\_data/s30/nation.tbl' into table nation 
 1. Create an empty MySQL database into a folder that will be used for the benchmark
 ```
 
-cd $DB\_HOME\
-./scripts/mysql\_install\_db --defaults-file=$PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/config/s30/load\_mysql\_myisam\_my.cnf --basedir=$DB\_HOME --datadir=$PROJECT\_HOME/db\_data/myisam-s30/
+cd $DB_HOME
+./scripts/mysql_install_db --defaults-file=$PROJECT_HOME/mariadb-tools/dbt3_benchmark/config/s30/load_mysql_myisam_my.cnf --basedir=$DB_HOME --datadir=$PROJECT_HOME/db_data/myisam-s30/
 
 ```
 
@@ -539,7 +539,7 @@ cd $DB\_HOME\
 1. Shutdown the database server:
 ```
 
-./bin/mysqladmin --user=root --socket=$PROJECT\_HOME/temp/mysql.sock shutdown 0
+./bin/mysqladmin --user=root --socket=$PROJECT_HOME/temp/mysql.sock shutdown 0
 
 ```
 
@@ -572,10 +572,10 @@ gunzip < postgresql-9.1rc1.tar.gz |tar xf -
 1. Execute the following commands into the shell to install PostgreSQL:
 ```
 
-mkdir $PROJECT\_HOME/PostgreSQL\_bin\
-cd $PROJECT\_HOME/postgresql-9.1rc1\
-./configure --prefix=$PROJECT\_HOME/bin/PostgreSQL\_bin\
-make\
+mkdir $PROJECT_HOME/PostgreSQL_bin
+cd $PROJECT_HOME/postgresql-9.1rc1
+./configure --prefix=$PROJECT_HOME/bin/PostgreSQL_bin
+make
 make install
 
 ```
@@ -590,9 +590,9 @@ make install
 1. Prepare the database to test with:
 ```
 
-mkdir $PROJECT\_HOME/db\_data/postgre\_s30\
-cd $PROJECT\_HOME/bin/PostgreSQL\_bin\
-./bin/initdb -D $PROJECT\_HOME/db\_data/postgre\_s30
+mkdir $PROJECT_HOME/db_data/postgre_s30
+cd $PROJECT_HOME/bin/PostgreSQL_bin
+./bin/initdb -D $PROJECT_HOME/db_data/postgre_s30
 
 ```
 
@@ -600,7 +600,7 @@ cd $PROJECT\_HOME/bin/PostgreSQL\_bin\
 1. Start the server:
 ```
 
-./bin/postgres -D $PROJECT\_HOME/db\_data/postgre\_s30 -p 54322 &
+./bin/postgres -D $PROJECT_HOME/db_data/postgre_s30 -p 54322 &
 
 ```
 
@@ -608,8 +608,8 @@ cd $PROJECT\_HOME/bin/PostgreSQL\_bin\
 1. Load the dataload into the DB
 ```
 
-./bin/createdb -O {YOUR\_USERNAME} dbt3 -p 54322\
-./bin/psql -p 54322 -d dbt3 -f $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/dbt3\_mysql/make-dbt3-db\_pg.sql
+./bin/createdb -O {YOUR_USERNAME} dbt3 -p 54322
+./bin/psql -p 54322 -d dbt3 -f $PROJECT_HOME/mariadb-tools/dbt3_benchmark/dbt3_mysql/make-dbt3-db_pg.sql
 
 ```
 
@@ -623,7 +623,7 @@ cd $PROJECT\_HOME/bin/PostgreSQL\_bin\
 
 ```
 
-./bin/pg\_ctl -D $PROJECT\_HOME/db\_data/postgre\_s30/ -p 54322 stop
+./bin/pg_ctl -D $PROJECT_HOME/db_data/postgre_s30/ -p 54322 stop
 
 ```
 
@@ -675,7 +675,7 @@ To prepare the database for work follow these steps:
 1. Go to [MariaDB 5.3](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/5.3/changes-improvements-in-mariadb-5-3).x installation directory
 ```
 
-cd $PROJECT\_HOME/bin/mariadb-5.3.x-beta-linux-x86\_64
+cd $PROJECT_HOME/bin/mariadb-5.3.x-beta-linux-x86_64
 
 ```
 
@@ -684,7 +684,7 @@ cd $PROJECT\_HOME/bin/mariadb-5.3.x-beta-linux-x86\_64
 example `$PROJECT_HOME/db_data/dbt3_results_db`)
 ```
 
-./scripts/mysql\_install\_db --datadir=$PROJECT\_HOME/db\_data/dbt3\_results\_db
+./scripts/mysql_install_db --datadir=$PROJECT_HOME/db_data/dbt3_results_db
 
 ```
 
@@ -692,7 +692,7 @@ example `$PROJECT_HOME/db_data/dbt3_results_db`)
 1. Start mysqld for results db
 ```
 
-./bin/mysqld\_safe --defaults-file=$PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/config/results\_mariadb\_my.cnf --port=12340 --socket=$PROJECT\_HOME/temp/mysql\_results.sock --datadir=$PROJECT\_HOME/db\_data/dbt3\_results\_db/ &
+./bin/mysqld_safe --defaults-file=$PROJECT_HOME/mariadb-tools/dbt3_benchmark/config/results_mariadb_my.cnf --port=12340 --socket=$PROJECT_HOME/temp/mysql_results.sock --datadir=$PROJECT_HOME/db_data/dbt3_results_db/ &
 
 ```
 
@@ -700,7 +700,7 @@ example `$PROJECT_HOME/db_data/dbt3_results_db`)
 1. Install the database
 ```
 
-./bin/mysql -u root -P 12340 -S $PROJECT\_HOME/temp/mysql\_results.sock < $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/dbt3\_mysql/make-results-db.sql
+./bin/mysql -u root -P 12340 -S $PROJECT_HOME/temp/mysql_results.sock < $PROJECT_HOME/mariadb-tools/dbt3_benchmark/dbt3_mysql/make-results-db.sql
 
 ```
 
@@ -708,7 +708,7 @@ example `$PROJECT_HOME/db_data/dbt3_results_db`)
 1. Shutdown the results db server:
 ```
 
-./bin/mysqladmin --user=root --port=12340 --socket=$PROJECT\_HOME/temp/mysql\_results.sock shutdown 0
+./bin/mysqladmin --user=root --port=12340 --socket=$PROJECT_HOME/temp/mysql_results.sock shutdown 0
 
 ```
 
@@ -814,17 +814,17 @@ This file has the following format:
 
 ```
 
-\[common]\
-RESULTS\_DB\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/results\_db\_conf/results\_db.conf\
-TEST\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/test\_conf/test\_myisam.conf
+[common]
+RESULTS_DB_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/results_db_conf/results_db.conf
+TEST_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/test_conf/test_myisam.conf
 
-\[mariadb\_5\_3]\
-QUERIES\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/queries\_conf/queries.conf\
-DB\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/db\_conf/db\_mariadb\_5\_3\_myisam.conf
+[mariadb_5_3]
+QUERIES_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/queries_conf/queries.conf
+DB_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/db_conf/db_mariadb_5_3_myisam.conf
 
-\[mysql\_5\_5]\
-QUERIES\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/queries\_conf/queries\_mysql.conf\
-DB\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/db\_conf/db\_mysql\_5\_5\_myisam.conf\
+[mysql_5_5]
+QUERIES_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/queries_conf/queries_mysql.conf
+DB_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/db_conf/db_mysql_5_5_myisam.conf
 ...
 
 ```
@@ -904,8 +904,8 @@ Here is an example command that will be executed:
 
 ```
 
-unlink /path/to/datadir/mysql\
-ln -s /path/to/value/in/MYSQL\_SYSTEM\_DIR/mysql\_mariadb\_5\_3 /path/to/datadir/mysql
+unlink /path/to/datadir/mysql
+ln -s /path/to/value/in/MYSQL_SYSTEM_DIR/mysql_mariadb_5_3 /path/to/datadir/mysql
 
 ```
 
@@ -917,9 +917,9 @@ The configuration file looks like this:
 
 ```
 
-\[db\_settings]\
-DBMS\_HOME = $PROJECT\_HOME/bin/mariadb-5.3.2-beta-linux-x86\_64\
-DBMS\_USER = root\
+[db_settings]
+DBMS_HOME = $PROJECT_HOME/bin/mariadb-5.3.2-beta-linux-x86_64
+DBMS_USER = root
 ...
 
 ```
@@ -969,9 +969,9 @@ The configuration file looks like this:
 
 ```
 
-QUERIES\_AT\_ONCE = 0\
-CLEAR\_CACHES = 1\
-WARMUP = 0\
+QUERIES_AT_ONCE = 0
+CLEAR_CACHES = 1
+WARMUP = 0
 ...
 
 ```
@@ -1020,18 +1020,18 @@ The queries configuration file could look like this:
 
 ```
 
-\[queries\_settings]\
-QUERIES\_HOME = /path/to/queries
+[queries_settings]
+QUERIES_HOME = /path/to/queries
 
-\[query1]\
-QUERY=1.sql\
-EXPLAIN\_QUERY=1\_explain.sql\
-STARTUP\_PARAMS=
+[query1]
+QUERY=1.sql
+EXPLAIN_QUERY=1_explain.sql
+STARTUP_PARAMS=
 
-\[query2]\
-QUERY=2.sql\
-EXPLAIN\_QUERY=2\_explain.sql\
-STARTUP\_PARAMS=--optimizer\_switch='mrr=on' --mrr\_buffer\_size=8M --some\_startup\_parmas\
+[query2]
+QUERY=2.sql
+EXPLAIN_QUERY=2_explain.sql
+STARTUP_PARAMS=--optimizer_switch='mrr=on' --mrr_buffer_size=8M --some_startup_parmas
 ...
 
 ```
@@ -1078,8 +1078,8 @@ The results database configuration could look like this:
 
 ```
 
-DBMS\_HOME = $PROJECT\_HOME/mariadb-5.3.x-beta-linux-x86\_64\
-DBMS\_USER = root\
+DBMS_HOME = $PROJECT_HOME/mariadb-5.3.x-beta-linux-x86_64
+DBMS_USER = root
 ...
 
 ```
@@ -1339,7 +1339,7 @@ Here are the main activities that this script does:
  command:
 ```
 
-sudo /sbin/sysctl vm.drop\_caches=3
+sudo /sbin/sysctl vm.drop_caches=3
 
 ```
 
@@ -1350,7 +1350,7 @@ sudo /sbin/sysctl vm.drop\_caches=3
  command):
 ```
 
-{your\_username} ALL=NOPASSWD:/sbin/sysctl
+{your_username} ALL=NOPASSWD:/sbin/sysctl
 
 ```
   1. Start the database server
@@ -1439,14 +1439,14 @@ sar -r 0 2>null
 * Example call for MyISAM test for scale factor 30 and timeout 10 minutes:
 ```
 
-perl launcher.pl\
-\--project-home=/path/to/project/home/\
-\--results-output-dir=/path/to/project/home/results/myisam\_test\
-\--datadir=/path/to/project/home/db\_data/\
-\--test=/path/to/project/home/mariadb-tools/dbt3\_benchmark/tests/myisam\_test\_mariadb\_5\_3\_mysql\_5\_5\_mysql\_5\_6.conf\
-\--queries-home=/path/to/project/home/gen\_query/\
-\--scale-factor=30\
-\--TIMEOUT=600
+perl launcher.pl \
+--project-home=/path/to/project/home/ \
+--results-output-dir=/path/to/project/home/results/myisam_test \
+--datadir=/path/to/project/home/db_data/ \
+--test=/path/to/project/home/mariadb-tools/dbt3_benchmark/tests/myisam_test_mariadb_5_3_mysql_5_5_mysql_5_6.conf \
+--queries-home=/path/to/project/home/gen_query/ \
+--scale-factor=30 \
+--TIMEOUT=600
 
 ```
 
@@ -1465,15 +1465,15 @@ configuration file to 10 minutes.
  and 3 runs for each query:
 ```
 
-perl launcher.pl\
-\--project-home=/path/to/project/home/\
-\--results-output-dir=/path/to/project/home/results/innodb\_test\
-\--datadir=/path/to/project/home/db\_data/\
-\--test=/path/to/project/home/mariadb-tools/dbt3\_benchmark/tests/innodb\_test\_mariadb\_5\_3\_mysql\_5\_5\_mysql\_5\_6.conf\
-\--queries-home=/path/to/project/home/gen\_query/\
-\--scale-factor=30\
-\--TIMEOUT=7200\
-\--NUM\_TESTS=3
+perl launcher.pl \
+--project-home=/path/to/project/home/ \
+--results-output-dir=/path/to/project/home/results/innodb_test \
+--datadir=/path/to/project/home/db_data/ \
+--test=/path/to/project/home/mariadb-tools/dbt3_benchmark/tests/innodb_test_mariadb_5_3_mysql_5_5_mysql_5_6.conf \
+--queries-home=/path/to/project/home/gen_query/ \
+--scale-factor=30 \
+--TIMEOUT=7200 \
+--NUM_TESTS=3
 
 ```
 
@@ -1497,9 +1497,9 @@ perl launcher.pl\
  and add the new configuration settings:
 ```
 
-\[mariadb\_5\_3\_new\_configuration]\
-QUERIES\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/queries\_conf/queries-mariadb.conf\
-DB\_CONFIG = $PROJECT\_HOME/mariadb-tools/dbt3\_benchmark/tests/db\_conf/db\_mariadb\_5\_3\_myisam\_new\_configuration.conf
+[mariadb_5_3_new_configuration]
+QUERIES_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/queries_conf/queries-mariadb.conf
+DB_CONFIG = $PROJECT_HOME/mariadb-tools/dbt3_benchmark/tests/db_conf/db_mariadb_5_3_myisam_new_configuration.conf
 
 ```
 
@@ -1566,4 +1566,3 @@ Results page: (TODO)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
-```

--- a/server/reference/sql-statements/account-management-sql-statements/grant.md
+++ b/server/reference/sql-statements/account-management-sql-statements/grant.md
@@ -361,7 +361,7 @@ The `READ_ONLY ADMIN` privilege is included in [SUPER](grant.md#super).
 {% endtab %}
 
 {% tab title="< 10.5" %}
-`READ\_ONLY ADMIN` isn't available.
+`READ_ONLY ADMIN` isn't available.
 {% endtab %}
 {% endtabs %}
 

--- a/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status.md
+++ b/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status.md
@@ -257,7 +257,7 @@ Additional behavior to be aware of:
 {% endtab %}
 
 {% tab title="< 12.0" %}
-**Connects\_Tried:** and **Master\_Retry\_Count:** are not available. If the Performance Schema is enabled, [`replication\_connection\_configuration`](../../../system-tables/performance-schema/performance-schema-tables/performance-schema-replication_connection_configuration-table.md) has `CONNECTION_RETRY_COUNT` available as an older alternative to `Master_Retry_Count`.
+**Connects\_Tried:** and **Master\_Retry\_Count:** are not available. If the Performance Schema is enabled, [`replication_connection_configuration`](../../../system-tables/performance-schema/performance-schema-tables/performance-schema-replication_connection_configuration-table.md) has `CONNECTION_RETRY_COUNT` available as an older alternative to `Master_Retry_Count`.
 {% endtab %}
 {% endtabs %}
 

--- a/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/adding-plugins-to-the-mariadb-docker-official-image.md
+++ b/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/adding-plugins-to-the-mariadb-docker-official-image.md
@@ -22,7 +22,7 @@ $ docker run --rm mariadb:latest ls -C /usr/lib/mysql/plugin
 
 Using the `--plugin-load-add` flag with the plugin name (can be repeated), the plugins will be loaded and ready when the container is started:
 
-For example, to enable the `simple\_password\_check` plugin:
+For example, to enable the `simple_password_check` plugin:
 
 ```bash
 $ docker run --name some-%%REPO%% -e MARIADB_ROOT_PASSWORD=my-secret-pw --network=host -d mariadb:latest --plugin-load-add=simple_password_check
@@ -47,7 +47,7 @@ Create the SQL file used in initialization:
 $ echo 'INSTALL SONAME "disks";' > my_initdb/disks.sql
 ```
 
-In this case, the `my\_initdb` is a `/docker-entrypoint-initdb.d` directory per "Initializing a fresh instance" section above.
+In this case, the `my_initdb` is a `/docker-entrypoint-initdb.d` directory per "Initializing a fresh instance" section above.
 
 ### Identifying Additional Plugins in Additional Packages
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-to-mariadb-enterprise-server-10.6.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-10.6/upgrade-to-mariadb-enterprise-server-10.6.md
@@ -73,7 +73,7 @@ If you have the [MariaDB Audit Plugin](../../../../../reference/plugins/mariadb-
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-11.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-from-mariadb-community-server-to-mariadb-enterprise-server-11.4.md
@@ -75,7 +75,7 @@ The MariaDB Enterprise Audit Plugin will automatically be installed after instal
 
 MariaDB Enterprise Server 11.4 changes the `COMPRESSED` row format to read-only. Before upgrading, modify any compressed InnoDB tables to use the `DYNAMIC` row format.
 
-1.  Use the `information\_schema.INNODB\_SYS\_TABLES` to identify any InnoDB tables that use the `COMPRESSED` row format:
+1.  Use the `information_schema.INNODB_SYS_TABLES` to identify any InnoDB tables that use the `COMPRESSED` row format:
 
     ```sql
     SELECT NAME, ROW_FORMAT
@@ -406,7 +406,7 @@ The utility is called [mariadb-upgrade](../../../../../clients-and-utilities/dep
 $ sudo mariadb-upgrade
 ```
 
-And the utility is called `mysql\_upgrade` in MariaDB Enterprise Server 10.3 and 10.2:
+And the utility is called `mysql_upgrade` in MariaDB Enterprise Server 10.3 and 10.2:
 
 ```bash
 $ sudo mysql_upgrade

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-to-mariadb-enterprise-server-11.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-to-mariadb-enterprise-server-11.4.md
@@ -72,7 +72,7 @@ If you have the [MariaDB Audit Plugin](../../../../../reference/plugins/mariadb-
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-to-mariadb-enterprise-server-11.8.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.8/upgrade-to-mariadb-enterprise-server-11.8.md
@@ -51,7 +51,7 @@ If you have the [MariaDB Audit Plugin](../../../../../reference/plugins/mariadb-
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The MariaDB Enterprise Audit Plugin will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The MariaDB Enterprise Audit Plugin will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.3.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.3.md
@@ -44,7 +44,7 @@ If you have the [MariaDB Audit Plugin](../../../../reference/plugins/mariadb-aud
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.4.md
@@ -44,7 +44,7 @@ If you have the [MariaDB Audit Plugin](../../../../reference/plugins/mariadb-aud
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.5.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.5.md
@@ -44,7 +44,7 @@ If you have the [MariaDB Audit Plugin](../../../../reference/plugins/mariadb-aud
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.6.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-10.6.md
@@ -44,7 +44,7 @@ If you have the [MariaDB Audit Plugin](../../../../reference/plugins/mariadb-aud
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-11.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-11.4.md
@@ -44,7 +44,7 @@ If you have the [MariaDB Audit Plugin](../../../../reference/plugins/mariadb-aud
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-11.8.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrading-to-mariadb-enterprise-server/upgrade-to-mariadb-enterprise-server-11.8.md
@@ -44,7 +44,7 @@ If you have the [MariaDB Audit Plugin](../../../../reference/plugins/mariadb-aud
 UNINSTALL SONAME 'server_audit';
 ```
 
-And if you load the plugin in a configuration file using the `plugin\_load\_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
+And if you load the plugin in a configuration file using the `plugin_load_add` option, then the option should also be removed. The [MariaDB Enterprise Audit Plugin](../../../../reference/plugins/mariadb-enterprise-audit.md) will automatically be installed after installing MariaDB Enterprise Server 10.4 or later.
 
 ## Uninstall the Old Version <a href="#uninstall-the-old-version" id="uninstall-the-old-version"></a>
 


### PR DESCRIPTION
Fixes [DOCS-6523](https://mariadbcorp.atlassian.net/browse/DOCS-6523). Sibling of #990 (DOCS-6543) — same escaping debris, different location.

Escaping a Markdown metacharacter does nothing inside a code fence or an inline code span: the backslash is not consumed, it is published. Readers see `SELECT JSON\_REMOVE(@json, '$.A\[last]')`, and anyone who copies the sample gets a syntax error. Nothing in CI sees it.

## Most of the ticket's inventory was legitimate content

The ticket listed 178 lines in 13 files. Four of those were a scanner artifact — the Cloud page's hits are prose under a ```` fence, not fenced content — leaving **174 lines in 12 files**. Of those, **160 in 4 files were debris**. The other 14 are real, and a regex sweep would have broken them:

| Page | Why the backslash stays |
|---|---|
| `mariadb-install-db.md` | `Db: test\_%` is the literal value in `mysql.db` — confirmed against a live server |
| `syntax-differences-...-sql-server.md`, `set-character-set.md` | `'wp\_%'` / `'character_set\_%'` escape the LIKE wildcard. Both run; `set-character-set` returns exactly the row set the page shows |
| `regexp.md` | `'new\\*.\\*line'` is correct SQL string escaping. Run: returns `0`, which is what the page states |
| `installing-mariadb-alongside-mysql.md` | `\_` is the branch character in `ps --forest` output |
| `connect-table-types-special-virtual-tables.md`, `cookbook-multi-repo-workspace.md` | Windows paths (`..\*.cc`, `$DocsRepo\.claude\commands\*.md`) |
| `troubleshooting-row-size-too-large-...md` | `"^\*"` is an egrep pattern inside a shell script |
| `maxscale-troubleshooting.md` | `my\_database` is the *point* of the "bad vs good" GRANT pair |
| `mroonga_escape.md` | The function's own output. Left alone — Mroonga isn't installed here, so I can't verify it |

## Two of the three big files were not an escaping bug at all

**`mariadb-1001-changelog.md`** — a stray opening fence at line 559 and a stray closing one at 927 **inverted every block after them**. 295 lines of revision list rendered as a code block, with literal backslashes and literal Markdown links, while the two quoted commit messages rendered as collapsed one-paragraph prose. Confirmed by fetching the live page: it contains `set\_statistics\_for\_table` and `JOIN\_TAB`, and `revno: 3768.1.1 committer: Christopher Powers …` all on one line. Deleting the two strays fixes all 47 flagged lines at once; the two commit-message blocks are then de-escaped, because they are now genuinely code.

**`dbt3-automation-scripts.md`** — an unclosed fence after the licence footer, plus 130 lines of `\_`, `\[`, `\~` and `\--` inside real shell and INI samples. The **trailing** backslash on those lines is a migration hard break, not a shell continuation: every line but the last of each paragraph carries one, `.conf` file contents included. The two `perl launcher.pl` blocks are the genuine exception and now use a proper ` \` continuation, which they did not have before (`launcher.pl\` with no space would have concatenated the next option onto the command name).

## Inline code spans — the same defect, not in the ticket

A code span is as literal as a fence, so `` `plugin\_load\_add` `` publishes the backslash too. **54 spans in 27 files; 47 fixed.** This needed a Markdown-correct scan rather than a regex: `` \`x\` `` in prose is an *escaped backtick*, not a code span, and a naive pattern reports 76 with 22 false positives.

Left alone deliberately: `` `\_` `` in the mariadb-client skill (the client's prompt escape for a space), `` `\_` `` in `show-variables.md` (the page is explaining LIKE escaping), and `pdf/README.md` (it documents this bug).

## Drive-by fixes

- `maxscale-configuration-guide.md:2070` said a grant "is read as" the *same* escaped string it started from. The whole point is that the escape is stripped
- `authentication-modules.md:67` — one wildcard-grant sentence with lost spaces and unbalanced backticks, so it ran words together and leaked backticks into the text
- `10.6.8-4.md:209` — a bulk auto-linker had put a Markdown link *inside* a code span, breaking the Windows path in a quoted installer error message
- `mariadb-connector-net-guide.md` — the `xml` block never closed, so section (c) and the `bash` sample were swallowed into it
- `binarylog-backup-examples.md` — a ```bash block wrapped in a ```` block, so the first line of the rendered code was literally "```bash". Mechanical only; the Cloud pages are Tauseef's and Daria's

## Verification

- Fence scan: 174 → 14 lines, and every remaining one is in the table above
- Span scan: 54 → 5, and every remaining one is deliberate
- Fence-balance scan repo-wide: the only remaining odd-count files are `mariadb-cloud/SUMMARY.md` (a GitBook OpenAPI block, correct) and `.claude/skills/gitbook-canonical/SKILL.md` (it documents fences)
- `doc-lint.sh <the 28 changed files>` → clean, codespell and lychee both ran
- Live-server checks for the four SQL cases, live-page fetch for the changelog

[DOCS-6523]: https://mariadbcorp.atlassian.net/browse/DOCS-6523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ