### PR TITLE
DOCS-6567 Fail the lint when a page is missing from SUMMARY.md

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -7,7 +7,9 @@ Code. It contains:
 |------|------------|
 | `settings.json` | Project settings, incl. the `PreToolUse(Bash)` hook wiring |
 | `settings.local.json` | **Personal** overrides — gitignored, never committed |
-| `hooks/doc-lint.sh` | Canonical codespell + lychee linter (single source of truth, mirrors CI) |
+| `hooks/doc-lint.sh` | Canonical codespell + lychee linter (single source of truth, mirrors CI), plus four checks with no CI counterpart: includes, heading anchors, orphaned pages, gutted pages |
+| `hooks/fragcheck.py` | GitBook-accurate heading-anchor checker, called by `doc-lint.sh` |
+| `hooks/navcheck.py` | Orphaned-page (nav coverage) checker, called by `doc-lint.sh` |
 | `hooks/pre-commit.sh` | PreToolUse hook: gates Claude-made `git commit`s by calling `doc-lint.sh` |
 | `skills/` | Shared skills (e.g. `docs-check`) |
 | `commands/` | Shared slash commands (e.g. `/precommit`) |

--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
 # doc-lint.sh — the SINGLE SOURCE OF TRUTH for the codespell + lychee invocations that mirror
-# CI (.github/workflows/codespell.yml and link-check-pr.yml), plus three checks that have no CI
-# counterpart (see below): a GitBook include resolver, a heading-anchor gate, and a net
-# line-loss guard.
+# CI (.github/workflows/codespell.yml and link-check-pr.yml), plus four checks that have no CI
+# counterpart (see below): a GitBook include resolver, a heading-anchor gate, an orphaned-page
+# (nav coverage) gate, and a net line-loss guard.
 #
 # The pre-commit hook, the /precommit command, the docs-check skill, and dev-docs/cookbook-pre-pr.md
 # all delegate here instead of re-spelling the flags, so the CI-mirroring options live in exactly
@@ -276,6 +276,41 @@ elif ! git rev-parse --verify -q "$LINT_BASE" >/dev/null 2>&1; then
   echo "doc-lint: base revision '$LINT_BASE' not found — anchor check SKIPPED" >&2
 else
   python3 .claude/hooks/fragcheck.py new "$LINT_BASE" >/dev/null || rc=1
+fi
+
+# --- orphaned pages (nav coverage) — NO CI counterpart --------------------------------------
+# GitBook publishes only the pages listed in a space's SUMMARY.md. A page file with no nav entry
+# never renders, and NOTHING else here can see it: the markup is valid so codespell passes, the
+# links resolve so lychee passes, and the page is simply never built. There is no failing signal
+# anywhere — the only symptom is a reader reporting a missing page.
+#
+# DOCS-6566 is the case. dde0fb263 added four post-download pages (Server 12.3.3, 11.8.9,
+# 11.4.13, 10.11.19) and bumped their most-recent-*.md includes, but never touched
+# platform/SUMMARY.md; all four sat unpublished for eight days until a reader noticed, with every
+# gate green throughout. Replayed against dde0fb263, navcheck names all four and exits 1.
+#
+# Like the anchor gate above, it is diffed against $LINT_BASE and for the same reason: main
+# carries 219 pre-existing orphans (190 in server alone), so an absolute check would fail every
+# unrelated PR on breakage it did not introduce. It reports only pages newly orphaned — added
+# with no nav entry, or de-listed while the file survives.
+#
+# Unlike that gate this needs no worktree (the base side is read with git ls-tree / git show), so
+# it costs milliseconds and has no skip flag. A deliberately unlisted page is legitimate: name it
+# in DOC_LINT_ALLOW_ORPHAN (space/comma-separated, or "all") and say why in the commit message.
+#
+# Needs python3 (no third-party modules) and a git work tree; missing either is a SKIP, as is a
+# base revision that cannot be resolved — never a silent pass into failure.
+if [ ! -f .claude/hooks/navcheck.py ]; then
+  echo "doc-lint: .claude/hooks/navcheck.py not found — orphan check SKIPPED" >&2
+elif ! command -v python3 >/dev/null 2>&1; then
+  echo "doc-lint: python3 not installed — orphan check SKIPPED (no CI counterpart, so nothing" >&2
+  echo "          else will catch a page that is missing from SUMMARY.md)." >&2
+elif ! command -v git >/dev/null 2>&1 || ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "doc-lint: not a git work tree — orphan check SKIPPED (needs a base revision)" >&2
+elif ! git rev-parse --verify -q "$LINT_BASE" >/dev/null 2>&1; then
+  echo "doc-lint: base revision '$LINT_BASE' not found — orphan check SKIPPED" >&2
+else
+  python3 .claude/hooks/navcheck.py new "$LINT_BASE" "${files[@]}" >/dev/null || rc=1
 fi
 
 # --- net line-loss guard — NO CI counterpart ------------------------------------------------

--- a/.claude/hooks/navcheck.py
+++ b/.claude/hooks/navcheck.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""navcheck.py — orphaned-page (nav coverage) checker for the GitBook spaces.
+
+WHY THIS EXISTS
+    GitBook publishes only the pages listed in a space's SUMMARY.md. A page file
+    with no nav entry never renders -- and no other gate in this repo can see
+    that. The file is valid Markdown, so codespell passes; its links resolve, so
+    lychee passes; it is simply never built. There is no failing signal anywhere,
+    and the only symptom is a reader reporting a missing page.
+
+    DOCS-6566 is the case this exists for. dde0fb263 added four post-download
+    pages (Server 12.3.3, 11.8.9, 11.4.13, 10.11.19) and bumped their
+    most-recent-*.md includes, but never touched platform/SUMMARY.md. All four
+    sat unpublished for eight days until a reader noticed. Every gate was green
+    the whole time. Notably, every OTHER commit that ever added a post-download
+    page updated SUMMARY.md in the same commit -- so this is not a broken
+    generator to fix, it is a hand-edit step with no backstop, which is exactly
+    what a linter is for.
+
+WHY IT IS HISTORY-AWARE  (the same trap fragcheck.py documents)
+    main carries 219 pre-existing orphans -- 191 in server alone, measured over
+    the 11 spaces that have a SUMMARY.md (9,468 .md files vs 9,238 nav refs).
+    An absolute check would therefore fail every unrelated PR on breakage it did
+    not introduce, which is precisely why the heading-anchor gate diffs against a
+    base revision rather than reporting its ~1,272 pre-existing dead anchors.
+    `new` reports only what changed, so the backlog stays out of the way while a
+    newly orphaned page still fails.
+
+    A page is NEWLY orphaned when it is unreferenced now AND either did not exist
+    at the base revision, or was referenced there. That covers both directions:
+        * a page added with no nav entry          -- the DOCS-6566 case
+        * a nav entry deleted, page file surviving -- the quieter one, since the
+          page keeps working locally and only vanishes from the built site
+
+WHAT IS NOT A PAGE
+    * the space's own SUMMARY.md (it is the nav, not a page in it)
+    * anything under .gitbook/ -- includes and reusable snippets are pulled into
+      pages by {% include %} and are never nav-listed (117 such files today)
+    A directory only counts as a space if it holds a SUMMARY.md, which is what
+    keeps dev-docs/, .claude/ and help-tables/ out without naming them.
+
+    Cross-space SUMMARY entries are absolute app.gitbook.com URLs (6 today) and
+    are skipped: they point into another space, so they can never mark a local
+    file as referenced.
+
+MODES
+    navcheck.py check [path ...]      every orphan under each path -- for triage
+    navcheck.py new <rev> [path ...]  only pages newly orphaned vs <rev> -- the gate
+
+    Paths are the changed files; the spaces containing them are what gets
+    scanned, since adding a page to one space cannot orphan a page in another.
+    With no paths, every space is scanned.
+
+ESCAPE HATCH
+    DOC_LINT_ALLOW_ORPHAN  space/comma-separated repo-relative paths to exempt,
+                           or "all". A deliberately unlisted page is legitimate;
+                           name it here and say why in the commit message.
+
+Exit: 0 = no new orphans (or SKIPPED), 1 = new orphans found, 2 = usage error.
+Unlike fragcheck.py this needs no worktree -- the base side is read with
+git ls-tree and git show, which is why it costs milliseconds rather than seconds.
+"""
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+SUMMARY = 'SUMMARY.md'
+
+# Markdown link targets in SUMMARY.md. GitBook writes plain relative paths here;
+# the only exceptions on main are 6 absolute cross-space URLs, filtered below.
+LINK_RE = re.compile(r'\]\(\s*<?([^)>\s]+?)>?\s*\)')
+
+
+def repo_root(start='.'):
+    """Nearest ancestor that looks like this repo."""
+    d = pathlib.Path(start).resolve()
+    for cand in [d] + list(d.parents):
+        if (cand / '.codespellignore').is_file() or (cand / '.git').exists():
+            return cand
+    return d
+
+
+def git(root, *args):
+    """Run git, returning (ok, stdout)."""
+    p = subprocess.run(['git', '-C', str(root)] + list(args),
+                       capture_output=True, text=True)
+    return p.returncode == 0, p.stdout
+
+
+def is_page(rel, space):
+    """True if `rel` (repo-relative, posix) is a nav-listable page of `space`."""
+    if not rel.endswith('.md'):
+        return False
+    parts = rel.split('/')
+    if parts[0] != space:
+        return False
+    if os.path.basename(rel) == SUMMARY:
+        return False
+    return '.gitbook' not in parts
+
+
+def parse_refs(text, space):
+    """Repo-relative page paths that a space's SUMMARY.md links to."""
+    refs = set()
+    for target in LINK_RE.findall(text or ''):
+        target = target.split('#')[0].strip()
+        if not target or target.startswith(('http://', 'https://', 'mailto:')):
+            continue
+        if not target.endswith('.md'):
+            continue
+        # SUMMARY.md sits at the space root, so targets resolve against it.
+        refs.add(os.path.normpath(os.path.join(space, target)).replace(os.sep, '/'))
+    return refs
+
+
+def all_spaces(root):
+    return sorted(d.name for d in pathlib.Path(root).iterdir()
+                  if d.is_dir() and not d.name.startswith('.')
+                  and (d / SUMMARY).is_file())
+
+
+def spaces_for(root, paths):
+    """Spaces touched by `paths`; every space when `paths` is empty."""
+    known = all_spaces(root)
+    if not paths:
+        return known
+    hit = set()
+    for p in paths:
+        try:
+            rel = pathlib.Path(p).resolve().relative_to(root).as_posix()
+        except ValueError:
+            rel = str(p).lstrip('./')
+        head = rel.split('/')[0]
+        if head in known:
+            hit.add(head)
+    return sorted(hit)
+
+
+def orphans_now(root, space):
+    """Pages of `space` in the working tree with no SUMMARY.md entry."""
+    sm = pathlib.Path(root) / space / SUMMARY
+    if not sm.is_file():
+        return set()
+    refs = parse_refs(sm.read_text(encoding='utf-8', errors='replace'), space)
+    pages = set()
+    for dirpath, dirnames, filenames in os.walk(pathlib.Path(root) / space):
+        dirnames[:] = [d for d in dirnames if d != '.gitbook']
+        for fn in filenames:
+            rel = os.path.relpath(os.path.join(dirpath, fn), root).replace(os.sep, '/')
+            if is_page(rel, space):
+                pages.add(rel)
+    return pages - refs
+
+
+def orphans_at(root, rev, space):
+    """Same, as of `rev`. Read from the object store -- no worktree needed."""
+    ok, listing = git(root, 'ls-tree', '-r', '--name-only', rev, '--', space + '/')
+    if not ok:
+        return set()
+    pages = {ln for ln in listing.splitlines() if is_page(ln, space)}
+    ok, text = git(root, 'show', f'{rev}:{space}/{SUMMARY}')
+    if not ok:
+        # The space did not exist at rev, so nothing there was orphaned.
+        return set()
+    return pages - parse_refs(text, space)
+
+
+def allowed():
+    raw = os.environ.get('DOC_LINT_ALLOW_ORPHAN', '')
+    return {t for t in re.split(r'[\s,]+', raw) if t}
+
+
+# Above this many findings the copy-paste exemption line is longer than the
+# report it follows, so it stops being an offer and becomes noise. `check` on
+# main hits 219; the gate path realistically produces one batch of a few.
+HINT_MAX = 10
+
+
+def report(found, label):
+    print(f'navcheck: {len(found)} page(s) {label} but not listed in SUMMARY.md:',
+          file=sys.stderr)
+    for rel in found:
+        print(f'  {rel}', file=sys.stderr)
+    print('\n          GitBook publishes only what SUMMARY.md lists, so these files\n'
+          '          will not appear on the live site at all -- no other check can\n'
+          '          see this, because the markup is valid and the links resolve\n'
+          '          (DOCS-6566). Add a nav entry in the space\'s SUMMARY.md, placed\n'
+          '          where a reader would look for it.', file=sys.stderr)
+    if len(found) <= HINT_MAX:
+        print('          Deliberately unlisted? Re-run with\n'
+              f'          DOC_LINT_ALLOW_ORPHAN=\'{" ".join(found)}\'\n'
+              '          and say why in the commit message.', file=sys.stderr)
+    else:
+        print('          Deliberately unlisted? Name those paths in\n'
+              '          DOC_LINT_ALLOW_ORPHAN and say why in the commit message.',
+              file=sys.stderr)
+
+
+def cmd_check(args):
+    root = repo_root(args[0] if args else '.')
+    skip = allowed()
+    if 'all' in skip:
+        return 0
+    found = []
+    for space in spaces_for(root, args):
+        found += sorted(orphans_now(root, space) - skip)
+    if found:
+        report(sorted(found), 'present')
+        return 1
+    print('navcheck: no orphaned pages')
+    return 0
+
+
+def cmd_new(args):
+    if not args:
+        print('navcheck: `new` needs a revision', file=sys.stderr)
+        return 2
+    rev, paths = args[0], args[1:]
+    root = repo_root(paths[0] if paths else '.')
+
+    skip = allowed()
+    if 'all' in skip:
+        return 0
+
+    ok, _ = git(root, 'rev-parse', '--verify', '-q', rev + '^{commit}')
+    if not ok:
+        print(f'navcheck: base revision {rev!r} not found — SKIPPED', file=sys.stderr)
+        return 0
+
+    fresh, pre = [], 0
+    for space in spaces_for(root, paths):
+        now = orphans_now(root, space) - skip
+        before = orphans_at(root, rev, space)
+        pre += len(now & before)
+        fresh += sorted(now - before)
+
+    if fresh:
+        report(sorted(fresh), 'added or de-listed')
+        return 1
+
+    print(f'navcheck: no newly orphaned pages vs {rev} '
+          f'({pre} pre-existing, unchanged)')
+    return 0
+
+
+def main(argv):
+    if len(argv) < 2 or argv[1] in ('-h', '--help'):
+        print(__doc__.rstrip(), file=sys.stderr)
+        return 2
+    mode, args = argv[1], argv[2:]
+    if mode == 'check':
+        return cmd_check(args)
+    if mode == 'new':
+        return cmd_new(args)
+    print(f'navcheck: unknown mode {mode!r} (expected `check` or `new`)', file=sys.stderr)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/.claude/skills/docs-check/SKILL.md
+++ b/.claude/skills/docs-check/SKILL.md
@@ -37,7 +37,7 @@ Default to the files the user changed. Determine the set in this order:
 
 Run all that apply, then report each as PASS / FAIL / SKIPPED.
 
-### 1–4. Spelling + links + includes + gutted pages — via `doc-lint.sh`
+### 1–5. Spelling + links + includes + orphans + gutted pages — via `doc-lint.sh`
 
 Run the **canonical** linter (the single source of truth for the CI-mirroring flags/excludes)
 on the file set, from the repo root:
@@ -94,6 +94,20 @@ on the file set, from the repo root:
   "normalised"** — those ids exist to keep old inbound links working, and rewriting them breaks
   exactly what they preserve. On `main` 48 headings differed from their text slug and only 8 were
   defects, so treating the wide class as the bug would be a 6× overstatement. Added in DOCS-6492.
+- It also gates **orphaned pages** — a page file with no entry in its space's `SUMMARY.md`.
+  GitBook publishes only what `SUMMARY.md` lists, so the page never renders, and no other check
+  here can see it: the markup is valid (codespell PASSes) and the links resolve (lychee PASSes);
+  the page is simply never built. DOCS-6566 is the case — `dde0fb263` added four post-download
+  pages without touching `platform/SUMMARY.md` and they sat unpublished for eight days with every
+  gate green, until a reader reported them. Like the anchor gate it is **history-aware**, and for
+  the same reason: `main` carries 219 pre-existing orphans (190 in `server`), so it reports only
+  pages newly orphaned against `DOC_LINT_BASE` — added with no nav entry, or de-listed while the
+  file survives. Needs python3 and a git work tree; missing either is a SKIP. Costs ~40 ms, so
+  there is no skip flag. A deliberately unlisted page is legitimate: re-run with
+  `DOC_LINT_ALLOW_ORPHAN='<path>'` and tell the user to say why in the commit message — report it
+  as FAIL when unverified, WARN when acknowledged. For triage,
+  `.claude/hooks/navcheck.py check [path ...]` lists every current orphan, not just the new ones.
+  Added in DOCS-6567.
 - It also flags a **gutted page** — any file that lost more than 40% of its lines *net*
   (deletions minus additions; min 20 lines lost, pre-image ≥ 30 lines) against `DOC_LINT_BASE`
   (default `HEAD`). No CI counterpart, never SKIPs. This catches what the other checks
@@ -138,10 +152,20 @@ a `{%`-like fragment inside a code sample is not a real block.
 
 ### 6. SUMMARY.md consistency
 
-If any page was **added/moved/renamed**, confirm the space's `SUMMARY.md` has a matching entry
-pointing at the correct path. Flag pages with no nav entry, and `SUMMARY.md` entries pointing
-at non-existent files. (Note: the nightly error-sync job legitimately auto-commits
-`server/SUMMARY.md` — don't treat its entries as anomalies.)
+**The orphan half of this is now automated** — `doc-lint.sh` fails on a page with no nav entry
+(see the orphan gate above), so don't re-derive it by hand or second-guess its verdict. Until
+DOCS-6567 this bullet was the repo's *only* orphan check, and being an LLM heuristic that runs
+only when someone invokes the skill is exactly how DOCS-6566 shipped four unpublished pages.
+
+What remains for you, because the automated gate does not cover it:
+
+- `SUMMARY.md` entries pointing at **non-existent files** (the dangling direction — a nav entry
+  whose target was deleted or renamed).
+- Whether a moved/renamed page's entry sits in the **right place** in the tree and reads sensibly
+  in context — ordering and nesting are editorial, not mechanical.
+
+(Note: the nightly error-sync job legitimately auto-commits `server/SUMMARY.md` — don't treat its
+entries as anomalies.)
 
 ### 7. Fact-check report present (heuristic, paper trail)
 
@@ -165,6 +189,7 @@ docs-check on 3 files:
   codespell ...... PASS
   lychee ......... FAIL (2 broken links — see below)
   includes ....... FAIL (dead include in platform/post-download/x.md:22)
+  orphan pages ... FAIL (platform/post-download/x.md has no SUMMARY.md entry)
   gutted pages ... FAIL (storage-engines/README.md lost 93% of its lines net)
   frontmatter .... PASS
   gitbook blocks . FAIL (unclosed {% tabs %} in server/foo.md)

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -15,7 +15,7 @@ skill, which runs them for you; this page documents what it does and how to run 
 
 Only the first two can fail your PR; aliases and help-tables are regenerated automatically.
 
-## 1. Spelling + links + includes + gutted pages — `doc-lint.sh`
+## 1. Spelling + links + includes + orphans + gutted pages — `doc-lint.sh`
 
 The codespell and lychee invocations that mirror CI live in **one** place,
 `.claude/hooks/doc-lint.sh`. Run it instead of re-typing the flags:
@@ -81,6 +81,33 @@ DOC_LINT_SKIP_FRAGMENTS=1 .claude/hooks/doc-lint.sh <files>
 ```
 
 (Added in DOCS-6491.)
+
+It also gates **orphaned pages** — a page file with no entry in its space's `SUMMARY.md`. GitBook
+publishes only what `SUMMARY.md` lists, so such a page never renders, and no other check here can
+see that: the markup is valid so codespell passes, the links resolve so lychee passes, and the
+page is simply never built. There is no failing signal anywhere; the only symptom is a reader
+reporting a missing page.
+
+DOCS-6566 is the case. `dde0fb263` added four post-download pages (Server 12.3.3, 11.8.9, 11.4.13
+and 10.11.19) and bumped their `most-recent-*.md` includes but never touched
+`platform/SUMMARY.md`. All four sat unpublished for eight days with every gate green, until a
+reader noticed. Replayed against that commit, the check names all four and fails.
+
+Like the anchor gate it is history-aware, and for the same reason: `main` carries **219**
+pre-existing orphans (190 in `server` alone), so an absolute check would fail every unrelated PR
+on breakage it did not introduce. It reports only pages *newly* orphaned against `DOC_LINT_BASE` —
+added with no nav entry, or de-listed while the file survives. Unlike the anchor gate it needs no
+worktree, so it costs ~40 ms and has no skip flag.
+
+A deliberately unlisted page is legitimate, so this gate is acknowledged rather than silenced:
+
+```bash
+DOC_LINT_ALLOW_ORPHAN='space/path/to/page.md' .claude/hooks/doc-lint.sh <files>
+```
+
+and say why in the commit message; `DOC_LINT_ALLOW_ORPHAN=all` disables the check. For triage,
+`.claude/hooks/navcheck.py check [path ...]` prints the full current orphan inventory rather than
+just the new ones. (Added in DOCS-6567.)
 
 Finally, it flags a **gutted page**: any file in the set that lost more than **40%** of its lines
 *net* (deletions minus additions, minimum 20 lines lost, pre-image at least 30 lines) against


### PR DESCRIPTION
Fixes [DOCS-6567](https://mariadbcorp.atlassian.net/browse/DOCS-6567). Follow-up to DOCS-6566 (#1003).

## The gap

GitBook publishes only the pages listed in a space's `SUMMARY.md`. A page file with no nav entry never renders — and **no gate in this repo could see that**. The markup is valid, so codespell passes. The links resolve, so lychee passes. The page is simply never built, so there is no failing signal anywhere. The only symptom is a reader reporting a missing page.

That is how DOCS-6566 happened: `dde0fb263` added four post-download pages and bumped their `most-recent-*.md` includes but never touched `platform/SUMMARY.md`. All four sat unpublished for eight days, every check green throughout, until a reader noticed.

Before this PR the repo's only orphan check was check 6 of the `docs-check` skill — an LLM-performed heuristic that runs solely when a human invokes it.

## The change

New `.claude/hooks/navcheck.py`, wired into `doc-lint.sh` as a fourth check with no CI counterpart.

**It is history-aware, and that is the load-bearing design decision.** `main` carries **219** pre-existing orphans (190 in `server` alone, measured across the 11 spaces that have a `SUMMARY.md`: 9,468 `.md` files vs 9,238 nav refs). An absolute check would fail every unrelated PR on breakage it did not introduce — precisely the trap already documented for the heading-anchor gate and its ~1,272 pre-existing dead anchors. So it diffs against `DOC_LINT_BASE` and reports only pages *newly* orphaned:

- a page added with no nav entry — the DOCS-6566 case;
- a nav entry deleted while the page file survives — the quieter direction, since the page keeps working locally and only vanishes from the built site.

**Unlike `fragcheck.py` it needs no worktree.** It only needs a file list and one file's contents per space, so the base side is read with `git ls-tree` and `git show`. That is why it costs ~40 ms scoped to a space (209 ms across all 11) against fragcheck's ~14 s, and why it has no skip flag.

## Verification

Replaying the real `dde0fb263` in a worktree at that commit:

```
navcheck: 4 page(s) added or de-listed but not listed in SUMMARY.md:
  platform/post-download/mariadb-server-10.11.19.md
  platform/post-download/mariadb-server-11.4.13.md
  platform/post-download/mariadb-server-11.8.9.md
  platform/post-download/mariadb-server-12.3.3.md
exit=1
```

It catches the actual incident and names all four pages.

| Scenario | Expected | Actual |
| --- | --- | --- |
| clean tree, all spaces | 0 | 0 |
| added page with no nav entry | 1 | 1 |
| …acknowledged via `DOC_LINT_ALLOW_ORPHAN` | 0 | 0 |
| nav entry deleted, page survives | 1 | 1 |
| edit to a **pre-existing** orphan | 0 | 0 |
| unresolvable base rev → SKIP | 0 | 0 |
| file outside any space | 0 | 0 |
| bad mode → usage error | 2 | 2 |
| `doc-lint.sh` end-to-end, clean tree | 0 | 0 |

`py_compile`, `bash -n` and `shellcheck -S warning` are clean; `doc-lint.sh` passes on the changed docs.

## Scope decisions

- A directory counts as a space only if it holds a `SUMMARY.md`. That keeps `dev-docs/`, `.claude/` and `help-tables/` out without hardcoding names.
- `.gitbook/` is excluded — 117 include and reusable-snippet files that are pulled in by `{% include %}` and are never nav-listed.
- The space's own `SUMMARY.md` is not a page in itself.
- Cross-space `SUMMARY` entries are absolute `app.gitbook.com` URLs (6 today) and are skipped; they point into another space and can never mark a local file as referenced.
- `DOC_LINT_ALLOW_ORPHAN` (space/comma-separated, or `all`) exempts a deliberately unlisted page, matching how `DOC_LINT_ALLOW_SHRINK` works for the gutted-page guard.

## Docs

`dev-docs/cookbook-pre-pr.md`, `.claude/skills/docs-check/SKILL.md` and `.claude/README.md` are updated. Check 6 of the skill is rewritten: its orphan half is now automated, and the note says plainly that being an invoke-only heuristic is how DOCS-6566 shipped. What remains there is the dangling direction (nav entries pointing at deleted files) and whether a moved page's entry sits in the right place — both genuinely editorial.

## Note for reviewers

**CI does not exercise this.** The gate runs in the pre-commit hook and via `docs-check`, not in a workflow, so the green checks on this PR say nothing about it. The replay above is the evidence. Adding a CI job is a separate change and deliberately not bundled here.

Triaging the 219 pre-existing orphans is also out of scope — some are surely intentional, some are likely lost content of exactly the DOCS-6566 kind. `.claude/hooks/navcheck.py check` prints the full inventory for whoever picks that up.


[DOCS-6567]: https://mariadbcorp.atlassian.net/browse/DOCS-6567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ