### PR TITLE
DOCS-6559 Document the text %iE prints after the error number

### DIFF
--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1004.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1004.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1005.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1005.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1006.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1006.md
@@ -12,11 +12,13 @@ description: >-
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 ### Insufficient Disk Space
 
 The server has insufficient free disk space to create the database. Free up space and retry.
 
-### File permissions
+### File Permissions
 
 There may be a file permission issue on the data directories. Check both the user and group permissions and set accordingly.
 

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1009.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1009.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1010.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1010.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1011.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1011.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1013.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1013.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1014.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1014.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1015.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1015.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1016.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1016.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1017.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1017.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1018.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1018.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1019.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1019.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1021.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1021.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1023.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1023.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1024.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1024.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1025.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1025.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1026.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1026.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1030.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1030.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1039.md
+++ b/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1039.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1135.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1135.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1180.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1180.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1181.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1181.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1182.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1182.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1183.md
+++ b/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1183.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1388.md
+++ b/server/reference/error-codes/mariadb-error-codes-1300-to-1399/e1388.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1538.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1538.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1571.md
+++ b/server/reference/error-codes/mariadb-error-codes-1500-to-1599/e1571.md
@@ -2,9 +2,11 @@
 
 | Error Code | SQLSTATE | Error                      | Description                                                    |
 | ---------- | -------- | -------------------------- | -------------------------------------------------------------- |
-| 1571       | HY000    | ER\_EVENT\_SET\_VAR\_ERROR | Error during starting/stopping of the scheduler. Error code %u |
+| 1571       | HY000    | ER\_EVENT\_SET\_VAR\_ERROR | Error during starting/stopping of the scheduler. Error code %d |
 
 ## Possible Causes and Solutions
+
+The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.
 
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 

--- a/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4256.md
+++ b/server/reference/error-codes/mariadb-error-codes-4200-to-4299/e4256.md
@@ -6,6 +6,8 @@
 
 ## Possible Causes and Solutions
 
+The server prints more than the number shown above: it follows the error number with the operating-system error text in double quotes, for example `2 "No such file or directory"`.
+
 {% include "../../../.gitbook/includes/contributing-content.md" %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>


### PR DESCRIPTION
Documents what the server's `%iE` specifier actually prints, on the 29 error-code pages whose message uses it.

Jira: [DOCS-6559](https://mariadbcorp.atlassian.net/browse/DOCS-6559) — a spin-off of DOCS-6557.

## The problem

The docs render `%iE` as `%d`, on the same editorial convention that renders `%-.192s` as `%s`. That convention is right for a width or a precision, and wrong here — `%iE` is not "an integer".

In `strings/my_vsnprintf.c:746-761` (and the mirrored positional-argument branch at `:549-566`), `%iE` prints the number **and then** a space, a double quote, `my_strerror()` for that number, and a closing double quote. So `Can't create file '%-.200s' (errno: %iE)` reaches the user as:

```
Can't create file '/tmp/x' (errno: 2 "No such file or directory")
```

The page showed `(errno: %d)`. A reader comparing the page against what their server printed sees an extra quoted clause the documented message does not have — and that clause is the half that says what actually went wrong.

## What's here

Per the decision on the ticket (option 3 of three): **the table rows keep `%d`**, and each of the 29 pages gains **one sentence** under `## Possible Causes and Solutions`.

**The 29 are not one group.** For the 22 file and OS errors the quoted text is the operating-system message. For the 7 codes that report an engine or internal number — 1030, 1180–1183, 1538, 1571 — `my_strerror()` returns MariaDB's **own** handler text for numbers in `HA_ERR_FIRST..HA_ERR_LAST` (120–202, `include/my_base.h:469,566`) and the OS text otherwise. Those seven say so instead of claiming an operating-system error:

> The server prints more than the number shown above: it follows the error number with its text in double quotes, for example `130 "Incorrect file format"`. Numbers from 120 to 202 are MariaDB storage-engine errors and take their text from MariaDB; any other number is an operating-system error.

**Why the sentence goes inside `## Possible Causes and Solutions` and not under the table:** `.github/scripts/update_mariadb_docs.py` preserves exactly that section across a page rewrite (`preserve_custom_content()`); anything placed between the table and the heading would be dropped if the page were ever regenerated. Related: DOCS-6564.

## Drive-by fixes

* **`e1571` rendered the same specifier as `%u`** where all 28 other pages use `%d`. The server prints `%iE` through `process_int_arg(..., 'd', ...)`, so `%u` was wrong on its own terms as well as inconsistent.
* **`e1006` had a sentence-case `### File permissions` heading** (house style is Title Case; no linter catches this).

## Source verification

| # | Claim | Source evidence | Verdict |
| --- | --- | --- | --- |
| 1 | `%iE` prints the number, then a space, `"`, `my_strerror()` text, `"` | `strings/my_vsnprintf.c:746-761`; positional-arg branch `:549-566` | VERIFIED |
| 2 | The closing quote is emitted only if at least 3 bytes remain in the buffer | `my_vsnprintf.c:751` (`if (real_end - to >= 3)`), `:759` | VERIFIED — why the pages say what the server prints, not "always" |
| 3 | For 120–202 the text is MariaDB's handler message, not the OS's | `my_vsnprintf.c:931-935`; `include/my_base.h:469` (`HA_ERR_FIRST 120`), `:566` (`HA_ERR_LAST 202`); table in `include/my_handler_errors.h:24` | VERIFIED |
| 4 | `130` is `"Incorrect file format"` | `include/my_handler_errors.h`, `/* 130 */` entry | VERIFIED |
| 5 | Exactly 29 `eng` messages use `%iE` | `grep -c '^ *eng ".*%iE' sql/share/errmsg-utf8.txt` → 29 | VERIFIED |
| 6 | Those 29 map to these 29 pages | positional parse of `errmsg-utf8.txt` honouring `start-error-number`, `skip-to-error-number` and SQLSTATE-carrying symbol lines; yields 1395 codes, 1:1 with the 1395 `eNNNN.md` files, no code without a page and no page without a code | VERIFIED |
| 7 | `%iE` is printed as signed decimal, so `%u` on e1571 is wrong | `my_vsnprintf.c:750` (`process_int_arg(..., 'd', ...)`) | VERIFIED |

Server tree at `3e3f56d99e0` (`main`).

## Checks

`codespell` and `lychee` via `.claude/hooks/doc-lint.sh` on all 29 changed files: clean, exit 0, no skipped tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6559]: https://mariadbcorp.atlassian.net/browse/DOCS-6559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ