### PR TITLE
DOCS-6508 Fix four nonexistent variables on server reference pages

### DIFF
--- a/server/clients-and-utilities/myisam-clients-and-utilities/memory-and-disk-use-with-myisamchk.md
+++ b/server/clients-and-utilities/myisam-clients-and-utilities/memory-and-disk-use-with-myisamchk.md
@@ -21,7 +21,7 @@ There are a number of [system variables](../../ha-and-performance/optimization-a
 * [sort\_buffer\_size](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#sort_buffer_size). By default this is 4M, but it's very useful to increase to make myisamchk sorting much faster. Since the server won't be running when you run myisamchk, you can increase substantially. 16M is usually a minimum, but values such as 256M are not uncommon if memory is available.
 * [key\_buffer\_size](../../server-usage/storage-engines/myisam-storage-engine/myisam-system-variables.md#key_buffer_size) (which particularly helps with the --extend-check and --safe-recover options.
 * [read\_buffer\_size](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#read_buffer_size)
-* `write_buffer_size`
+* `write_buffer_size` (a myisamchk option, not a server system variable)
 
 For example, if you have more than 512MB available to allocate to the process, the following settings could be used:
 

--- a/server/reference/full-list-of-mariadb-options-system-and-status-variables.md
+++ b/server/reference/full-list-of-mariadb-options-system-and-status-variables.md
@@ -1040,7 +1040,6 @@ description: >-
 * [lc\_messages](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#lc_messages)
 * [lc\_messages\_dir](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#lc_messages_dir)
 * [lc\_time\_names](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#lc_time_names)
-* `legacy_xa_rollback_at_disconnect`
 * [license](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#license)
 * [local\_infile](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#local_infile)
 * [lock\_wait\_timeout](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#lock_wait_timeout)
@@ -1747,7 +1746,6 @@ description: >-
 * -O, --[set-variable](../server-management/starting-and-stopping-mariadb/mariadbd-options.md)
 * [shared\_memory](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#shared_memory)
 * [shared\_memory\_base\_name](../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#shared_memory_base_name)
-* `show_old_temporals`
 * [show\_slave\_auth\_info](../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#show_slave_auth_info)
 * \--[silent-startup](../server-management/starting-and-stopping-mariadb/mariadbd-options.md)
 * [simple\_password\_check\_digits](plugins/password-validation-plugins/simple-password-check-plugin.md#simple_password_check_digits)

--- a/server/reference/sql-statements/transactions/xa-transactions.md
+++ b/server/reference/sql-statements/transactions/xa-transactions.md
@@ -262,8 +262,7 @@ See [Transaction Coordinator Log Overview: MariaDB Galera Cluster](../../../serv
 From MariaDB 10.5, `XA PREPARE` persists the XA transaction following the XA Specification. If an existing application relies on the previous behavior, upgrading to 10.5 or later can leave XA transactions in the `PREPARE`d state indefinitely after disconnect, causing such applications to no longer function correctly.
 {% endhint %}
 
-As a work-around, the variable `legacy_xa_rollback_at_disconnect` can be set to TRUE to re-enable the old behavior and roll back XA transactions in the `PREPARE`d state at disconnect. This is non-standard
-behaviour, and is not recommended for new applications. If rollback-at-disconnect is desired, it is better to use a normal (non-XA) transaction.
+If rollback-at-disconnect is desired, it is better to use a normal (non-XA) transaction rather than XA.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/server-management/starting-and-stopping-mariadb/mariadbd-options.md
+++ b/server/server-management/starting-and-stopping-mariadb/mariadbd-options.md
@@ -108,7 +108,6 @@ other MariaDB and MySQL versions. Options that are also system variables are lis
 * [--old-alter-table](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#old_alter_table)
 * [--old-mode](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#old_mode)
 * [--old-passwords](../../ha-and-performance/optimization-and-tuning/system-variables/server-system-variables.md#old_passwords)
-* `--show-old-temporals`
 
 ## Locale Options
 

--- a/server/server-usage/storage-engines/spider/spider-system-variables.md
+++ b/server/server-usage/storage-engines/spider/spider-system-variables.md
@@ -29,7 +29,7 @@ Before this change, a non-minus-one system variable value would override the tab
   * `0` Normal Mode. Uses a counter that Spider gets from the remote backend server with an exclusive lock for the auto-increment value. This mode is slow. Use Quick Mode (`2`), if you use Spider tables with the table partitioning feature and the auto-increment column is the first column of the index.
   * `1` Quick Mode. Uses an internal Spider counter for the auto-increment value. This mode is fast, but it is possible for duplicates to occur when updating the same table from multiple Spider proxies.
   * `2` Set Zero Mode. The auto-increment value is given by the remote backend. Sets the column to `0`, even if you set the value to the auto-increment column in your statement. If you use the table with the table partitioning feature, it sets to zero after choosing an inserted partition.
-  * `3` When the auto-increment column is set to `NULL`, the value is given by the remote backend server. If you set the auto-increment column to `0`,the value is given by the local server. Set `spider_reset_auto_increment` to `2` or `3` if you want to use an auto-increment column on the remote server.
+  * `3` When the auto-increment column is set to `NULL`, the value is given by the remote backend server. If you set the auto-increment column to `0`,the value is given by the local server. Set `spider_auto_increment_mode` to `2` or `3` if you want to use an auto-increment column on the remote server.
 * Scope: Global, Session
 * Dynamic: Yes
 * Data Type: `numeric`


### PR DESCRIPTION
Four variables were documented on server reference pages but exist in **neither** the Community (13.1.0) nor Enterprise (10.6.28) server source — verified by exact-string `git grep` against both trees (fact-check report on DOCS-6508).

- **`legacy_xa_rollback_at_disconnect`** — 0 hits; no XA rollback-at-disconnect variable exists. Removed the fabricated work-around sentence in `xa-transactions.md` and the entry in the full options/variables list.
- **`show_old_temporals`** — MySQL-only (present only in a mysql-test file as "Port … from MySQL 5.6"). Removed the `--show-old-temporals` mariadbd option and the `show_old_temporals` system-variable list entry.
- **`spider_reset_auto_increment`** — no such Spider variable. The sentence sits inside `spider_auto_increment_mode`'s own mode-3 description, so renamed to `spider_auto_increment_mode`.
- **`write_buffer_size`** — a myisamchk client option, not a server system variable; annotated as such on the myisamchk memory page.

**Spider rename — partially confirmed:** A Spider engineer confirmed `spider_auto_increment_mode` is the likely intended variable (informal review, not a full sign-off). They were unable to confirm whether the accompanying behavioral claim — that modes 2/3 are what you'd use "to use an auto-increment column on the remote server" — is accurate, due to time constraints. The rename is included in this PR; the behavioral description is pre-existing doc text, carried over unchanged, and has not been independently verified by this fix.

Ticket: https://mariadbcorp.atlassian.net/browse/DOCS-6508

🤖 Generated with [Claude Code](https://claude.com/claude-code)