### PR TITLE
DOCS-6507 Remove the leaked GitBook preview URL from the Tools docs

### DIFF
--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -13,6 +13,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      # A `~/changes/<N>/` URL addresses an UNMERGED GitBook change request in
+      # the editor, not published content. It depends on a change request that
+      # may be merged, discarded or renumbered, and it sends a reader somewhere
+      # they cannot go. lychee structurally cannot catch these: it only scans
+      # the files a PR changed, and these URLs sit on pages nobody is touching.
+      # The URL is also syntactically valid and may answer 200 to an
+      # authenticated editor, so it would not necessarily fail even when
+      # scanned. This grep is tree-wide and costs about a second. See DOCS-6507.
+      #
+      # `~/reusable/...` is NOT banned: those are legitimate {% include %}
+      # targets and appear on 58 pages.
+      - name: Ban GitBook change-request preview URLs
+        run: |
+          if git grep -n -e '~/changes/' -- '*.md' '*.html' ':!agent-skills/topical/'; then
+            echo "::error::A GitBook change-request preview URL is committed (listed above). It points at an unmerged change request, not published content. Replace it with a link to the published page, or unlink the text."
+            exit 1
+          fi
+
       - name: Get changed files
         id: changes
         # SHA-pinned rather than tag-pinned: this action was compromised in

--- a/tools/mariadb-enterprise-manager/administration/update-enterprise-manager.md
+++ b/tools/mariadb-enterprise-manager/administration/update-enterprise-manager.md
@@ -7,7 +7,7 @@ description: Instructions for updating an existing Enterprise Manager deployment
 {% hint style="info" %}
 Prerequisites
 
-* Make a backup of Enterprise Manager data following instructions in [Backup & Restore of Enterprise Manager](https://mariadb.com/docs/tools/~/changes/145/mariadb-enterprise-manager/administration/backup-and-restore-of-enterprise-manager)
+* Make a backup of Enterprise Manager data following instructions in [Backup & Restore of Enterprise Manager](backup-and-restore-of-enterprise-manager.md)
 {% endhint %}
 
 ## Enterprise Manager Update with Internet Access


### PR DESCRIPTION
[DOCS-6507](https://mariadbcorp.atlassian.net/browse/DOCS-6507).

## The link

`tools/mariadb-enterprise-manager/administration/update-enterprise-manager.md:10` pointed at:

```
https://mariadb.com/docs/tools/~/changes/145/mariadb-enterprise-manager/administration/backup-and-restore-of-enterprise-manager
```

A `~/changes/<N>/` URL addresses an **unmerged change request** in the GitBook editor. It is not published content, it depends on a change request that may be merged, discarded or renumbered, and the link text ("Backup & Restore of Enterprise Manager") promises a reader an ordinary docs page.

The page it means already exists, in the same directory, and is published:

```
$ curl -o /dev/null -w '%{http_code}\n' https://mariadb.com/docs/tools/mariadb-enterprise-manager/administration/backup-and-restore-of-enterprise-manager
200
```

It is also in `tools/SUMMARY.md:19`, one line above the page that was linking to it. So this is a plain same-directory relative link, not an unlink.

## Scope confirmed

The ticket listed three instances, two of which were absorbed into #948 (DOCS-6499 slice 4). `grep -rn '~/changes/'` across the whole tree now finds exactly the one this PR fixes, plus a comment in `pdf/gitbook_preprocess.py` that already documents the class. I also checked the neighbouring shapes — `~/revisions/`, `~/drafts/`, `.gitbook.io`, `app.gitbook.com/.../~/changes` — and there are none.

## The CI gate the ticket asks for

> A one-off `grep -rn '~/changes/'` is the reliable check, and it is cheap enough to be worth adding to the link-check workflow as an explicit pattern ban — a published page should never contain one.

Added as a step in `link-check-pr.yml`, before the lychee step:

```yaml
- name: Ban GitBook change-request preview URLs
  run: |
    if git grep -n -e '~/changes/' -- '*.md' '*.html' ':!agent-skills/topical/'; then
      echo "::error::..."
      exit 1
    fi
```

Design notes:

- **Tree-wide, not changed-files.** That is the whole point — lychee structurally cannot see this class, because it only scans what a PR touches and these URLs sit on pages nobody is editing. The URL is also syntactically valid and may answer 200 to an authenticated editor, so it would not necessarily fail even if it *were* scanned.
- **`~/reusable/` is deliberately not banned.** Those are legitimate `{% include %}` targets, on 58 pages.
- **`agent-skills/topical/` is excluded**, matching the `files_ignore` already applied to the lychee step: that tree is vendored verbatim from `MariaDB/skills`, so a hit there is not ours to fix.
- **`git grep` rather than `grep -r`**, so `.git` is skipped for free and the exclusion is a pathspec rather than a directory-name glob.

**Both paths of the gate were exercised locally**, not just the passing one: it exits clean on this branch, and dropping a file containing the pattern into the tree makes it fire and print the offending line.

## Checks

`doc-lint.sh` clean, CI-exact codespell clean on both files, `fragcheck.py new main` reports no new dead anchors, and the workflow YAML parses with the new step in the right position.

[DOCS-6507]: https://mariadbcorp.atlassian.net/browse/DOCS-6507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ