### PR TITLE
DOCS-6560 Clarify how Sort_priority_queue_sorts relates to the total

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/filesort-with-small-limit-optimization.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/filesort-with-small-limit-optimization.md
@@ -18,7 +18,7 @@ There are two ways to check whether filesort has used a priority queue.
 
 ### Status Variable
 
-The first way is to check the [Sort\_priority\_queue\_sorts](../system-variables/server-status-variables.md#sort_priority_queue_sorts) status variable. It shows the number of times that sorting was done through a priority queue. (The total number of times sorting was done is a sum [Sort\_range](../system-variables/server-status-variables.md#sort_range) and [Sort\_scan](../system-variables/server-status-variables.md#sort_scan)).
+The first way is to check the [Sort\_priority\_queue\_sorts](../system-variables/server-status-variables.md#sort_priority_queue_sorts) status variable. It shows the number of times that sorting was done through a priority queue. Every such sort is also counted by [Sort\_range](../system-variables/server-status-variables.md#sort_range) or [Sort\_scan](../system-variables/server-status-variables.md#sort_scan), so the total number of sorts is the sum of `Sort_range` and `Sort_scan` alone — adding `Sort_priority_queue_sorts` counts those sorts twice.
 
 ### Slow Query Log
 

--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-status-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-status-variables.md
@@ -1870,7 +1870,7 @@ Issuing a [FLUSH STATUS](../../../reference/sql-statements/administrative-sql-st
 
 #### `Sort_priority_queue_sorts`
 
-* Description: The number of times that sorting was done through a priority queue. (The total number of times sorting was done is a sum [Sort\_range](server-status-variables.md#sort_range) and [Sort\_scan](server-status-variables.md#sort_scan)). See [filesort with small LIMIT optimization](../query-optimizations/filesort-with-small-limit-optimization.md).
+* Description: The number of times that sorting was done through a priority queue. Every such sort is also counted by [Sort\_range](server-status-variables.md#sort_range) or [Sort\_scan](server-status-variables.md#sort_scan), so the total number of sorts is the sum of `Sort_range` and `Sort_scan` alone — adding `Sort_priority_queue_sorts` counts those sorts twice. See [filesort with small LIMIT optimization](../query-optimizations/filesort-with-small-limit-optimization.md).
 * Scope: Global, Session
 * Data Type: `numeric`
 


### PR DESCRIPTION
Fixes the `Sort_priority_queue_sorts` description reported through the MariaDB contact form.

Jira: [DOCS-6560](https://mariadbcorp.atlassian.net/browse/DOCS-6560)

## What the reader reported

> If I'm correct, the total number of sorts performed should be the sum of Sort_priority_queue_sorts, Sort_range and Sort_scan. Even if I'm wrong, documentation is still missing an 'of' there to clarify.

**The missing "of" is real. The proposed arithmetic is not** — and the second half is the more useful finding, because the sentence invited exactly that misreading.

## Why the total excludes Sort_priority_queue_sorts

In `sql/filesort.cc`, `filesort()` increments one of the two counters **unconditionally**, before it decides whether to use a priority queue:

```c
  if (select && select->quick)
    thd->inc_status_sort_range();          // :321
  else
    thd->inc_status_sort_scan();           // :323
  ...
  if (costs.fastest_sort == PQ_SORT_ALL_FIELDS ||
      costs.fastest_sort == PQ_SORT_ORDER_BY_FIELDS)
  {
    status_var_increment(thd->status_var.filesort_pq_sorts_);   // :344
```

Those are the only call sites — `inc_status_sort_range()` and `inc_status_sort_scan()` are called nowhere else in `sql/`, and `filesort_pq_sorts_` is incremented nowhere else. So every priority-queue sort is counted a **second** time under `Sort_range` or `Sort_scan`: the PQ counter is a subset, and summing all three double-counts every PQ sort.

Confirmed on a live 12.3.3 server rather than reasoned about:

| Query | `Sort_priority_queue_sorts` | `Sort_range` | `Sort_scan` |
| --- | --- | --- | --- |
| `SELECT b FROM t1 ORDER BY b LIMIT 10` (full scan) | 1 | 0 | 1 |
| `SELECT b FROM t1 WHERE a BETWEEN 1 AND 5000 ORDER BY b LIMIT 10` | 1 | 1 | 0 |
| `SELECT b FROM t1 ORDER BY b` (no LIMIT, no priority queue) | 0 | 0 | 1 |

## What changed

The sentence now states the subset relationship outright instead of only gaining the missing word — the arithmetic was what actually misled the reader:

> The number of times that sorting was done through a priority queue. Every such sort is also counted by `Sort_range` or `Sort_scan`, so the total number of sorts is the sum of `Sort_range` and `Sort_scan` alone — adding `Sort_priority_queue_sorts` counts those sorts twice.

**Two pages, not one.** The ticket names only the status-variables page, but `filesort-with-small-limit-optimization.md` repeats the same sentence verbatim, so both are corrected.

## Source verification

| # | Claim | Source evidence | Verdict |
| --- | --- | --- | --- |
| 1 | `Sort_range` or `Sort_scan` is incremented on every `filesort()` call | `sql/filesort.cc:320-323` — an unconditional if/else before any PQ decision | VERIFIED |
| 2 | `Sort_priority_queue_sorts` is incremented only when a priority queue is chosen | `sql/filesort.cc:340-344` | VERIFIED |
| 3 | The PQ increment happens *after* the range/scan increment in the same function | `:321-323` precede `:344` | VERIFIED |
| 4 | Those are the only call sites of all three counters | `grep -rn "inc_status_sort_range\|inc_status_sort_scan\|filesort_pq_sorts" sql/` → `filesort.cc:321`, `:323`, `:344` plus their definitions in `sql_class.cc`/`sql_class.h` | VERIFIED |
| 5 | Therefore total sorts = `Sort_range` + `Sort_scan`, with PQ a subset | the three live-server runs above | VERIFIED |

Server tree at `3e3f56d99e0` (`main`); behaviour reproduced on MariaDB 12.3.3.

## Checks

`codespell` and `lychee` via `.claude/hooks/doc-lint.sh` on both changed files: clean, exit 0, no skipped tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6560]: https://mariadbcorp.atlassian.net/browse/DOCS-6560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ