### PR TITLE
DOCS-6556 Document all three query_cache_type values

### DIFF
--- a/agent-skills/granular/statements/mariadb-select/SKILL.md
+++ b/agent-skills/granular/statements/mariadb-select/SKILL.md
@@ -23,7 +23,7 @@ This skill covers the **delta between standard SQL `SELECT` and MariaDB's**. It 
 | Worrying about a long query running forever | Either `SELECT /*+ MAX_EXECUTION_TIME(5000) */ …` (since 12.0) or `SET STATEMENT max_statement_time = 5 FOR SELECT …` (older) — both bound the statement at the server level |
 | Unbounded `SELECT` that might scan too much during exploration | `LIMIT 1000 ROWS EXAMINED 100000` — caps both rows returned *and* rows examined (a MariaDB-specific safety net not in standard SQL) |
 | `JOIN_PREFIX(t1, t2)` written as an old-style optimizer hint | The join-order hints (`JOIN_PREFIX`, `JOIN_ORDER`, `JOIN_FIXED_ORDER`, `JOIN_SUFFIX`) are *only* valid inside the `/*+ … */` hint comment syntax (since 12.0). The legacy hint keywords (`STRAIGHT_JOIN`, `HIGH_PRIORITY`, etc.) sit between `SELECT` and the column list and don't use the `/*+ */` form |
-| `SQL_CACHE` / `SQL_NO_CACHE` hints | The query cache is **off by default** (`query_cache_type=0`) and is generally counter-productive on modern InnoDB workloads (high write concurrency invalidates cached entries constantly). Drop these hints from generated SQL unless the user has explicitly enabled the cache and is on a read-mostly workload |
+| `SQL_CACHE` / `SQL_NO_CACHE` hints | The query cache is **off by default** (`query_cache_type=OFF`) and is generally counter-productive on modern InnoDB workloads (high write concurrency invalidates cached entries constantly). Drop these hints from generated SQL unless the user has explicitly enabled the cache and is on a read-mostly workload |
 
 ## Optimizer Hints
 

--- a/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/query-cache.md
+++ b/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/query-cache.md
@@ -28,11 +28,13 @@ SHOW VARIABLES LIKE 'have_query_cache';
 
 If this is set to `NO`, you cannot enable the query cache unless you rebuild or reinstall a version of MariaDB with the cache available.
 
-To see if the cache is enabled, view the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) server variable. It is disabled by default — enable it by setting `query_cache_type` to `1` :
+To see if the cache is enabled, view the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) server variable. It is disabled by default — enable it by setting `query_cache_type` to `ON`:
 
 ```sql
-SET GLOBAL query_cache_type = 1;
+SET GLOBAL query_cache_type = ON;
 ```
+
+`ON` is one of three values the variable accepts. See [Query Cache Types](query-cache.md#query-cache-types) below for all of them, and for the difference between the global and the session value.
 
 The [query\_cache\_size](../system-variables/server-system-variables.md#query_cache_size) is set to 1MB by default. Set the cache to a larger size if needed, for example:
 
@@ -43,6 +45,72 @@ SET GLOBAL query_cache_size = 2000000;
 The `query_cache_type` is automatically set to `ON` if the server is started with the `query_cache_size` set to a non-zero (and non-default) value.
 
 See [Limiting the size of the Query Cache](query-cache.md#limiting-the-size-of-the-query-cache) below for details.
+
+## Query Cache Types
+
+The [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) server variable takes three values. Each can be given by name or by the equivalent number, so `SET GLOBAL query_cache_type = ON` and `SET GLOBAL query_cache_type = 1` are the same statement. The name is what gets reported back:
+
+| Value    | Number | Behavior                                                                                                                                                                                              |
+| -------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OFF`    | `0`    | Results are neither stored in nor retrieved from the query cache. This is the default.                                                                                                                 |
+| `ON`     | `1`    | Every cacheable query is stored and retrieved, except one that specifies [SQL\_NO\_CACHE](query-cache.md#sql_no_cache-and-sql_cache).                                                                   |
+| `DEMAND` | `2`    | Only a query that specifies [SQL\_CACHE](query-cache.md#sql_no_cache-and-sql_cache) is stored and retrieved. Every other query bypasses the cache.                                                      |
+
+Any other value is rejected:
+
+```sql
+SET GLOBAL query_cache_type = 3;
+ERROR 1231 (42000): Variable 'query_cache_type' can't be set to the value of '3'
+```
+
+`ON` and `DEMAND` both still require memory to store results in. If [query\_cache\_size](../system-variables/server-system-variables.md#query_cache_size) is `0`, setting `query_cache_type` to `ON` or `DEMAND` is accepted without error but nothing is cached.
+
+See [Queries Stored in the Query Cache](query-cache.md#queries-stored-in-the-query-cache) for the conditions a query must meet to be cacheable at all.
+
+### Global and Session Values
+
+`query_cache_type` has both a global and a session value, and it is the **session** value that decides how a given connection uses the cache. A connection inherits the global value when it opens, so `SET GLOBAL` on its own affects only connections opened afterwards:
+
+```sql
+SELECT @@global.query_cache_type, @@session.query_cache_type;
++---------------------------+----------------------------+
+| @@global.query_cache_type | @@session.query_cache_type |
++---------------------------+----------------------------+
+| ON                        | ON                         |
++---------------------------+----------------------------+
+
+SET GLOBAL query_cache_type = DEMAND;
+
+SELECT @@global.query_cache_type, @@session.query_cache_type;
++---------------------------+----------------------------+
+| @@global.query_cache_type | @@session.query_cache_type |
++---------------------------+----------------------------+
+| DEMAND                    | ON                         |
++---------------------------+----------------------------+
+```
+
+Set both to change the current connection as well:
+
+```sql
+SET GLOBAL query_cache_type = DEMAND;
+SET SESSION query_cache_type = DEMAND;
+```
+
+A session can move between `ON` and `DEMAND` as it likes, and can always set its own value to `OFF` to opt out of a cache that is enabled globally. It cannot opt *in* while the cache is globally disabled:
+
+```sql
+SET SESSION query_cache_type = ON;
+ERROR 1925 (HY000): Query cache is globally disabled and you can't enable it only for this session
+```
+
+A session set to `OFF` neither stores results nor reads results stored by other sessions, and `SQL_CACHE` in a query does not override it.
+
+`query_cache_type` is one of the variables that cannot be set for the duration of a single statement with [SET STATEMENT](../../../reference/sql-statements/administrative-sql-statements/set-commands/set-statement.md):
+
+```sql
+SET STATEMENT query_cache_type = OFF FOR SELECT 1;
+ERROR 1971 (42000): The system variable query_cache_type cannot be set in SET STATEMENT.
+```
 
 ## How the Query Cache Works
 
@@ -88,7 +156,7 @@ When using `query_cache_type=DEMAND` and the query specifies `SQL_CACHE`, the se
 
 ## Queries Stored in the Query Cache
 
-If the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable is set to `1`, or `ON`, all queries fitting the size constraints will be stored in the cache unless they contain a `SQL_NO_CACHE` clause, or are of a nature that caching makes no sense, for example making use of a function that returns the current time. Queries with `SQL_NO_CACHE` will not attempt to acquire query cache lock.
+If the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable is set to `ON`, all queries fitting the size constraints will be stored in the cache unless they contain a `SQL_NO_CACHE` clause, or are of a nature that caching makes no sense, for example making use of a function that returns the current time. Queries with `SQL_NO_CACHE` will not attempt to acquire query cache lock.
 
 If any of the following functions are present in a query, it will not be cached. Queries with these functions are sometimes called 'non-deterministic' — don't get confused with the use of this term in other contexts.
 
@@ -129,7 +197,7 @@ A query will also not be added to the cache if:
 
 The query itself can also specify that it is not to be stored in the cache by using the `SQL_NO_CACHE` attribute. Query-level control is an effective way to use the cache more optimally.
 
-It is also possible to specify that _no_ queries must be stored in the cache unless the query requires it. To do this, the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) server variable must be set to `2`, or `DEMAND`. Then, only queries with the `SQL_CACHE` attribute are cached.
+It is also possible to specify that _no_ queries must be stored in the cache unless the query requires it. To do this, the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) server variable must be set to `DEMAND`. Then, only queries with the `SQL_CACHE` attribute are cached.
 
 ## Limiting the Size of the Query Cache
 
@@ -233,11 +301,11 @@ SHOW STATUS LIKE 'Qcache%';
 +-------------------------+----------+
 ```
 
-## Emptying and disabling the Query Cache
+## Emptying and Disabling the Query Cache
 
 To empty or clear all results from the query cache, use [RESET QUERY CACHE](../../../reference/sql-statements/administrative-sql-statements/reset.md). [FLUSH TABLES](../../../reference/sql-statements/administrative-sql-statements/flush-commands/flush.md) will have the same effect.
 
-Setting either [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) or [query\_cache\_size](../system-variables/server-system-variables.md#query_cache_size) to `0` will disable the query cache, but to free up the most resources, set both to `0` when you wish to disable caching.
+Setting [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) to `OFF`, or [query\_cache\_size](../system-variables/server-system-variables.md#query_cache_size) to `0`, will disable the query cache. To free up the most resources, set both when you wish to disable caching.
 
 ## Limitations
 
@@ -407,7 +475,7 @@ When two processes execute the same query, only the last process stores the quer
 
 There are two aspects to the query cache: placing a query in the cache, and retrieving it from the cache.
 
-1. Adding a query to the query cache. This is done automatically for cacheable queries (see ([Queries Stored in the Query Cache](query-cache.md#queries-stored-in-the-query-cache)) when the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable is set to `1`, or `ON` and the query contains no `SQL_NO_CACHE` clause, or when the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable is set to `2`, or `DEMAND`, and the query contains the `SQL_CACHE` clause.
+1. Adding a query to the query cache. This is done automatically for cacheable queries (see ([Queries Stored in the Query Cache](query-cache.md#queries-stored-in-the-query-cache)) when the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable is set to `ON` and the query contains no `SQL_NO_CACHE` clause, or when the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable is set to `DEMAND`, and the query contains the `SQL_CACHE` clause.
 2. Retrieving a query from the cache. This is done after the server receives the query and before the query parser. In this case one point should be considered:
 
 When using `SQL_NO_CACHE`, it should be after the first `SELECT` hint:

--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/select-modifier-hints.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/select-modifier-hints.md
@@ -12,7 +12,7 @@ description: >-
 
 ## SQL\_CACHE / SQL\_NO\_CACHE
 
-If the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable is set to 2 or `DEMAND`, and the current statement is cacheable, `SQL_CACHE` causes the query to be cached and `SQL_NO_CACHE` causes the query not to be cached. For `UNION`s, `SQL_CACHE` or `SQL_NO_CACHE` should be specified for the first query. See also [The Query Cache](../buffers-caches-and-threads/query-cache.md) for more detail and a list of the types of statements that aren't cacheable.
+`SQL_CACHE` and `SQL_NO_CACHE` control whether a cacheable statement uses the [query cache](../buffers-caches-and-threads/query-cache.md), and which of them applies depends on the [query\_cache\_type](../system-variables/server-system-variables.md#query_cache_type) system variable. When `query_cache_type` is `ON`, `SQL_NO_CACHE` keeps the query out of the cache. When it is `DEMAND`, `SQL_CACHE` is what puts the query in, and every other query bypasses the cache. Neither modifier has any effect when `query_cache_type` is `OFF`. For `UNION`s, `SQL_CACHE` or `SQL_NO_CACHE` should be specified for the first query. See also [The Query Cache](../buffers-caches-and-threads/query-cache.md) for more detail and a list of the types of statements that aren't cacheable.
 
 ## SQL\_BUFFER\_RESULT
 

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -2241,7 +2241,7 @@ MariaDB sets the limit with [setrlimit](https://linux.die.net/man/2/setrlimit). 
 
 #### `query_cache_type`
 
-* Description: If set to `0`, the [query cache](../buffers-caches-and-threads/query-cache.md) is disabled (although a buffer of [query\_cache\_size](server-system-variables.md#query_cache_size) bytes is still allocated). If set to `1` all SELECT queries will be cached unless SQL\_NO\_CACHE is specified. If set to `2` (or `DEMAND`), only queries with the SQL CACHE clause will be cached. Note that if the server is started with the query cache disabled, it cannot be enabled at runtime.
+* Description: Determines how the [query cache](../buffers-caches-and-threads/query-cache.md) is used. `OFF` disables it, although a buffer of [query\_cache\_size](server-system-variables.md#query_cache_size) bytes is still allocated. `ON` caches every cacheable `SELECT` unless it specifies `SQL_NO_CACHE`. `DEMAND` caches only a `SELECT` that specifies `SQL_CACHE`. The equivalent numbers `0`, `1` and `2` can be given in place of the names. It is the session value that determines how a connection uses the cache: a session can always set its own value to `OFF`, but cannot enable the cache for itself while the global value is `OFF`. The query cache can be enabled at runtime even when the server was started with `query_cache_type=OFF`, as long as [query\_cache\_size](server-system-variables.md#query_cache_size) is not `0`. See [Query Cache Types](../buffers-caches-and-threads/query-cache.md#query-cache-types) for details.
 
 **Warning:** Starting from [MariaDB 10.1.7](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.7), query\_cache\_type is automatically set to ON if the server is started with the [query\_cache\_size](server-system-variables.md#query_cache_size) set to a non-zero (and non-default) value. This will happen even if [query\_cache\_type](server-system-variables.md#query_cache_type) is explicitly set to OFF in the configuration.
 
@@ -2250,7 +2250,7 @@ MariaDB sets the limit with [setrlimit](https://linux.die.net/man/2/setrlimit). 
 * Dynamic: Yes
 * Data Type: `enumeration`
 * Default Value: `OFF`
-* Valid Values: `0` or `OFF`, `1` or `ON`, `2` or `DEMAND`
+* Valid Values: `OFF` or `0`, `ON` or `1`, `DEMAND` or `2`
 
 #### `query_cache_wlock_invalidate`
 


### PR DESCRIPTION
Closes [DOCS-6556](https://mariadbcorp.atlassian.net/browse/DOCS-6556), requested by Monty in `#docs-talk`:

> Please update mariadb.com/docs/…/query-cache with all the options for the query_cache_type variable (and changes query_cache_type=1 -> query_cache_type= ON | DEMAND

## What was wrong

The [Query Cache](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/query-cache) page told the reader to enable the cache with `SET GLOBAL query_cache_type = 1` and mentioned the other values only in passing, as "`2`, or `DEMAND`", in two separate places. The three values were never listed together anywhere, and `OFF` was never named at all — the page says "setting either `query_cache_type` or `query_cache_size` to `0`", but `0` is not what `query_cache_type` ever reports.

## What this changes

A new **Query Cache Types** section on the Query Cache page with all three values, their numeric equivalents, and what each does. Every numeric reference on the page is now a name.

The section also documents behavior the page never covered, all of it executed on 12.3.3:

* **`query_cache_type` is a session variable**, and it is the session value that decides how a connection uses the cache. `SET GLOBAL` alone does not change the connection that issues it — a genuine foot-gun, since the obvious way to turn the cache on appears to do nothing in the session you typed it in.
* A session can always set itself to `OFF`, but **cannot enable the cache for itself while the global value is `OFF`** (`ERROR 1925`).
* A session set to `OFF` neither stores results nor reads results other sessions cached, and `SQL_CACHE` does not override it.
* `query_cache_type` cannot be used with `SET STATEMENT` (`ERROR 1971`).
* `ON` or `DEMAND` with `query_cache_size = 0` is accepted without error and caches nothing.

## The system-variable entry (second commit)

The `query_cache_type` entry in Server System Variables had the same numbers-first problem, plus a factual error: *"Note that if the server is started with the query cache disabled, it cannot be enabled at runtime."*

That is MySQL's behavior, not MariaDB's. `Query_cache::init()` does mark the cache `DISABLED` for the life of the server when `query_cache_type` is `0` at startup — and its comment says exactly that — but the sysvar update hook undoes it: `fix_query_cache_type()` calls `fix_query_cache_size()` → `Query_cache::resize()`, and `resize()` sets `m_cache_status` back to `OK` whenever the size is non-zero and the type is not `OFF` (`sql/sql_cache.cc:1340-1345`, `sql/sys_vars.cc:3569-3584`, at `5818146a1d0`).

Confirmed live on 12.3.3, a server started with the default `query_cache_type=OFF`: `SET GLOBAL query_cache_type=ON` is accepted, and `Qcache_inserts` and `Qcache_hits` both advance on a repeated `SELECT`. The entry now states the correct behavior with the `query_cache_size` proviso.

The 10.1.7 warning below it — `query_cache_type` is forced to `ON` when `query_cache_size` is set to a non-zero *and non-default* value — was checked and is accurate: `sql/mysqld.cc:5065-5070` guards on `!IS_SYSVAR_AUTOSIZE(&query_cache_size)`, and that macro treats a compile-time default as auto-set, which is why the default 1M does not trigger it.

## Drive-by fixes

* **`select-modifier-hints.md`** said `SQL_CACHE` and `SQL_NO_CACHE` both depend on `query_cache_type` being `DEMAND`. `SQL_NO_CACHE` is the one that matters under `ON`; under `DEMAND` it is a no-op, and under `OFF` neither modifier applies. Rewritten as the three-way rule.
* Heading `Emptying and disabling the Query Cache` → Title Case.
* `mariadb-select/SKILL.md`: `query_cache_type=0` → `OFF`.

## Verification

* Every code block and error message in the new section was executed against the local 12.3.3 server; the caching claims were checked by `Qcache_inserts` / `Qcache_hits` / `Qcache_queries_in_cache` deltas across `ON`, `DEMAND` and `OFF`, with `SQL_CACHE` and `SQL_NO_CACHE`, and across two connections for the cross-session case.
* `doc-lint.sh` clean on all four files (its fail path probed separately, since it is silent on success).
* `fragcheck.py new origin/main`: no new dead heading anchors (20 pre-existing, unchanged) and no stolen ids, which covers the renamed heading and the new `#query-cache-types` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6556]: https://mariadbcorp.atlassian.net/browse/DOCS-6556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ