### PR TITLE
DOCS-6520 Fix the isolation-level advice on the SQL Server page

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
+++ b/server/ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md
@@ -3001,7 +3001,7 @@ MariaDB sets the limit with [setrlimit](https://linux.die.net/man/2/setrlimit). 
 #### `tx_isolation`
 
 * Description: The transaction isolation level. Setting this session variable via `set @@tx_isolation=` will take effect for only the subsequent transaction in the current session, much like [SET TRANSACTION ISOLATION LEVEL](../../../reference/sql-statements/transactions/set-transaction.md). To set for a session, use `SET SESSION tx_isolation` or `SET @@session.tx_isolation`. See [MDEV-31751](https://jira.mariadb.org/browse/MDEV-31751). See also [SET TRANSACTION ISOLATION LEVEL](../../../reference/sql-statements/transactions/set-transaction.md). In [MariaDB 11.1](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.1/what-is-mariadb-111), this system variable is deprecated and replaced by [transaction\_isolation](server-system-variables.md#transaction_isolation).
-* Command line: `--transaction-isolation=name`
+* Command line: None. The startup option is `--transaction-isolation=name`, which sets [transaction\_isolation](server-system-variables.md#transaction_isolation).
 * Scope: Global, Session
 * Dynamic: Yes
 * Type: enumeration
@@ -3012,7 +3012,7 @@ MariaDB sets the limit with [setrlimit](https://linux.die.net/man/2/setrlimit). 
 #### `tx_read_only`
 
 * Description: Default transaction access mode. If set to `OFF`, the default, access is read/write. If set to `ON`, access is read-only. The `SET TRANSACTION` statement can also change the value of this variable. See [SET TRANSACTION](../../../reference/sql-statements/transactions/set-transaction.md) and [START TRANSACTION](../../../reference/sql-statements/transactions/start-transaction.md). In [MariaDB 11.1](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/11.1/what-is-mariadb-111), this system variable is deprecated and replaced by [transaction\_read\_only](server-system-variables.md#transaction_read_only).
-* Command line: `--transaction-read-only=#`
+* Command line: None. The startup option is `--transaction-read-only=#`, which sets [transaction\_read\_only](server-system-variables.md#transaction_read_only).
 * Scope: Global, Session
 * Dynamic: Yes
 * Type: boolean

--- a/server/reference/sql-statements/transactions/set-transaction.md
+++ b/server/reference/sql-statements/transactions/set-transaction.md
@@ -157,6 +157,10 @@ Distributed [XA transactions](xa-transactions.md) should always use this isolati
 
 If the [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) system variable is not set to `ON`, strictly speaking anything other than `READ UNCOMMITTED` is not clearly defined. While it is `ON`, an attempt to acquire a lock on a record that does not exist in the current read view raises an error and rolls the transaction back.
 
+Its default is not the same across supported releases. It is `ON` from MariaDB 11.6.2, and `OFF` in the earlier series that introduced it, which includes the 10.11 and 11.4 long-term releases. Advice to keep the default is therefore ambiguous; set the variable explicitly.
+
+Prefer `ON`, because it is what makes `REPEATABLE READ` behave as its name claims. The reason to choose `OFF` is application compatibility, not performance. With `ON`, an `UPDATE` or `DELETE` that touches a row changed since the transaction's snapshot fails with [ER\_CHECKREAD](../../error-codes/mariadb-error-codes-1000-to-1099/e1020.md) (1020) and the whole transaction is rolled back, exactly as for a deadlock; the server treats the two errors as the same class, and replication retries both. An application that already retries on `ER_LOCK_DEADLOCK` needs no change. A legacy application that does not handle `ER_CHECKREAD` the same way loses those transactions instead of retrying them, and `innodb_snapshot_isolation=OFF` gives it the MySQL-compatible — though not well-defined — behavior until it can be fixed.
+
 ### Access Mode
 
 {% tabs %}
@@ -175,7 +179,14 @@ It is not permitted to specify both `READ WRITE` and `READ ONLY` in the same sta
 
 ## Choosing an Isolation Level
 
-Stay on the default `REPEATABLE READ` unless the application needs the semantics of a different level. In particular, `READ COMMITTED` is not a throughput setting: it opens a new read view at the start of every statement, and under high concurrency the cost of building those snapshots can make it slower than `REPEATABLE READ`, not faster. That path was made cheaper by [MDEV-21423](https://jira.mariadb.org/browse/MDEV-21423) from MariaDB 11.8.9 and 12.3.3, which reduces the overhead without removing it.
+Stay on the default `REPEATABLE READ` unless the application needs the semantics of a different level. `READ COMMITTED` is not a throughput setting in either direction: which level costs more depends on the shape of the workload, because the two differ in *when* a read view is opened.
+
+At `READ COMMITTED`, every statement opens its own read view. At `REPEATABLE READ`, all statements share the read view taken when the transaction started. That single difference cuts both ways:
+
+* **Many short statements in a recently started transaction are more expensive at `READ COMMITTED`.** Opening a read view means collecting the identifiers of the read-write transactions that are currently active, and under high concurrency that collection is measurable. This is a common shape for web applications. [MDEV-21423](https://jira.mariadb.org/browse/MDEV-21423) reduced the cost from MariaDB 11.8.9 and 12.3.3 without removing it.
+* **Complex statements in a long-running transaction can be cheaper at `READ COMMITTED`.** Each statement is allowed to see more recent data, so rebuilding the row versions it needs walks less history. At `REPEATABLE READ` the read view stays fixed at the start of the transaction, and the older it gets, the further back through the undo history InnoDB has to walk to reconstruct the snapshot that a statement is entitled to see.
+
+So measure the workload rather than assume a direction.
 
 The reasons to choose `READ COMMITTED` are about behavior rather than speed:
 
@@ -187,7 +198,7 @@ What you give up in exchange:
 * Reads are no longer repeatable. Two identical `SELECT` statements in the same transaction can return different rows.
 * Statement-based binary logging is not available, as described under [Gap Locking at READ COMMITTED](#gap-locking-at-read-committed).
 
-Whichever level you choose, leave [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) at its default. See [innodb\_snapshot\_isolation](#innodb_snapshot_isolation) above.
+[innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) is a separate decision from the isolation level, and one to make explicitly rather than inherit, because its default is not the same in every supported release. See [innodb\_snapshot\_isolation](#innodb_snapshot_isolation) above.
 
 ## Examples
 

--- a/server/reference/sql-statements/transactions/set-transaction.md
+++ b/server/reference/sql-statements/transactions/set-transaction.md
@@ -173,6 +173,22 @@ It is not permitted to specify both `READ WRITE` and `READ ONLY` in the same sta
 
 `READ WRITE` and `READ ONLY` can also be specified in the [START TRANSACTION](start-transaction.md) statement, in which case the specified mode is only valid for one transaction.
 
+## Choosing an Isolation Level
+
+Stay on the default `REPEATABLE READ` unless the application needs the semantics of a different level. In particular, `READ COMMITTED` is not a throughput setting: it opens a new read view at the start of every statement, and under high concurrency the cost of building those snapshots can make it slower than `REPEATABLE READ`, not faster. That path was made cheaper by [MDEV-21423](https://jira.mariadb.org/browse/MDEV-21423) from MariaDB 11.8.9 and 12.3.3, which reduces the overhead without removing it.
+
+The reasons to choose `READ COMMITTED` are about behavior rather than speed:
+
+* Every statement sees the most recently committed data. This suits an application written against a database whose default behaves that way, such as SQL Server. See [MariaDB Transactions and Isolation Levels for SQL Server Users](../../../server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-sql-server/mariadb-transactions-and-isolation-levels-for-sql-server-users.md).
+* InnoDB takes no gap locks, so an insert into a range that another transaction has locked is not blocked. See [Gap Locking at READ COMMITTED](#gap-locking-at-read-committed). On its own this is not a reason to expect better throughput, for the read view reason above.
+
+What you give up in exchange:
+
+* Reads are no longer repeatable. Two identical `SELECT` statements in the same transaction can return different rows.
+* Statement-based binary logging is not available, as described under [Gap Locking at READ COMMITTED](#gap-locking-at-read-committed).
+
+Whichever level you choose, leave [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) at its default. See [innodb\_snapshot\_isolation](#innodb_snapshot_isolation) above.
+
 ## Examples
 
 ```sql

--- a/server/reference/sql-statements/transactions/set-transaction.md
+++ b/server/reference/sql-statements/transactions/set-transaction.md
@@ -157,7 +157,9 @@ Distributed [XA transactions](xa-transactions.md) should always use this isolati
 
 If the [innodb\_snapshot\_isolation](../../../server-usage/storage-engines/innodb/innodb-system-variables.md#innodb_snapshot_isolation) system variable is not set to `ON`, strictly speaking anything other than `READ UNCOMMITTED` is not clearly defined. While it is `ON`, an attempt to acquire a lock on a record that does not exist in the current read view raises an error and rolls the transaction back.
 
-Its default is not the same across supported releases. It is `ON` from MariaDB 11.6.2, and `OFF` in the earlier series that introduced it, which includes the 10.11 and 11.4 long-term releases. Advice to keep the default is therefore ambiguous; set the variable explicitly.
+{% hint style="warning" %}
+The default of `innodb_snapshot_isolation` is not the same across supported releases. It is `ON` from MariaDB 11.6.2, and `OFF` in the earlier series that introduced it, which includes the 10.11 and 11.4 long-term releases. Advice to keep the default is therefore ambiguous; set the variable explicitly.
+{% endhint %}
 
 Prefer `ON`, because it is what makes `REPEATABLE READ` behave as its name claims. The reason to choose `OFF` is application compatibility, not performance. With `ON`, an `UPDATE` or `DELETE` that touches a row changed since the transaction's snapshot fails with [ER\_CHECKREAD](../../error-codes/mariadb-error-codes-1000-to-1099/e1020.md) (1020) and the whole transaction is rolled back, exactly as for a deadlock; the server treats the two errors as the same class, and replication retries both. An application that already retries on `ER_LOCK_DEADLOCK` needs no change. A legacy application that does not handle `ER_CHECKREAD` the same way loses those transactions instead of retrying them, and `innodb_snapshot_isolation=OFF` gives it the MySQL-compatible — though not well-defined — behavior until it can be fixed.
 

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-sql-server/mariadb-transactions-and-isolation-levels-for-sql-server-users.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-sql-server/mariadb-transactions-and-isolation-levels-for-sql-server-users.md
@@ -163,7 +163,7 @@ The locks that a locking read acquires do depend on the isolation level. InnoDB 
 
 The default isolation level in MariaDB is `REPEATABLE READ`. This can be changed with the [transaction\_isolation](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#transaction_isolation) system variable. The older name `tx_isolation` still works, but has been deprecated since MariaDB 11.1 and produces a warning.
 
-Applications developed for SQL Server and later ported to MariaDB may run with `READ COMMITTED` without problems, since it is the level closest to the SQL Server default. Do not switch to it expecting better scalability: `READ COMMITTED` creates a new read view at the start of every statement, which under high concurrency can make it slower than `REPEATABLE READ`, not faster. See [Choosing an Isolation Level](../../../../reference/sql-statements/transactions/set-transaction.md#choosing-an-isolation-level).
+Applications developed for SQL Server and later ported to MariaDB may run with `READ COMMITTED` without problems, since it is the level closest to the SQL Server default. Do not switch to it as a scalability measure, though, because neither level is uniformly faster: `READ COMMITTED` creates a new read view at the start of every statement, which costs more in a transaction made of many short statements and less in a long-running transaction made of complex ones. See [Choosing an Isolation Level](../../../../reference/sql-statements/transactions/set-transaction.md#choosing-an-isolation-level).
 
 To use `READ COMMITTED` by default, add the following line to the MariaDB configuration file:
 

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-sql-server/mariadb-transactions-and-isolation-levels-for-sql-server-users.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-sql-server/mariadb-transactions-and-isolation-levels-for-sql-server-users.md
@@ -1,8 +1,8 @@
 ---
 description: >-
   Complete transaction isolation for SQL Server users: START
-  TRANSACTION/COMMIT/ROLLBACK, tx_isolation levels, WITH CONSISTENT SNAPSHOT,
-  innodb_lock_wait_timeout.
+  TRANSACTION/COMMIT/ROLLBACK, transaction_isolation levels, WITH CONSISTENT
+  SNAPSHOT, innodb_lock_wait_timeout.
 ---
 
 # MariaDB Transactions and Isolation Levels for SQL Server Users
@@ -149,33 +149,39 @@ For more information about MariaDB isolation levels see [SET TRANSACTION](../../
 
 ### Locking Reads
 
-In MariaDB, the locks acquired by a read do not depend on the isolation level (with one exception noted below).
-
 As a general rule:
 
 * Plain [SELECTs](../../../../reference/sql-statements/data-manipulation/selecting-data/select.md) are not locking, they acquire snapshots instead.
-* To force a read to acquire a shared lock, use [SELECT ... LOCK IN SHARED MODE](../../../../reference/sql-statements/data-manipulation/selecting-data/lock-in-share-mode.md).
+* To force a read to acquire a shared lock, use [SELECT ... LOCK IN SHARE MODE](../../../../reference/sql-statements/data-manipulation/selecting-data/lock-in-share-mode.md).
 * To force a read to acquire an exclusive lock, use [SELECT ... FOR UPDATE](../../../../reference/sql-statements/data-manipulation/selecting-data/for-update.md).
+
+The locks that a locking read acquires do depend on the isolation level. InnoDB takes no [gap locks](../../../../server-usage/storage-engines/innodb/innodb-lock-modes.md#gap-locks) at `READ COMMITTED` or `READ UNCOMMITTED`, so a locking read at those levels locks the index records it examines but not the gaps between them. See [Gap Locking at READ COMMITTED](../../../../reference/sql-statements/transactions/set-transaction.md#gap-locking-at-read-committed).
+
+`SERIALIZABLE` is the other level at which reads behave differently: within a transaction, InnoDB treats a plain `SELECT` as `LOCK IN SHARE MODE`. A consistent read run with `autocommit=1` is exempt, because a read-only transaction can be serialized as a consistent read.
 
 ### Changing the Isolation Level
 
-The default, the isolation level in MariaDB is `REPEATABLE READ`. This can be changed with the [tx\_isolation](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#tx_isolation) system variable.
+The default isolation level in MariaDB is `REPEATABLE READ`. This can be changed with the [transaction\_isolation](../../../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#transaction_isolation) system variable. The older name `tx_isolation` still works, but has been deprecated since MariaDB 11.1 and produces a warning.
 
-Applications developed for SQL Server and later ported to MariaDB may run with `READ COMMITTED` without problems. Using a stricter level would reduce scalability. To use `READ COMMITTED` by default, add the following line to the MariaDB configuration file:
+Applications developed for SQL Server and later ported to MariaDB may run with `READ COMMITTED` without problems, since it is the level closest to the SQL Server default. Do not switch to it expecting better scalability: `READ COMMITTED` creates a new read view at the start of every statement, which under high concurrency can make it slower than `REPEATABLE READ`, not faster. See [Choosing an Isolation Level](../../../../reference/sql-statements/transactions/set-transaction.md#choosing-an-isolation-level).
+
+To use `READ COMMITTED` by default, add the following line to the MariaDB configuration file:
 
 ```
-tx_isolation = 'READ COMMITTED'
+transaction-isolation = READ-COMMITTED
 ```
+
+The startup option is spelled `transaction-isolation`; there is no `tx_isolation` startup option, and a configuration file containing one stops the server from starting.
 
 It is also possible to change the default isolation level for the current session:
 
-```bash
-SET SESSION tx_isolation = 'read-committed';
+```sql
+SET SESSION transaction_isolation = 'read-committed';
 ```
 
 Or just for one transaction, by issuing the following statement before starting a transaction:
 
-```bash
+```sql
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 ```
 
@@ -190,7 +196,7 @@ MariaDB supports the following isolation levels:
 
 MariaDB isolation levels differ from SQL Server in the following ways:
 
-* `REPEATABLE READ` does not acquire share locks on all read rows, nor a range lock on the missing values that match a `WHERE` clause.
+* At `REPEATABLE READ`, a plain `SELECT` acquires no share locks on the rows it reads, and no range lock on the missing values that match a `WHERE` clause; it reads from a snapshot instead. A locking read at `REPEATABLE READ` does take next-key locks, which cover the gaps.
 * It is not possible to change the isolation level in the middle of a transaction.
 * `SNAPSHOT` isolation level is not supported. Instead, you can use `START TRANSACTION WITH CONSISTENT SNAPSHOT` to acquire a snapshot at the beginning of the transaction. This is compatible with all isolation levels.
 


### PR DESCRIPTION
[DOCS-6520](https://mariadbcorp.atlassian.net/browse/DOCS-6520). Follow-up to DOCS-6519 (#961), which corrected `SET TRANSACTION` and deliberately left this page alone.

## 1. The scalability claim is backwards

> Applications developed for SQL Server and later ported to MariaDB may run with `READ COMMITTED` without problems. **Using a stricter level would reduce scalability.**

Marko Mäkelä, in the thread that produced DOCS-6519:

> `READ COMMITTED` can be significantly slower than `REPEATABLE READ`, because it is creating a new read view at the start of each SQL statement. The read view creation was recently reworked in MDEV-21423 to reduce the impact.

The MDEV-21423 commit message says the same thing from the other side:

> Under high concurrency, MVCC snapshot creation may spend a significant amount of time in `lf_hash_iterate()`/`l_find()` while collecting active read-write transaction identifiers. This overhead is particularly visible in sysbench `oltp_read_write` with `transaction-isolation=READ-COMMITTED`.

That commit (`241050cca82`) is on `main` and is tagged `mariadb-11.8.9` and `mariadb-12.3.3` — so it is a mid-series improvement, and older series do not have it. The page now says READ COMMITTED is not a throughput setting, and points at a new section rather than repeating the argument.

## 2. The config-file recipe stops the server from starting

`tx_isolation` is `NO_CMD_LINE` (`sql/sys_vars.cc:4658`); the startup option is `transaction-isolation` (`sql/mysqld.cc:7287`), whose accepted values are the hyphenated `tx_isolation_names` (`sql/handler.cc:156`). Confirmed against a 12.3.3 binary:

```
--transaction-isolation=name
                    Default transaction isolation level. One of: READ-UNCOMMITTED,
                    READ-COMMITTED, REPEATABLE-READ, SERIALIZABLE
```

`tx_isolation` does not appear in `--verbose --help` at all. The recipe is now `transaction-isolation = READ-COMMITTED`, with a sentence saying why the other spelling fails.

## 3. `tx_isolation` deprecated since 11.1

`DEPRECATED(1101, "transaction_isolation")` at `sql/sys_vars.cc:4661`. Live on 12.3.3:

```
Warning 1287  '@@tx_isolation' is deprecated and will be removed in a future
release. Please use '@@transaction_isolation' instead
```

All three uses on the page move to `transaction_isolation`, and the link target moves to `#transaction_isolation`.

## 4. Two locking claims corrected

*"In MariaDB, the locks acquired by a read do not depend on the isolation level (with one exception noted below)."* They do — `storage/innobase/row/row0sel.cc:4776`:

```c
/* Do not lock gaps at READ UNCOMMITTED or READ COMMITTED
isolation level */
const bool set_also_gap_locks =
        prebuilt->select_lock_type != LOCK_NONE
        && trx->isolation_level > TRX_ISO_READ_COMMITTED
```

The promised "one exception noted below" was never actually named anywhere on the page. Replaced with the real dependency, plus the `SERIALIZABLE` case from `ha_innodb.cc:16811`, where a plain `SELECT` in a non-autocommit transaction becomes `LOCK IN SHARE MODE`.

*"`REPEATABLE READ` does not acquire share locks on all read rows, nor a range lock on the missing values that match a `WHERE` clause."* True of plain reads only — the same guard above makes a **locking** read at `REPEATABLE READ` take next-key locks. Now scoped.

## New section on SET TRANSACTION

The question that started all of this — *"for high volume systems, does MariaDB recommend setting the isolation level to READ COMMITTED?"* — had no answer anywhere in the docs. `SET TRANSACTION` now has a **Choosing an Isolation Level** section that answers it: stay on the default, and here is what READ COMMITTED buys and costs.

## Drive-by fixes

- `server-system-variables.md`: `tx_isolation` and `tx_read_only` both listed a command line of their own. Both are `NO_CMD_LINE` (`sys_vars.cc:4658`, `:4719`); the options belong to the replacement variables. Reworded rather than removed, since the option does reach the same storage.
- Migration page: link text `SELECT ... LOCK IN SHARED MODE` → `LOCK IN SHARE MODE` (the statement's actual name; the link target was already right).
- Migration page: two `sql` snippets were fenced as `bash`.
- Migration page: `tx_isolation` in the frontmatter description.

## Checks

`doc-lint.sh` clean on all three files, CI-exact codespell clean, `fragcheck.py new main` reports no new dead anchors, and every added relative link resolves against the tree.

[DOCS-6520]: https://mariadbcorp.atlassian.net/browse/DOCS-6520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ