### PR TITLE
DOCS-6552 Add OpenSUSE Leap 15.6 deprecation notices to the 2026Q2 Community Server release notes

### DIFF
--- a/release-notes/community-server/10.11/10.11.18.md
+++ b/release-notes/community-server/10.11/10.11.18.md
@@ -38,7 +38,7 @@ MariaDB 10.11.18 is a [Stable (GA)](../about/release-criteria.md) **corrective r
 
 ### General
 
-* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 10.11](what-is-mariadb-1011.md) for Fedora 42
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 10.11](what-is-mariadb-1011.md) for OpenSUSE Leap 15.6 and Fedora 42
 
 ### Security
 

--- a/release-notes/community-server/11.4/11.4.12.md
+++ b/release-notes/community-server/11.4/11.4.12.md
@@ -38,7 +38,7 @@ MariaDB 11.4.12 is a [Stable (GA)](../about/release-criteria.md) **corrective re
 
 ### General
 
-* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 11.4](what-is-mariadb-114.md) for Ubuntu 25.04 "Plucky Puffin" and Fedora 42
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 11.4](what-is-mariadb-114.md) for OpenSUSE Leap 15.6, Ubuntu 25.04 "Plucky Puffin", and Fedora 42
 
 ### Security
 

--- a/release-notes/community-server/11.8/11.8.8.md
+++ b/release-notes/community-server/11.8/11.8.8.md
@@ -36,7 +36,7 @@ MariaDB 11.8.8 is a [Stable (GA)](../about/release-criteria.md) **corrective rel
 
 ### General
 
-* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 11.8](what-is-mariadb-118.md) for Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 11.8](what-is-mariadb-118.md) for OpenSUSE Leap 15.6, Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42
 
 ### Security
 

--- a/release-notes/community-server/12.3/12.3.2.md
+++ b/release-notes/community-server/12.3/12.3.2.md
@@ -69,7 +69,7 @@ Thanks, and enjoy MariaDB!
 
 ### General
 
-* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 12.3](mariadb-12.3-changes-and-improvements.md) for Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 12.3](mariadb-12.3-changes-and-improvements.md) for OpenSUSE Leap 15.6, Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42
 
 ### Security
 

--- a/release-notes/community-server/13.0/13.0.1.md
+++ b/release-notes/community-server/13.0/13.0.1.md
@@ -43,6 +43,10 @@ Thanks, and enjoy MariaDB!
 * [`binlog_row_event_max_size`](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#binlog_row_event_max_size) default value was increased to 64k ([MDEV-37608](https://jira.mariadb.org/browse/MDEV-37608))
 * [`default_master_connection`](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-and-binary-log-system-variables#default_master_connection) can now be set on global level ([MDEV-9247](https://jira.mariadb.org/browse/MDEV-9247))
 
+### General
+
+* As per the [MariaDB Deprecation Policy](../about/platform-deprecation-policy.md), this will be the last release of [MariaDB 13.0](mariadb-13.0-changes-and-improvements.md) for OpenSUSE Leap 15.6, Ubuntu 25.10 "Questing Quokka", Ubuntu 25.04 "Plucky Puffin", and Fedora 42
+
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formid="4316" formId="4316" %}


### PR DESCRIPTION
Closes [DOCS-6552](https://mariadbcorp.atlassian.net/browse/DOCS-6552).

The 2026Q2 Community Server release notes omitted **OpenSUSE Leap 15.6** from their platform-deprecation bullets, even though those releases were the last to ship Leap 15.6 packages. `13.0.1` was the larger gap — the policy page lists it as final for four platforms and its notes announced none of them.

## Changes

| Page | Change |
|---|---|
| `10.11/10.11.18.md:41` | Leap 15.6 added → `for OpenSUSE Leap 15.6 and Fedora 42` |
| `11.4/11.4.12.md:41` | Leap 15.6 added (list reaches three items, so it gains the Oxford comma) |
| `11.8/11.8.8.md:39` | Leap 15.6 added |
| `12.3/12.3.2.md:72` | Leap 15.6 added |
| `13.0/13.0.1.md:48` | **New `### General` subsection** with all four platforms |

Ordering puts OpenSUSE first, matching the policy-page row order and the only two precedents pairing OpenSUSE with Ubuntu (`old-releases/10.1/10.1.41.md:34`, `old-releases/10.4/10.4.7.md:47`).

## Verification

Re-checked independently against `archive.mariadb.org` on 2026-08-31, using own-version RPM counts rather than the directory-exists test (which lingers a release and gives wrong answers):

| Release | Own-version RPMs in `opensuse156-amd64` | Successor | Verdict |
|---|---|---|---|
| 10.11.18 | 38 | `10.11.19` built, no `opensuse*` target | archive-proven |
| 11.4.12 | 41 | `11.4.13` built, no `opensuse*` target | archive-proven |
| 11.8.8 | 41 | `11.8.9` fully built, ships `opensuse160` — no `156` | archive-proven |
| 12.3.2 | 45 | `12.3.3` fully built, ships `opensuse160` — no `156` | archive-proven |
| 13.0.1 | 45 | `13.1.0` **not built** — see below | policy-sourced |

For 13.0.1's other three platforms: `fedora42-amd64/rpms/` has 45 RPMs at 13.0.1, and `dists/plucky` and `dists/questing` each carry 38 packages at `1:13.0.1`.

## Two notes for the reviewer

**The 13.0.1 rows are policy-sourced, not archive-proven.** `mariadb-13.1.0/` returns HTTP 200 but holds only `bintar-linux-systemd-x86_64/` and `source/` — no `yum/`, no `repo/`. Its 404 on `opensuse156` is the same 404 it returns for every target, so it is not evidence of a drop. These four claims rest on `platform-deprecation-policy.md:52-55`. That is the right basis given the bullet reads "this **will be** the last release", but they are worth re-checking once 13.1.0 ships real repos.

**This is the counterpart to DOCS-6339's no-change closure.** DOCS-6214 dropped Leap 15.6 from these bullets believing the five releases were not the real final builds; DOCS-6339 was filed to "correct" the policy page on the same belief and was closed with no change once the archive showed the row was right. The policy page was always correct, so the gap was on the release-notes side. Both conclusions are consistent.

`13.0.1`'s `## Notable Items` previously had no subsections, so its four existing bullets now sit above the new `### General` heading. It renders correctly and matches house convention (`11.7.1` is the precedent — an RC carrying the same `non-stable.md` include, with `### General` as its last subsection).

## Checks

`codespell` 2.4.2 and `lychee` 0.24.2 both PASS via `.claude/hooks/doc-lint.sh`. Frontmatter, block balance, link style and `SUMMARY.md` all clean — no pages added, moved or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6552]: https://mariadbcorp.atlassian.net/browse/DOCS-6552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ