### PR TITLE
DOCS-6524 Run fragcheck.py in CI: PR gate plus nightly digest

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -275,6 +275,16 @@ elif ! command -v git >/dev/null 2>&1 || ! git rev-parse --is-inside-work-tree >
 elif ! git rev-parse --verify -q "$LINT_BASE" >/dev/null 2>&1; then
   echo "doc-lint: base revision '$LINT_BASE' not found — anchor check SKIPPED" >&2
 else
+  # Spelled identically in .github/workflows/fragcheck-pr.yml (PR gate, base =
+  # the PR base) and .github/workflows/nightly-fragcheck.yml (base = a rolling
+  # 24 hours) — DOCS-6524. The mode takes no flags, which is why CI calls the
+  # script directly instead of routing through this file the way it must for the
+  # codespell and lychee flag sets; if that ever changes, change all three.
+  #
+  # One difference is deliberate: an uncheckoutable base is a SKIP here (never
+  # block a local commit over a missing baseline) and a hard failure in CI,
+  # where a check that cannot run must not report success. Both workflows assert
+  # the base object exists before invoking, because this returns 0 in that case.
   python3 .claude/hooks/fragcheck.py new "$LINT_BASE" >/dev/null || rc=1
 fi
 

--- a/.github/workflows/fragcheck-pr.yml
+++ b/.github/workflows/fragcheck-pr.yml
@@ -1,0 +1,201 @@
+name: Check Heading Anchors in PR
+
+# Gates dead GitBook heading anchors (`page.md#some-heading`) -- the one
+# documentation rot class that had no CI counterpart at all.
+#
+# link-check-pr.yml deliberately passes no --include-fragments, and that is
+# correct: measured on main under DOCS-6491, lychee's GitHub-flavoured slugger
+# was wrong in BOTH directions on this repo -- 1,129 reported fragment errors of
+# which 386 were false positives (the anchor resolves on the live site), while
+# 213 genuinely dead anchors went unreported. .claude/hooks/fragcheck.py
+# implements GitBook's own slug rules instead, validated at 4,599/4,599 computed
+# anchors against the rendered pages, and is what runs here.
+#
+# Until now every entry point to that script was local: the /precommit command,
+# the docs-check skill, and the Claude Code PreToolUse(Bash) hook -- whose own
+# header records the limit, that it "only gates commits that Claude Code makes
+# via the Bash tool. Human git commit, IDE commits, and GitBook-UI edits bypass
+# it entirely." So a PR from anyone who did not run doc-lint.sh by hand was not
+# anchor-checked at all. PR #966 is the worked example: its test plan records
+# that fragcheck "failed on a network fetch", so the author got no anchor check.
+# That PR happened to be clean, but by luck rather than by gate. See DOCS-6524.
+#
+# WHY `new` AND NOT `check`
+#   `check` prints the standing inventory -- 15 dead anchors on main as this was
+#   written, all of them already owned by DOCS-6509/6510. Gating on that would
+#   turn every unrelated PR red on breakage it did not introduce, which is the
+#   same trap the lychee `broken-reference` exclusion documents.
+#
+#   `new <base>` scans the working tree and a throwaway git worktree at <base>
+#   and reports only the difference, so pre-existing rot stays out of the way
+#   while a heading rename that breaks inbound links from pages this PR never
+#   touched still fails. It gates two classes:
+#     * anchors the base revision resolved and the head does not (a rename)
+#     * headings that took over another heading's explicit id (DOCS-6492) --
+#       invisible to every link checker, this one included, because the anchors
+#       all exist and resolve; they just land on the wrong section
+#
+# WHY THIS CALLS THE SCRIPT DIRECTLY RATHER THAN doc-lint.sh
+#   doc-lint.sh is the single source of truth for the codespell and lychee FLAG
+#   sets, because those are ~40 lines of excludes that CI and local must not
+#   drift on. `fragcheck.py new <rev>` has no flags at all, and running
+#   doc-lint.sh here would re-run codespell and lychee, which already have their
+#   own workflows. The invocation below is spelled exactly as doc-lint.sh spells
+#   it; the comment there points back at this file so the two cannot drift
+#   unnoticed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+# A second push supersedes the first: this scans the whole tree twice by design,
+# so an abandoned run is ~30s of runner time with nobody reading the result.
+concurrency:
+  group: fragcheck-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fragcheck:
+    runs-on: ubuntu-latest
+    # Two full-tree scans measured ~13.5s locally. 10 minutes is generous
+    # headroom; without it the job inherits the 6-hour default, and a wedged
+    # git worktree call would end as *cancelled*, which `if: failure()` does
+    # not catch.
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # REQUIRED. `new` checks the base revision out into a throwaway
+          # worktree, so the base commit object must be present. On a shallow
+          # clone it is not -- and note what that failure looks like: the script
+          # prints "cannot check out <rev> -- no baseline, SKIPPED" and exits
+          # ZERO. A shallow checkout would therefore leave this gate
+          # permanently, silently green. The assertion step below exists so that
+          # cannot happen quietly.
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changes
+        # SHA-pinned rather than tag-pinned: this action was compromised in
+        # March 2025 (CVE-2025-30066), when tags in the v1-v45 range were
+        # repointed at code that leaked runner secrets. Pinning the commit
+        # removes the retag vector. Dependabot keeps the SHA and the comment
+        # in sync. See DOCS-6362.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          # Only .md matters: anchors are published by Markdown headings and
+          # linked from Markdown. .html pages carry no GitBook heading anchors.
+          files: |
+            **.md
+          # agent-skills/topical/ is vendored verbatim from MariaDB/skills (see
+          # agent-skills/topical/VENDORED.md). Fixes go upstream, not here.
+          #
+          # This filter decides only WHETHER to run. The scan itself is
+          # deliberately tree-wide -- see the `new` note in the header.
+          files_ignore: |
+            agent-skills/topical/**
+
+      - name: Set up Python
+        if: steps.changes.outputs.any_changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          # fragcheck.py is standard library only, so this pins the interpreter
+          # rather than installing anything.
+          python-version: '3.12'
+
+      # Separated from the scan step on purpose. `fragcheck.py new` treats an
+      # uncheckoutable base as a SKIP and returns 0, which is right for a local
+      # pre-commit hook (never block a commit over a missing baseline) and wrong
+      # for a gate (a check that cannot run must not report success). Asserting
+      # first converts that silent pass into a red run.
+      - name: Verify the base revision is present
+        if: steps.changes.outputs.any_changed == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASE_SHA:-}" ]]; then
+            echo "::error::The PR base SHA is empty, so the anchor gate has no baseline to diff against."
+            exit 1
+          fi
+          # cat-file -e, not rev-parse: rev-parse succeeds on a well-formed sha
+          # that is not in the object database, which is exactly the shallow-clone
+          # case this guards.
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Base commit ${BASE_SHA} is not in this clone, so the anchor gate would SKIP and report success. Check that fetch-depth: 0 is still set on the checkout step."
+            exit 1
+          fi
+          echo "Base revision ${BASE_SHA} present."
+
+      - name: Check heading anchors
+        if: steps.changes.outputs.any_changed == 'true'
+        id: fragcheck
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          # Findings go to stderr, the clean message to stdout; capture both in
+          # order so the summary reads the way the local run does. Via env rather
+          # than interpolated into the script -- the house rule
+          # link-check-pr.yml documents (DOCS-6361).
+          set +e
+          python3 .claude/hooks/fragcheck.py new "$BASE_SHA" > fragcheck.log 2>&1
+          rc=$?
+          set -e
+          cat fragcheck.log
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          # rc 1 is findings; rc 2 is a usage error from the script itself
+          # (e.g. no revision passed). Anything else is a crash. All three are
+          # failures here, but they get different messages so the fix is obvious
+          # from the annotation alone.
+          case "$rc" in
+            0) ;;
+            1) echo "::error::This PR kills a heading anchor that its base revision resolved, or gives a heading another heading's id. Details in the job log and the run summary." ;;
+            2) echo "::error::fragcheck.py rejected its arguments -- the workflow is misconfigured, not the PR." ;;
+            *) echo "::error::fragcheck.py exited $rc (crash). This is a tooling failure, not a PR finding." ;;
+          esac
+          exit "$rc"
+
+      - name: Record the result in the run summary
+        # always(): the default is an implicit success(), which would skip
+        # exactly the runs worth recording.
+        if: always() && steps.changes.outputs.any_changed == 'true'
+        env:
+          RC: ${{ steps.fragcheck.outputs.rc }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Heading-anchor check"
+            echo
+            if [[ ! -s fragcheck.log ]]; then
+              echo "No output was produced -- an earlier step failed before the scan ran."
+            else
+              case "${RC:-}" in
+                0) echo "No new dead heading anchors, and no heading took over another's id." ;;
+                1) echo "This PR introduces heading-anchor breakage. A renamed heading breaks every inbound link to its old anchor, including links from pages this PR never touched: either restore the heading text or retarget the links listed below." ;;
+                *) echo "The check did not complete (exit ${RC:-unknown}). This is a tooling failure, not a PR finding." ;;
+              esac
+              echo
+              # Fenced, and with four backticks. This summary is a GFM rendering
+              # surface and the output embeds heading text and file paths from
+              # the PR, which are author-controlled: unfenced, a crafted heading
+              # could forge a heading, plant a link, or open an HTML comment that
+              # swallows the rest of the page. Four backticks so content
+              # containing three cannot close the fence. Same reasoning as
+              # nightly-unlabeled-prs.yml.
+              echo '````text'
+              cat fragcheck.log
+              echo '````'
+              echo
+              echo "Run the same check locally with:"
+              echo
+              echo '````bash'
+              echo "python3 .claude/hooks/fragcheck.py new ${GITHUB_BASE_REF:-main}"
+              echo '````'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-fragcheck.yml
+++ b/.github/workflows/nightly-fragcheck.yml
@@ -1,0 +1,326 @@
+name: Nightly heading-anchor digest
+
+# Reports heading anchors that died in the last 24 hours.
+#
+# WHY THIS IS NOT REDUNDANT WITH fragcheck-pr.yml
+#   This repo has write paths that never produce a pull request, and a
+#   `pull_request` trigger is structurally blind to all of them:
+#     * GitBook-UI edits sync straight back to Git as GITBOOK-* commits (the
+#       pre-commit hook header says so in as many words)
+#     * the alias-expansion bot rewrites links on merge (DOCS-6481) -- a link
+#       rewriter is exactly the kind of thing that can break a fragment AFTER
+#       the PR gate ran green
+#   So the gate covers PRs and this covers the tree. See DOCS-6524.
+#
+# WHY `new` AND NOT `check`
+#   `check` prints the standing inventory -- 15 dead anchors as this was
+#   written, all already owned by DOCS-6509/6510 -- so a nightly `check` would
+#   report the same 15 every night forever. That is precisely the failure
+#   nightly-unlabeled-prs.yml warns about in its own header: "a daily '0
+#   untriaged' message trains the channel to ignore the bot." A daily identical
+#   15 is worse, because it also looks like work.
+#
+#   A rolling 24-hour base instead makes this the SAME invocation as the PR
+#   gate with a different base -- one code path, one set of buckets -- and it is
+#   stateless: no baseline file to commit, no cache artifact to expire.
+#
+# Tue-Fri it posts to Slack only when the delta is non-empty. The run summary
+# records every run regardless, including the failed ones.
+#
+# Monday is the exception, and it exists to make silence mean something. Most
+# nights will genuinely be clean, so silence is the healthy state -- and GitHub
+# suspends schedules after 60 days without a push. Without a weekly "nothing to
+# report", a suspended cron is indistinguishable from a clean repo. `errors:
+# true` below catches a failed *delivery*, but a run that never happens cannot
+# report itself.
+#
+# The residual gap is the same one the unlabeled-PR digest documents: a Monday
+# message proves Monday worked, not Tue-Fri. That bounds undetected breakage at
+# about a week rather than eliminating it.
+#
+# Read-only by design: no auto-filed Jira tickets, no opened GitHub issues. The
+# standing backlog is already owned by DOCS-6509/6510, so filing would
+# duplicate, and both fragcheck and the digest precedent deliberately leave the
+# decision to a human.
+
+on:
+  workflow_dispatch:
+    inputs:
+      always_post:
+        description: 'Post to Slack even when no anchors broke'
+        required: false
+        default: false
+        type: boolean
+      base_rev:
+        description: 'Override the rolling base revision (a sha or anything git rev-parse accepts)'
+        required: false
+        default: ''
+        type: string
+  # 06:20 UTC, five minutes after the unlabeled-PR digest so the two do not
+  # arrive in the channel as one indistinguishable block. Weekends are skipped:
+  # a Saturday digest reaches nobody and only ages by Monday.
+  #
+  # Split into two entries rather than one '20 6 * * 1-5' so the steps can tell
+  # Monday apart: github.event.schedule carries the cron string verbatim, which
+  # is only useful as a discriminator if Monday has its own line.
+  schedule:
+    # Tue-Fri: speaks only when something broke.
+    - cron: '20 6 * * 2-5'
+    # Monday: also speaks when nothing broke, as the weekly heartbeat.
+    - cron: '20 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-fragcheck
+  cancel-in-progress: false
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    # Two full-tree scans, ~13.5s locally. Without this the job inherits the
+    # 6-hour default, so a wedged git call burns six hours of runner time and
+    # then ends as *cancelled* -- which `if: failure()` does not catch, so
+    # nobody would hear about it.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # REQUIRED, and load-bearing in a way worth spelling out: `new` checks
+          # the base revision out into a throwaway worktree, and when it cannot,
+          # it prints "no baseline, SKIPPED" and returns ZERO. On a shallow
+          # clone this digest would therefore report "nothing broke" every night
+          # forever. The resolve step below turns that into a red run.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Standard library only; this pins the interpreter, it installs nothing.
+          python-version: '3.12'
+
+      - name: Resolve the rolling base revision
+        id: base
+        env:
+          BASE_OVERRIDE: ${{ inputs.base_rev }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${BASE_OVERRIDE:-}" ]]; then
+            # A hand-supplied revision is resolved rather than trusted, so a
+            # typo fails here with a clear message instead of becoming a SKIP.
+            base=$(git rev-parse --verify "${BASE_OVERRIDE}^{commit}" 2>/dev/null || true)
+            if [[ -z "$base" ]]; then
+              echo "::error::base_rev '${BASE_OVERRIDE}' does not resolve to a commit in this clone."
+              exit 1
+            fi
+          else
+            # HEAD, not origin/main: on a schedule trigger the checkout IS the
+            # default branch, and actions/checkout does not guarantee a
+            # remote-tracking ref to lean on.
+            #
+            # -1 --before gives the newest commit at or before the cutoff, so
+            # the window is "everything committed in the last 24 hours".
+            base=$(git rev-list -1 --before='24 hours ago' HEAD || true)
+            if [[ -z "$base" ]]; then
+              echo "::error::No commit older than 24 hours was found, so there is no rolling base. Expected on a brand-new or shallow clone only."
+              exit 1
+            fi
+          fi
+
+          # Same assertion as the PR gate, and for the same reason: rev-parse
+          # succeeds on a well-formed sha that is absent from the object
+          # database, and an absent base is a silent pass.
+          if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "::error::Base commit ${base} is not in this clone, so the scan would SKIP and report success."
+            exit 1
+          fi
+
+          {
+            echo "sha=$base"
+            echo "short=$(git rev-parse --short "$base")"
+            echo "date=$(git log -1 --format=%cI "$base")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Scan for newly dead heading anchors
+        id: scan
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set -uo pipefail
+          set +e
+          python3 .claude/hooks/fragcheck.py new "$BASE_SHA" > fragcheck.log 2>&1
+          rc=$?
+          set -e
+          cat fragcheck.log
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          # A FINDING IS NOT A FAILURE HERE. This is a read-only digest, so rc 1
+          # must leave the job green -- otherwise every finding would also fire
+          # the `if: failure()` notice below and the channel would get two
+          # messages for one event, one of them claiming the digest is broken.
+          # rc 2 (the script rejecting its arguments) and anything else (a
+          # crash) ARE failures: they mean the digest did not run.
+          case "$rc" in
+            0|1) exit 0 ;;
+            2) echo "::error::fragcheck.py rejected its arguments -- the workflow is misconfigured."; exit 1 ;;
+            *) echo "::error::fragcheck.py exited $rc (crash). The digest did not run."; exit 1 ;;
+          esac
+
+      - name: Build the Slack payload
+        id: payload
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RC: ${{ steps.scan.outputs.rc }}
+          BASE_SHORT: ${{ steps.base.outputs.short }}
+          BASE_DATE: ${{ steps.base.outputs.date }}
+          COMPARE_URL: ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.base.outputs.sha }}...${{ github.sha }}
+          # 'true' only on the Monday cron. github.event.schedule holds the cron
+          # string exactly as written above, and is absent on workflow_dispatch,
+          # where the comparison yields false. Renders as the literal 'true' or
+          # 'false', which --argjson reads as a boolean.
+          HEARTBEAT: ${{ github.event.schedule == '20 6 * * 1' }}
+        run: |
+          set -euo pipefail
+
+          # jq builds the whole payload, so heading text containing a quote, a
+          # backslash or an emoji cannot produce invalid JSON. Hand-interpolating
+          # it into a YAML payload: block is the same class of bug as the
+          # filename quoting in link-check-pr.yml (DOCS-6361).
+          #
+          # But valid JSON is not the same as safe *mrkdwn*. The scan output
+          # embeds heading text and file paths from the repo, and anyone with a
+          # GitHub account can open a PR on this public repo -- and a GitBook-UI
+          # edit reaches the tree with no review at all. Slack parses `text` as
+          # mrkdwn, where `<url|label>` is link syntax, so an unescaped heading
+          # reading
+          #   see <https://evil.example|github.com/.../pull/9999>
+          # would render as a clickable link whose visible text is a github.com
+          # URL and whose target is not, delivered by a trusted bot. `esc`
+          # neutralizes that. Same reasoning, and the same deliberate decision
+          # not to escape `*`, `_` or backticks, as nightly-unlabeled-prs.yml.
+          #
+          # The body is truncated at 2,800 characters: Slack rejects an
+          # incoming-webhook payload over 4,000 with msg_too_long, and at
+          # `errors: true` that is a red run rather than a swallowed one -- so a
+          # night with 200 broken anchors would otherwise fail to deliver
+          # exactly when it matters most. The step summary carries the full log.
+          jq -n \
+            --rawfile log fragcheck.log \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg run "$RUN_URL" \
+            --arg base "$BASE_SHORT" \
+            --arg basedate "$BASE_DATE" \
+            --arg compare "$COMPARE_URL" \
+            --argjson rc "${RC:-0}" \
+            --argjson heartbeat "${HEARTBEAT:-false}" '
+            def esc: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
+
+            ($log | esc) as $body
+            | (if ($body | length) > 2800
+               then ($body[0:2800] + "\n… truncated; full output in the run summary.")
+               else $body end) as $body
+            | { text: (
+                  if $rc == 0 and $heartbeat then
+                    ":coffee: *Weekend was quiet* — no heading anchors broke in \($repo) since \($base) (\($basedate))."
+                    + "\n\n<\($run)|workflow run>"
+                  elif $rc == 0 then
+                    ":white_check_mark: No heading anchors broke in \($repo) since \($base)."
+                    + "\n\n<\($run)|workflow run>"
+                  else
+                    ":link: *Heading anchors broke in \($repo)* since \($base) (\($basedate))\n"
+                    + "```\n\($body)\n```"
+                    + "\n\nA renamed heading breaks every inbound link to its old anchor, including links from pages the commit never touched."
+                    + "\n<\($compare)|commits in this window> · <\($run)|workflow run>"
+                  end
+                ) }' > payload.json
+
+          jq -e . payload.json > /dev/null   # fail loudly rather than posting garbage
+
+      - name: Record the result in the run summary
+        # always(): the runs most worth a record are the ones that failed.
+        if: always()
+        env:
+          RC: ${{ steps.scan.outputs.rc }}
+          BASE_SHORT: ${{ steps.base.outputs.short }}
+          BASE_DATE: ${{ steps.base.outputs.date }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Heading-anchor digest"
+            echo
+            if [[ ! -s fragcheck.log ]]; then
+              echo "No output was produced -- an earlier step failed before the scan ran."
+            else
+              echo "Base revision \`${BASE_SHORT:-?}\` (${BASE_DATE:-unknown})."
+              echo
+              case "${RC:-}" in
+                0) echo "No heading anchors broke in this window." ;;
+                1) echo "Heading anchors broke in this window. Nothing was filed -- triage stays a human decision." ;;
+                *) echo "The scan did not complete (exit ${RC:-unknown})." ;;
+              esac
+              echo
+              # Fenced with four backticks: this is a GFM rendering surface and
+              # the output embeds repo heading text, so unfenced it could forge
+              # a heading or open an HTML comment. See nightly-unlabeled-prs.yml.
+              echo '````text'
+              cat fragcheck.log
+              echo '````'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Both Slack steps post to NOTIFICATIONS_WEBHOOK_URL -- one channel for the
+      # digest and for the notice that the digest broke. Note the consequence: if
+      # that webhook is what fails, the failure notice has nowhere to go either.
+      # `errors: true` still turns the run red, so the Actions tab remains the
+      # backstop, but nothing reaches Slack.
+      #
+      # Never set `payload-templated` on either step. It defaults to false; with
+      # it on, the action expands ${{ }} inside the payload against the env and
+      # github contexts, so a heading reading ${{ env.NOTIFICATIONS_WEBHOOK_URL }}
+      # would print the webhook into the channel.
+      #
+      # The Monday clause is what makes the heartbeat reach Slack at all -- rc is
+      # 0 on a clean Monday, so the first clause is false and without the second
+      # nothing would be sent. On a Monday that DID break something the first
+      # clause already fires and the payload is the normal digest, so this only
+      # ever adds the heartbeat, never a duplicate.
+      - name: Post the digest to Slack
+        if: steps.scan.outputs.rc != '0' || github.event.schedule == '20 6 * * 1' || inputs.always_post
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          webhook: ${{ secrets.NOTIFICATIONS_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # payload-file-path rather than an inline payload: block, because the
+          # message body is dynamic and must stay valid JSON. Keep the .json
+          # extension: the action picks its parser from it, and a .yml name would
+          # route this through js-yaml instead of JSON.parse.
+          payload-file-path: payload.json
+          # REQUIRED, not optional. This input defaults to false, and at v3.0.5
+          # the action's catch block has no else branch -- with errors off, a
+          # revoked webhook, an archived channel, a 429, or msg_too_long is
+          # swallowed with no warning and the step still goes green. Because this
+          # digest is deliberately silent when nothing broke, a dead webhook and
+          # a healthy repo would look identical in the channel indefinitely.
+          errors: true
+
+      # A step-level failure notice rather than a second job: a git or python
+      # error would otherwise fail silently at 06:20 with nobody watching. Note
+      # this covers failure() only -- a cancelled run, a dropped scheduled run,
+      # or a suspended cron reaches nobody. That is what the Monday heartbeat is
+      # for.
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          webhook: ${{ secrets.NOTIFICATIONS_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ *Heading-anchor digest failed*\n*Repo:* ${{ github.repository }}\n*Run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+          # Same reasoning as above, and it matters more here: this is the step
+          # that only runs when something is already broken.
+          errors: true

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -10,10 +10,24 @@ skill, which runs them for you; this page documents what it does and how to run 
 |-------|------|----------|
 | Spelling (content + filenames) | `codespell` | `codespell.yml` |
 | Broken links | `lychee` | `link-check-pr.yml` |
+| Heading anchors | `fragcheck.py new` | `fragcheck-pr.yml` |
 | Alias expansion | sed (auto-commit) | `expand-gitbook-aliases.yml` |
 | Help-tables regen | Python | `generate-help-tables.yml` |
 
-Only the first two can fail your PR; aliases and help-tables are regenerated automatically.
+Only the first three can fail your PR; aliases and help-tables are regenerated automatically.
+
+The heading-anchor gate arrived in DOCS-6524 and closed the one rot class that used to have no
+CI counterpart at all. Two consequences worth knowing:
+
+- **It is no longer only a local check.** Before, the anchor gate ran only via `/precommit`, the
+  `docs-check` skill, and the Claude Code pre-commit hook — and that hook covers only commits
+  Claude Code makes through the Bash tool, so a hand-written `git commit`, an IDE commit, or a
+  GitBook-UI edit bypassed it entirely. Now the same check runs on every PR touching `*.md`.
+- **A nightly digest (`nightly-fragcheck.yml`) covers what a PR trigger cannot.** GitBook-UI
+  edits sync straight back to Git, and the alias-expansion bot rewrites links *after* the PR gate
+  ran green. The nightly re-runs the same command against a rolling 24-hour base and posts to
+  Slack only when something broke, plus a Monday heartbeat so silence stays meaningful. It is
+  read-only: it files nothing, and triage stays a human decision.
 
 ## 1. Spelling + links + includes + gutted pages — `doc-lint.sh`
 
@@ -46,6 +60,12 @@ dead in the working tree, because the repo carries ~1,272 pre-existing dead anch
 check would fail every PR on breakage it did not introduce. It also scans the whole tree instead
 of the changed files, since renaming a heading breaks inbound links from pages the commit never
 touched — so findings naming files you did not edit are the check working, not noise.
+
+**CI runs this exact command too** (`fragcheck-pr.yml`, base = the PR base), so a finding here is
+a finding there. One difference is deliberate: locally, a base revision that cannot be checked
+out is a SKIP that returns 0 — never block a commit over a missing baseline — whereas in CI it is
+a hard failure, because a check that cannot run must not report success. Both workflows therefore
+assert the base commit is present *before* invoking the script.
 
 Enabling `--include-fragments` in lychee would *not* substitute for this. lychee's slugger is
 GitHub-flavoured and GitBook's is not, so on `main` it produced 386 false positives (the anchor


### PR DESCRIPTION
Fixes [DOCS-6524](https://mariadbcorp.atlassian.net/browse/DOCS-6524).

Dead GitBook heading anchors (`page.md#some-heading`) were the one documentation rot class with **no CI counterpart at all**. `fragcheck.py` has been checked in since DOCS-6491, but `grep -rn fragcheck .github/` returned zero hits — every entry point was local, and the Claude Code pre-commit hook covers only commits Claude Code makes through the Bash tool, so a hand-written `git commit`, an IDE commit, or a GitBook-UI edit bypassed it entirely.

## What this adds

| File | Trigger | Base |
|---|---|---|
| `fragcheck-pr.yml` | PR touching `*.md` | the PR base |
| `nightly-fragcheck.yml` | 06:20 UTC Mon–Fri + `workflow_dispatch` | rolling 24 hours |

Both run the identical command — `fragcheck.py new <base>` — so the gate and the digest are one code path with a different base. `new` reports only anchors the base resolved and the head does not, so the pre-existing dead anchors stay out of the way while a rename that breaks inbound links from **untouched** pages still fails.

The nightly is not redundant with the gate: GitBook-UI edits sync straight back to Git, and the alias-expansion bot rewrites links *on merge* — a link rewriter is exactly what can break a fragment after the gate ran green. A `pull_request` trigger is structurally blind to both.

## The bug this design is built around

`fragcheck.py new` treats a base revision it cannot check out as a SKIP and **returns 0**:

```
$ python3 .claude/hooks/fragcheck.py new deadbeef...
fragcheck: cannot check out deadbeef... — no baseline, SKIPPED
$ echo $?
0
```

That is right for a local pre-commit hook — never block a commit over a missing baseline — and wrong for a gate, where a check that cannot run must not report success. On a shallow clone this gate would have been permanently, silently green.

So both workflows assert the base commit is present *before* invoking. The assertion uses `git cat-file -e`, not `git rev-parse --verify`, because **`rev-parse` succeeds on a well-formed sha that is absent from the object database** — it just echoes it back:

```
$ git rev-parse --verify deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
deadbeefdeadbeefdeadbeefdeadbeefdeadbeef      # exit 0
$ git cat-file -e deadbeef...^{commit}        # exit 1  <- the one that catches it
```

## Fail paths, proved by probe rather than by a green run

A check that never fires cannot prove itself (DOCS-6481), so both gated classes were deliberately broken locally:

**1. Renamed heading.** Changed `#### **CREATE USER**` to `#### **CREATE USER Privilege**` in `grant.md`:

```
fragcheck: 5 heading anchor(s) that HEAD resolved are now dead:
  .../create-role.md:21: #create-user -> .../grant.md  [absent]
  .../create-user.md:74: #create-user -> .../grant.md  [absent]
  .../drop-role.md:17:   #create-user -> .../grant.md  [absent]
  .../drop-user.md:28:   #create-user -> .../grant.md  [absent]
  .../drop-user.md:74:   #create-user -> .../grant.md  [absent]
rc=1
```

All five inbound links come from four pages the probe never touched — the case a changed-files check structurally cannot see.

**2. Stolen heading id** (DOCS-6492) — invisible to every link checker, this one included, because the anchors all exist and resolve; they just land on the wrong section:

```
fragcheck: 1 heading(s) now carry another heading's anchor:
  probe-stolen.md:11: publishes #overview, which is line 7's anchor,
                      instead of its own #second-section
rc=1
```

Both probes reverted; `git status` clean before commit.

**Payload builder** exercised on all three branches (clean / Monday heartbeat / findings) and against a hostile heading — a filename containing `<https://evil.example|github.com/...>` comes out as `&lt;...&gt;`, so it cannot render as a Slack link whose visible text is a github.com URL. Same escaping reasoning as `nightly-unlabeled-prs.yml`; the step summary is separately fenced with four backticks.

## Carried over from the digest precedent

- `errors: true` on both Slack steps. At `slackapi/slack-github-action@v3.0.5` the catch block has no else branch, so a revoked webhook, archived channel, 429 or `msg_too_long` is swallowed and the step still goes green. Because a delta-only digest is silent on a clean night, a dead webhook and a healthy repo would look identical in the channel indefinitely.
- **Crons split `2-5` and `1`** so `github.event.schedule` can discriminate Monday; one combined `1-5` entry cannot.
- A finding is **not** a job failure in the nightly (`rc 1` exits 0). Otherwise every finding would also fire the `if: failure()` notice and the channel would get two messages for one event, one claiming the digest is broken. `rc 2` and crashes *are* failures.
- The Slack body is truncated at 2,800 chars: the webhook rejects >4,000 with `msg_too_long`, which at `errors: true` is a red run — so a night with 200 broken anchors would otherwise fail to deliver exactly when it matters most. Full output stays in the step summary.

## Checks

`doc-lint.sh` and CI-exact codespell pass on all four changed files. `actionlint` (which embeds shellcheck) reports **zero** findings on both new workflows; it does report 7 on four pre-existing workflows, none touched here — see the note below.

## Not done, and why

The acceptance criterion *"a deliberately broken webhook is shown to turn the run red"* is **not proved**. Doing so means pointing `NOTIFICATIONS_WEBHOOK_URL` at a dead endpoint, i.e. temporarily breaking the secret the unlabeled-PR digest also uses. `errors: true` is set and the upstream code path is cited above, but the empirical half needs someone with repo-admin access to do it deliberately, or a throwaway secret. Say the word and I'll walk through it after merge — `workflow_dispatch` with `always_post: true` also gives a one-click delivery test of the *working* case.

## Two things for elsewhere, not this PR

- The ticket says to keep the invocation in `doc-lint.sh` as the single source of truth. It is already there, and CI now spells it identically with a cross-reference comment in both directions — but CI calls the script **directly** rather than routing through `doc-lint.sh`, because that file is the single source of truth for the ~40 lines of codespell and lychee *flags*, and `fragcheck.py new <rev>` has no flags to drift, while running `doc-lint.sh` in CI would re-run codespell and lychee, which already have their own workflows. Flagging the deviation rather than burying it.
- `actionlint` flags `expand-gitbook-aliases.yml` for interpolating `github.event.pull_request.head.ref` — an untrusted value — directly into an inline script. That's a script-injection shape, and that workflow already has an open ticket for its defects (DOCS-6401), so I've added it there rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6524]: https://mariadbcorp.atlassian.net/browse/DOCS-6524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ