### PR TITLE
DOCS-6471 Add CI coverage for doc-lint.sh, and fix the bug it found

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -9,6 +9,7 @@ Code. It contains:
 | `settings.local.json` | **Personal** overrides — gitignored, never committed |
 | `hooks/doc-lint.sh` | Canonical codespell + lychee linter (single source of truth, mirrors CI) |
 | `hooks/pre-commit.sh` | PreToolUse hook: gates Claude-made `git commit`s by calling `doc-lint.sh` |
+| `hooks/doc-lint-test.sh` | Regression suite for `doc-lint.sh` — fixtures in a throwaway repo; run it after editing the linter |
 | `skills/` | Shared skills (e.g. `docs-check`) |
 | `commands/` | Shared slash commands (e.g. `/precommit`) |
 
@@ -98,6 +99,31 @@ team-wide guarantee. For coverage of *all* commits, install a real Git hook
 A file changed earlier in your branch but not currently staged can pass the hook yet still be
 linted by CI. Before opening a PR, run the full check over your whole branch diff — see
 `dev-docs/cookbook-pre-pr.md`.
+
+## Who tests the linter
+
+`hooks/doc-lint.sh` had no test of its own until DOCS-6471, and it cost a real outage: DOCS-6409
+was a `mktemp` template with no `X` characters that made the script **exit 2 on every
+GNU-coreutils run** — for 135 commits. Because the failing line sat *before* the checks, it
+silently took the GitBook include resolver down with it, so a feature shipped the same day never
+ran on Linux at all. On BSD/macOS `mktemp` the identical line worked fine, so the only machine
+that could have noticed was a Linux one, and nothing on Linux ever ran the script.
+
+`hooks/doc-lint-test.sh` is the gate for that class. It builds fixtures in a throwaway git repo
+under `TMPDIR` — it never reads this checkout's content — and asserts exit codes and messages for
+the include resolver, the gutted-page guard, the env-var knobs, the repo-root guard, and every
+"tool not installed" SKIP branch. Run it after any change to `doc-lint.sh`:
+
+```bash
+.claude/hooks/doc-lint-test.sh              # --keep to inspect the sandbox, --verbose for output
+```
+
+`.github/workflows/doc-lint-test.yml` runs it on **every** PR, on both `ubuntu-latest` and
+`macos-latest`, and shellchecks every tracked shell script alongside it. Both platforms on
+purpose: the suite's first run found the mirror image of DOCS-6409 — an empty-array expansion
+that is an error under `set -u` before bash 4.4, so on the bash 3.2 that stock macOS still ships,
+every `{% include %}` climbing out of its own directory was misreported as unresolvable. Same
+class of bug, opposite platform. A single-runner gate sees one and not the other.
 
 ## Single source of truth
 

--- a/.claude/hooks/doc-lint-test.sh
+++ b/.claude/hooks/doc-lint-test.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+#
+# doc-lint-test.sh — regression suite for doc-lint.sh.
+#
+# Usage:   .claude/hooks/doc-lint-test.sh [--keep] [--verbose]
+#          --keep     leave the sandbox behind and print its path
+#          --verbose  print the captured stdout/stderr of every case
+# Exit:    0 = every case passed, 1 = at least one case failed,
+#          2 = the suite could not set itself up (missing doc-lint.sh, no git, ...)
+#
+# WHY THIS EXISTS
+#   Nothing used to run doc-lint.sh outside the Claude Code pre-commit hook, and that hook
+#   "only gates commits that Claude Code makes via the Bash tool" (pre-commit.sh header) — so
+#   human, IDE and GitBook-UI commits never invoked it. DOCS-6409 is what that costs: a mktemp
+#   template with no X characters made the script exit 2 on every GNU-coreutils run from
+#   f2b5e332c (2026-08-05) until 2026-08-18 — 135 commits — and because the failing line sat
+#   BEFORE the checks, it silently took the include resolver down with it. On macOS/BSD mktemp
+#   the same line worked fine, so the only machine that could have noticed was a Linux one, and
+#   no Linux ever ran the script.
+#
+#   That is the failure class this suite is aimed at: the script's own plumbing, on a platform
+#   the author is not using. It is wired into CI by .github/workflows/doc-lint-test.yml, which
+#   runs it on ubuntu-latest on every PR — deliberately NOT only when the hooks change, because
+#   DOCS-6409 was not caused by an edit to the script. It was caused by the script meeting
+#   different coreutils.
+#
+# WHAT IT COVERS AND WHAT IT DOES NOT
+#   It exercises the two checks in doc-lint.sh that have no CI counterpart — the GitBook
+#   `{% include %}` resolver (DOCS-6372) and the net line-loss "gutted page" guard (DOCS-6470,
+#   for the DOCS-6442 class) — plus the plumbing every check sits behind: the repo-root config
+#   guard, the argument filter, the env-var knobs, and the tool-missing SKIP branches.
+#
+#   codespell and lychee are gated separately by codespell.yml and link-check-pr.yml, so their
+#   flag sets are not what this suite guards. What it does guard is that doc-lint REACHES them:
+#   the two cases marked "needs codespell" / "needs lychee" run only when the tool is on PATH,
+#   and prove the present-branch fires at all. That is the assertion DOCS-6409 would have failed.
+#
+#   The heading-anchor check is not covered here. It has its own CI gate (fragcheck-pr.yml,
+#   DOCS-6524) and fragcheck.py is absent from the sandbox, so what this suite asserts about it
+#   is only that its absence is a SKIP rather than a crash.
+#
+# TWO RULES THAT COME STRAIGHT FROM HOW DOCS-6409 HID
+#   1. NEVER PIPE THE SCRIPT UNDER TEST. Per DOCS-6409 impact note 4, `doc-lint.sh ... | tail`
+#      returns the PIPE's status, so a hard exit-2 failure reads as a clean 0 — which is how the
+#      regression stayed hidden. Every invocation here redirects to files and reads $? directly.
+#   2. ASSERT THE SKIP BRANCHES. A missing tool must print a notice and still exit 0. A
+#      regression there would either turn advisory notices into hard failures or, worse, turn a
+#      real failure into a silent pass.
+#
+# Determinism: every case runs with PATH trimmed to /usr/bin:/bin, where codespell and lychee are
+# absent on both ubuntu-latest and macOS, so the baseline behaviour is identical on the runner
+# and on a laptop. The two tool-dependent cases put the ambient tool's directory back on the
+# front of that PATH. On macOS /bin/bash is 3.2, which is the portability floor doc-lint.sh
+# claims in its own header — so running this locally tests that claim for free.
+#
+# Portability: no mapfile, no associative arrays, no `local -n` — bash 3.2 safe, like the script
+# it tests.
+
+set -uo pipefail
+
+KEEP=0
+VERBOSE=0
+for arg in "$@"; do
+  case "$arg" in
+    --keep)    KEEP=1 ;;
+    --verbose) VERBOSE=1 ;;
+    -h|--help) sed -n '3,8p' "$0"; exit 0 ;;
+    *) echo "doc-lint-test: unknown option '$arg'" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOC_LINT="$SCRIPT_DIR/doc-lint.sh"
+
+[ -x "$DOC_LINT" ] || { echo "doc-lint-test: $DOC_LINT not found or not executable" >&2; exit 2; }
+command -v git >/dev/null 2>&1 || { echo "doc-lint-test: git is required" >&2; exit 2; }
+
+# The minimal PATH the cases run under. codespell and lychee are never here; git, awk, wc, tr,
+# grep, basename and mktemp always are (verified on ubuntu-latest and macOS).
+MIN_PATH='/usr/bin:/bin'
+
+# Ambient locations of the optional tools, resolved BEFORE PATH is trimmed, so a tool-dependent
+# case can put just that one back.
+CODESPELL_DIR=''
+LYCHEE_DIR=''
+if p="$(command -v codespell 2>/dev/null)"; then CODESPELL_DIR="$(dirname "$p")"; fi
+if p="$(command -v lychee 2>/dev/null)";    then LYCHEE_DIR="$(dirname "$p")"; fi
+
+# --- sandbox ---------------------------------------------------------------------------------
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/doclint-test.XXXXXX")" || {
+  echo "doc-lint-test: mktemp -d failed" >&2; exit 2; }
+OUT="$SANDBOX/.stdout"
+ERR="$SANDBOX/.stderr"
+
+cleanup() {
+  if [ "$KEEP" = "1" ]; then
+    echo "Sandbox kept at: $SANDBOX" >&2
+  else
+    rm -rf "$SANDBOX"
+  fi
+}
+trap cleanup EXIT
+
+# gen_lines <n> <path> — a file of n numbered lines, spelling-clean and link-free.
+gen_lines() {
+  local n="$1" path="$2" i=1
+  mkdir -p "$(dirname "$path")"
+  : > "$path"
+  while [ "$i" -le "$n" ]; do
+    printf 'Paragraph %d of the fixture page.\n\n' "$i" >> "$path"
+    i=$((i + 1))
+  done
+}
+
+build_sandbox() {
+  mkdir -p "$SANDBOX/server/includes" "$SANDBOX/maxscale" \
+           "$SANDBOX/.gitbook/includes" "$SANDBOX/dev-docs" "$SANDBOX/.claude"
+
+  # The repo-root marker doc-lint.sh insists on. Carries one ignore word so the
+  # "-I .codespellignore is honoured" case has something to be ignored. Spliced for the same
+  # reason as the fixtures below.
+  printf '%s\n' "reci""eve" > "$SANDBOX/.codespellignore"
+
+  printf '# Clean Page\n\nNothing here trips any check.\n' > "$SANDBOX/server/clean.md"
+  printf '# No Links\n\nA page with no links at all.\n'     > "$SANDBOX/server/nolinks.md"
+  printf '# Target\n\nInclude target.\n'                    > "$SANDBOX/server/includes/real.md"
+  printf '# Cross Space Target\n\nIn another space.\n'      > "$SANDBOX/maxscale/included.md"
+
+  # Include fixtures.
+  printf '# Good Include\n\n{%% include "includes/real.md" %%}\n' \
+    > "$SANDBOX/server/ok-include.md"
+  printf '# Dead Include\n\n{%% include "../.gitbook/includes/nope.md" %%}\n' \
+    > "$SANDBOX/server/dead-include.md"
+  printf '# Cross Space Include\n\n{%% include "../maxscale/included.md" %%}\n' \
+    > "$SANDBOX/server/cross-space.md"
+  printf '# Remote Include\n\n{%% include "https://app.gitbook.com/s/x/~/reusable/y/" %%}\n' \
+    > "$SANDBOX/server/remote-include.md"
+  # Both directories are exempt from the include resolver: they document the syntax with
+  # placeholders that are not meant to resolve.
+  printf '# Docs About Includes\n\n{%% include "nope.md" %%}\n' > "$SANDBOX/dev-docs/exempt.md"
+  printf '# Hook Notes\n\n{%% include "nope.md" %%}\n'          > "$SANDBOX/.claude/exempt.md"
+
+  # Files the shrink guard needs a base revision for. Sizes are picked to isolate one
+  # threshold each; see the cases.
+  gen_lines 120 "$SANDBOX/server/gutted.md"      # 240 lines -> well over every threshold
+  gen_lines  10 "$SANDBOX/server/tiny.md"        #  20 lines -> under SHRINK_FLOOR (30)
+  gen_lines  20 "$SANDBOX/server/small-loss.md"  #  40 lines -> can lose <SHRINK_MIN net
+  gen_lines  50 "$SANDBOX/server/modest.md"      # 100 lines -> 25% loss: under PCT, over MIN
+
+  # codespell fixtures. The misspellings are spliced across a quote boundary on purpose: written
+  # whole, they would make this file itself a permanent false positive in every repo-wide
+  # codespell sweep. codespell tokenizes on word characters, so it only ever sees the halves.
+  typo="te""h"           # a misspelling of "the"
+  ignored="reci""eve"    # a misspelling of "receive" -- the word in the sandbox .codespellignore
+  printf '# Typo\n\nPlease %s file.\n' "$typo"    > "$SANDBOX/server/typo.md"
+  printf '# Nav\n\n* [%s](clean.md)\n'  "$typo"    > "$SANDBOX/server/SUMMARY.md"
+  printf '# Ignored\n\nPlease %s.\n'    "$ignored" > "$SANDBOX/server/ignored-word.md"
+
+  # lychee fixture: a relative target that does not exist. No network needed.
+  printf '# Bad Link\n\n[gone](./does-not-exist.md)\n' > "$SANDBOX/server/badlink.md"
+
+  # A stub lychee, for the one branch no installed lychee can reach any more. doc-lint.sh
+  # swallows lychee's "No links were found" to mirror the workflow's failIfEmpty: false
+  # (DOCS-6272) -- but failIfEmpty is a lychee-ACTION option: the action runs its own emptiness
+  # check, while the lychee BINARY has exited 0 on a link-free file since ~0.16 (verified on
+  # 0.24.2). So the carve-out is a compatibility shim for older local binaries, inert against a
+  # current one, and a real-lychee fixture cannot exercise it. The stub can, which keeps the shim
+  # from rotting into dead code that a future cleanup deletes by accident rather than on purpose.
+  mkdir -p "$SANDBOX/stub"
+  printf '#!/bin/sh\necho "No links were found"\nexit 2\n' > "$SANDBOX/stub/lychee"
+  chmod +x "$SANDBOX/stub/lychee"
+
+  # Not a Markdown/HTML path, so the argument filter must drop it.
+  printf 'not markdown\n' > "$SANDBOX/server/notes.txt"
+
+  (
+    cd "$SANDBOX" || exit 1
+    git init -q -b main . >/dev/null 2>&1 || git init -q . >/dev/null 2>&1
+    git config user.name  'doc-lint test'
+    git config user.email 'doc-lint-test@example.invalid'
+    git config commit.gpgsign false
+    git add -A >/dev/null
+    git commit -q -m 'fixtures' >/dev/null
+  ) || return 1
+
+  # Post-commit edits, so the working tree differs from HEAD for the shrink guard.
+  gen_lines  10 "$SANDBOX/server/gutted.md"       # 240 -> 20: net 220 of 240 (92%)
+  gen_lines   1 "$SANDBOX/server/tiny.md"         #  20 ->  2: pre-image under the floor
+  gen_lines  11 "$SANDBOX/server/small-loss.md"   #  40 -> 22: net 18, under SHRINK_MIN (20)
+  gen_lines  37 "$SANDBOX/server/modest.md"       # 100 -> 74: net 26, 26% — under PCT (40)
+  # Never committed, so the guard has no pre-image to compare against.
+  gen_lines 120 "$SANDBOX/server/brand-new.md"
+}
+
+# --- assertions ------------------------------------------------------------------------------
+PASSES=0
+FAILURES=0
+SKIPS=0
+CURRENT=''
+CASE_OK=1
+
+# lint <cwd> <path-additions|-> <env-assignments...> -- <doc-lint args...>
+# Runs doc-lint.sh with PATH trimmed to MIN_PATH (plus any additions), capturing stdout and
+# stderr to separate files and $? into RC. Redirection, never a pipe — see rule 1 above.
+RC=0
+lint() {
+  local cwd="$1" path_add="$2"; shift 2
+
+  local use_path="$MIN_PATH"
+  [ "$path_add" != '-' ] && use_path="$path_add:$MIN_PATH"
+
+  # `env -i` so the case sees exactly the variables it names and nothing the caller's shell
+  # happens to export -- a DOC_LINT_* left over in the ambient environment would otherwise make
+  # results depend on who ran the suite.
+  #
+  # Built as ONE array rather than expanding a separate envs[] array, because expanding an empty
+  # array under `set -u` is an error on bash 3.2 (macOS) -- the same trap this suite just found
+  # in doc-lint.sh's norm_path.
+  local cmd=(env -i "PATH=$use_path" "HOME=$SANDBOX" "TMPDIR=${TMPDIR:-/tmp}")
+  while [ "$#" -gt 0 ] && [ "$1" != '--' ]; do cmd+=("$1"); shift; done
+  shift  # drop the --
+  cmd+=("$DOC_LINT" "$@")
+
+  set +e
+  ( cd "$SANDBOX/$cwd" && "${cmd[@]}" ) > "$OUT" 2> "$ERR"
+  RC=$?
+  set -e
+
+  if [ "$VERBOSE" = "1" ]; then
+    echo "    stdout: $(wc -c < "$OUT" | tr -d ' ') bytes"
+    sed 's/^/      | /' < "$ERR"
+  fi
+}
+
+begin() { CURRENT="$1"; CASE_OK=1; }
+
+problem() {
+  [ "$CASE_OK" = "1" ] && printf 'FAIL: %s\n' "$CURRENT" >&2
+  CASE_OK=0
+  printf '      %s\n' "$1" >&2
+}
+
+end() {
+  if [ "$CASE_OK" = "1" ]; then
+    PASSES=$((PASSES + 1))
+    printf 'ok   %s\n' "$CURRENT"
+  else
+    FAILURES=$((FAILURES + 1))
+    printf '      --- stderr ---\n' >&2
+    sed 's/^/      /' < "$ERR" >&2
+    printf '      --------------\n' >&2
+  fi
+}
+
+skip() {
+  SKIPS=$((SKIPS + 1))
+  printf 'SKIP %s (%s)\n' "$1" "$2"
+}
+
+want_rc() {
+  [ "$RC" = "$1" ] || problem "expected exit $1, got $RC"
+}
+
+# Patterns are matched against stderr, because that is where doc-lint.sh contracts to put both
+# failures and SKIP notices.
+want_err() {
+  grep -qF -- "$1" "$ERR" || problem "expected \"$1\" on stderr"
+}
+
+want_no_err() {
+  grep -qF -- "$1" "$ERR" && problem "did NOT expect \"$1\" on stderr"
+  return 0
+}
+
+want_empty_stdout() {
+  [ -s "$OUT" ] && problem "expected empty stdout, got $(wc -c < "$OUT" | tr -d ' ') bytes"
+  return 0
+}
+
+# --- run -------------------------------------------------------------------------------------
+build_sandbox || { echo "doc-lint-test: could not build the sandbox" >&2; exit 2; }
+
+echo "doc-lint-test: sandbox $SANDBOX"
+echo "doc-lint-test: bash $BASH_VERSION, script under test $DOC_LINT"
+echo
+
+NOFRAG='DOC_LINT_SKIP_FRAGMENTS=1'
+
+# ---- argument handling and the repo-root guard ----------------------------------------------
+
+begin 'no arguments at all exits 0'
+lint . - "$NOFRAG" --
+want_rc 0
+end
+
+begin 'a non-Markdown argument is filtered out, exits 0'
+lint . - "$NOFRAG" -- server/notes.txt
+want_rc 0
+end
+
+begin 'a Markdown path that does not exist is filtered out, exits 0'
+lint . - "$NOFRAG" -- server/absent.md
+want_rc 0
+end
+
+begin 'wrong working directory is a config error, exits 2'
+# From server/ there is no .codespellignore. The path must still resolve from that CWD, or the
+# argument filter would empty the list and return 0 before the guard is ever reached.
+lint server - "$NOFRAG" -- clean.md
+want_rc 2
+want_err 'must be run from the repo root'
+end
+
+begin 'a clean page passes every check, exits 0'
+lint . - "$NOFRAG" -- server/clean.md
+want_rc 0
+want_no_err 'unresolvable include'
+want_no_err 'gutted page'
+end
+
+# ---- GitBook include resolver (DOCS-6372; no CI counterpart) ---------------------------------
+
+begin 'a resolvable same-space include passes'
+lint . - "$NOFRAG" -- server/ok-include.md
+want_rc 0
+end
+
+begin 'a dead include fails with "unresolvable include"'
+lint . - "$NOFRAG" -- server/dead-include.md
+want_rc 1
+want_err 'unresolvable include'
+want_err '.gitbook/includes/nope.md'
+end
+
+begin 'a cross-space include fails with "cross-space include"'
+lint . - "$NOFRAG" -- server/cross-space.md
+want_rc 1
+want_err 'cross-space include'
+want_err 'reusable'   # the by-ID form the message tells the author to use instead
+end
+
+begin 'an https include target is not resolved on disk'
+lint . - "$NOFRAG" -- server/remote-include.md
+want_rc 0
+end
+
+begin 'dev-docs/ and .claude/ are exempt from the include resolver'
+lint . - "$NOFRAG" -- dev-docs/exempt.md .claude/exempt.md
+want_rc 0
+want_no_err 'unresolvable include'
+end
+
+begin 'every include failure on one run is reported, not just the first'
+lint . - "$NOFRAG" -- server/dead-include.md server/cross-space.md
+want_rc 1
+want_err 'unresolvable include'
+want_err 'cross-space include'
+end
+
+# ---- net line-loss guard (DOCS-6470 / DOCS-6442; no CI counterpart) --------------------------
+
+begin 'a gutted page fails with "possible gutted page"'
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD -- server/gutted.md
+want_rc 1
+want_err 'possible gutted page'
+want_err 'server/gutted.md'
+end
+
+begin 'DOC_LINT_ALLOW_SHRINK naming the path acknowledges it, exits 0'
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD DOC_LINT_ALLOW_SHRINK=server/gutted.md -- server/gutted.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+begin 'DOC_LINT_ALLOW_SHRINK=all skips the guard entirely, exits 0'
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD DOC_LINT_ALLOW_SHRINK=all -- server/gutted.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+begin 'a comma-separated DOC_LINT_ALLOW_SHRINK list is accepted'
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD \
+     DOC_LINT_ALLOW_SHRINK=server/other.md,server/gutted.md -- server/gutted.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+begin 'a file absent from the base revision has nothing to have lost, exits 0'
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD -- server/brand-new.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+begin 'a pre-image under DOC_LINT_SHRINK_FLOOR is not considered'
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD -- server/tiny.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+begin 'a net loss under DOC_LINT_SHRINK_MIN is not flagged'
+# 40 lines -> 22: 45% of the pre-image, which is over DOC_LINT_SHRINK_PCT. Only the absolute
+# floor of 20 net lines keeps this green, so it isolates that knob.
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD -- server/small-loss.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+begin 'a net loss under DOC_LINT_SHRINK_PCT is not flagged'
+# 100 lines -> 74: 26 net lines, over DOC_LINT_SHRINK_MIN, so only the percentage keeps it green.
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD -- server/modest.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+begin 'lowering DOC_LINT_SHRINK_PCT flags the same modest loss'
+# The mirror of the case above: proves the threshold is really read from the environment rather
+# than the guard happening to be inert on this fixture.
+lint . - "$NOFRAG" DOC_LINT_BASE=HEAD DOC_LINT_SHRINK_PCT=10 -- server/modest.md
+want_rc 1
+want_err 'possible gutted page'
+end
+
+begin 'an unresolvable DOC_LINT_BASE disables the history-aware checks rather than failing'
+lint . - "$NOFRAG" DOC_LINT_BASE=refs/heads/no-such-branch -- server/gutted.md
+want_rc 0
+want_no_err 'possible gutted page'
+end
+
+# ---- SKIP branches: a missing tool is a notice, never a failure ------------------------------
+
+begin 'codespell absent is a SKIP notice on stderr, exits 0'
+lint . - "$NOFRAG" -- server/typo.md
+want_rc 0
+want_err 'codespell not installed'
+want_err 'SKIPPED'
+end
+
+begin 'lychee absent is a SKIP notice on stderr, exits 0'
+lint . - "$NOFRAG" -- server/badlink.md
+want_rc 0
+want_err 'lychee not installed'
+want_err 'SKIPPED'
+end
+
+begin 'a missing fragcheck.py is a SKIP notice, exits 0'
+# Reached only because the sandbox has no .claude/hooks/fragcheck.py; DOC_LINT_SKIP_FRAGMENTS is
+# deliberately NOT set here, so this exercises the absent-script branch rather than the opt-out.
+lint . - -- server/clean.md
+want_rc 0
+want_err 'fragcheck.py not found'
+want_err 'SKIPPED'
+end
+
+begin 'DOC_LINT_SKIP_FRAGMENTS=1 suppresses the anchor check silently'
+lint . - "$NOFRAG" -- server/clean.md
+want_rc 0
+want_no_err 'fragcheck.py not found'
+end
+
+begin 'diagnostics go to stderr; stdout stays empty even on failure'
+lint . - "$NOFRAG" -- server/dead-include.md
+want_rc 1
+want_empty_stdout
+end
+
+# ---- the tool-present branches: proof doc-lint actually REACHES its checkers -----------------
+# This is the assertion DOCS-6409 would have failed: the script died at line 209, before either
+# checker ran, and every SKIP-branch test above would still have passed.
+
+if [ -n "$CODESPELL_DIR" ]; then
+  begin 'codespell present: a misspelling fails with "possible misspellings" [needs codespell]'
+  lint . "$CODESPELL_DIR" "$NOFRAG" -- server/typo.md
+  want_rc 1
+  want_err 'possible misspellings'
+  want_no_err 'codespell not installed'
+  end
+
+  begin 'codespell present: -I .codespellignore is honoured [needs codespell]'
+  lint . "$CODESPELL_DIR" "$NOFRAG" -- server/ignored-word.md
+  want_rc 0
+  end
+
+  begin 'codespell present: SUMMARY.md is excluded, mirroring codespell.yml [needs codespell]'
+  # SUMMARY.md carries the same misspelling as typo.md. GitBook truncates its link labels at 100
+  # chars, often mid-word, so codespell.yml's files_ignore drops it — and doc-lint must match.
+  lint . "$CODESPELL_DIR" "$NOFRAG" -- server/SUMMARY.md
+  want_rc 0
+  want_no_err 'possible misspellings'
+  end
+else
+  skip 'codespell present: three cases' 'codespell not on PATH'
+fi
+
+if [ -n "$LYCHEE_DIR" ]; then
+  begin 'lychee present: a dead relative link fails with "broken links" [needs lychee]'
+  lint . "$LYCHEE_DIR" "$NOFRAG" -- server/badlink.md
+  want_rc 1
+  want_err 'broken links'
+  want_no_err 'lychee not installed'
+  end
+
+  begin 'lychee present: a stale path never reaches lychee [needs lychee]'
+  # The `[ -f "$f" ]` test in the argument filter is what makes this safe. Without it a path that
+  # has been deleted or renamed since it was staged reaches lychee, which exits 1 with "Input
+  # not found as file and not a valid URL" -- reported to the author as a broken LINK, on a page
+  # that no longer exists. Only a tool-present case can catch that: with both checkers absent
+  # the unfiltered path is inert, which is why the plain filter case above passes either way.
+  lint . "$LYCHEE_DIR" "$NOFRAG" -- server/absent.md
+  want_rc 0
+  want_no_err 'broken links'
+  end
+
+  begin 'lychee present: a page with no links is not a failure [needs lychee]'
+  # Pins the OUTCOME for a link-free page (a nav stub must never fail), not the carve-out branch
+  # — a current lychee exits 0 here, so the branch is not reached. The stub case below covers it.
+  lint . "$LYCHEE_DIR" "$NOFRAG" -- server/nolinks.md
+  want_rc 0
+  want_no_err 'broken links'
+  end
+else
+  skip 'lychee present: two cases' 'lychee not on PATH'
+fi
+
+begin 'lychee "No links were found" is swallowed, not reported as broken links'
+# Uses the stub lychee built above, because no current lychee binary can produce this. See the
+# comment on the stub in build_sandbox.
+lint . "$SANDBOX/stub" "$NOFRAG" -- server/nolinks.md
+want_rc 0
+want_no_err 'broken links'
+want_no_err 'lychee not installed'
+end
+
+# --- report ----------------------------------------------------------------------------------
+# A case group that opted out because its tool was missing is reported, not counted as a pass.
+# CI sets DOC_LINT_TEST_REQUIRE_ALL=1 on the runner where it installs codespell and lychee, so a
+# botched install turns into a red run instead of a green one that quietly tested less. Without
+# it, "31 passed, 0 failed, 1 skipped" is indistinguishable from full coverage at a glance --
+# the same trap as an empty-list guard that proves nothing about the path that fires (DOCS-6401).
+if [ "${DOC_LINT_TEST_REQUIRE_ALL:-}" = "1" ] && [ "$SKIPS" -gt 0 ]; then
+  printf 'FAIL: DOC_LINT_TEST_REQUIRE_ALL=1, but %d case group(s) opted out for a missing tool.\n' \
+    "$SKIPS" >&2
+  printf '      Every optional tool is expected on PATH here. Check the install steps.\n' >&2
+  FAILURES=$((FAILURES + 1))
+fi
+
+echo
+printf '%d passed, %d failed, %d skipped\n' "$PASSES" "$FAILURES" "$SKIPS"
+# No trailing `exit 0`: falling off the end yields the status of the test below, which is 0 when
+# nothing failed. Written this way because shellcheck 0.11 reports SC2329 ("this function is
+# never invoked") for the EXIT-trap cleanup above when a script ends in an unconditional `exit`.
+[ "$FAILURES" -eq 0 ] || exit 1

--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -174,6 +174,15 @@ fi
 # Normalize a path's `.` and `..` segments textually — the target need not exist, which rules
 # out `realpath` (BSD realpath has no portable `-m`). A `..` that climbs above the repo root is
 # left in place, so the path simply fails the existence test below.
+#
+# Every array expansion below is guarded by a length test on purpose. Expanding "${arr[@]}" or
+# "${arr[*]}" on an EMPTY array is an "unbound variable" error under `set -u` before bash 4.4 —
+# i.e. on the bash 3.2 that stock macOS still ships, which is the portability floor this script
+# claims in its header. Unguarded, norm_path returned the EMPTY STRING for any include that
+# climbs out of its own directory ("server/../maxscale/x.md"): the `..` emptied the array, the
+# recompaction died, and every such include was then misreported as *unresolvable* while the
+# cross-space branch below became unreachable. The mirror image of DOCS-6409, which only bit on
+# Linux — same class, opposite platform. Found by doc-lint-test.sh (DOCS-6471).
 norm_path() {
   local seg out=() n
   local IFS='/'
@@ -182,13 +191,19 @@ norm_path() {
       ''|.) ;;
       ..) n=${#out[@]}
           if [ "$n" -gt 0 ] && [ "${out[$((n-1))]}" != ".." ]; then
-            unset "out[$((n-1))]"; out=("${out[@]}")   # compact: bash 3.2 leaves a hole
+            unset "out[$((n-1))]"                      # bash 3.2 leaves a hole
+            if [ "${#out[@]}" -gt 0 ]; then
+              out=("${out[@]}")                        # compact it, but only if anything is left
+            fi
           else
             out+=("..")
           fi ;;
       *) out+=("$seg") ;;
     esac
   done
+  if [ "${#out[@]}" -eq 0 ]; then
+    return 0                                           # nothing left: the empty path
+  fi
   printf '%s' "${out[*]}"
 }
 

--- a/.github/workflows/doc-lint-test.yml
+++ b/.github/workflows/doc-lint-test.yml
@@ -1,0 +1,273 @@
+name: Test the Doc Lint Hooks
+
+# Gates the repo's shell tooling: shellcheck over every tracked shell script, and a fixture
+# suite over .claude/hooks/doc-lint.sh -- the script that hosts the two documentation-rot
+# checks with NO CI counterpart anywhere else (the GitBook `{% include %}` resolver from
+# DOCS-6372, and the net line-loss "gutted page" guard from DOCS-6470).
+#
+# WHY THIS EXISTS
+#   Until now nothing in CI ran doc-lint.sh at all, and its only caller is a Claude Code
+#   PreToolUse(Bash) hook that -- as pre-commit.sh's own header says -- "only gates commits that
+#   Claude Code makes via the Bash tool. Human git commit, IDE commits, and GitBook-UI edits
+#   bypass it entirely." So the script's plumbing was covered by nothing.
+#
+#   DOCS-6409 is what that cost. A `mktemp` template with no X characters made the script exit 2
+#   on every GNU-coreutils run, from f2b5e332c (2026-08-05) to the fix on 2026-08-18 -- 135
+#   commits. Because the failing line sat BEFORE the checks, it silently took the include
+#   resolver down with it, so a feature added that same day never ran on Linux even once. On
+#   BSD/macOS mktemp the identical line worked, so the only machine that could have noticed was
+#   a Linux one, and no Linux ever ran the script.
+#
+# WHY IT RUNS ON EVERY PR, NOT ONLY WHEN THE HOOKS CHANGE
+#   Because DOCS-6409 was not caused by an edit to the script. It was caused by the script
+#   meeting different coreutils. A paths: filter on .claude/hooks/** would have been green
+#   throughout those 135 commits. The suite is self-contained -- it builds fixtures in a
+#   throwaway git repo under TMPDIR and never reads the checkout's own content -- so it cannot
+#   report a finding an unrelated PR's author is unable to clear, which is the failure mode
+#   DOCS-6401 documents.
+#
+# WHY BOTH UBUNTU AND MACOS
+#   Same reason, from the other side. macos-latest still ships bash 3.2, which is the
+#   portability floor doc-lint.sh claims in its header ("no mapfile here [...] so it runs under
+#   bash 3.2 (macOS) too") -- and that claim was already broken when this landed. Expanding an
+#   empty array under `set -u` is an error before bash 4.4, so norm_path returned the empty
+#   string for every include that climbs out of its own directory. The mirror image of
+#   DOCS-6409: same class of bug, opposite platform, invisible to a single-runner gate.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: doc-lint-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # shellcheck is a static analyser, so its verdict does not vary by platform -- one runner is
+  # enough, and this stays a separate job so its check name says plainly which half failed.
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        # No fetch-depth: 0. Unlike fragcheck-pr.yml this needs no history at all -- it lints
+        # the files as they stand in the PR head.
+
+      - name: Install a pinned shellcheck
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+          # sha256 of shellcheck-v0.11.0.linux.x86_64.tar.xz, computed from the release asset
+          # (koalaman publishes no .sha256 sidecar). To bump the version, download the new
+          # tarball, recompute, and change both values together.
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+        run: |
+          set -euo pipefail
+          # Pinned rather than using the runner image's preinstalled shellcheck, so a runner
+          # image bump cannot add a new check and turn unrelated PRs red on files their author
+          # never touched. Bumping the pin is then a deliberate PR that fixes whatever the new
+          # version finds.
+          tarball="$RUNNER_TEMP/shellcheck.tar.xz"
+          curl -fsSL -o "$tarball" \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          echo "${SHELLCHECK_SHA256}  ${tarball}" | sha256sum --check --strict
+          tar -xJf "$tarball" -C "$RUNNER_TEMP"
+          install -m 0755 "$RUNNER_TEMP/shellcheck-${SHELLCHECK_VERSION}/shellcheck" \
+            /usr/local/bin/shellcheck
+          shellcheck --version
+
+      - name: Shellcheck every tracked shell script
+        id: shellcheck
+        run: |
+          set -uo pipefail
+
+          # Discovered, not enumerated: a shell script added anywhere in the repo is gated the
+          # day it lands, with no allowlist to remember to extend. The exceptions below are
+          # subtracted explicitly so each one is a decision on the record.
+          #
+          # release-notes/maxscale/script/ is the MaxScale team's release-note generator (last
+          # touched by its owners, not by Docs Infrastructure). It carries 12 pre-existing
+          # info/warning findings -- SC2086 quoting, SC2006 backticks, and two genuinely unused
+          # variables. `upgrade_version` is the interesting one: its comment says it "needs to
+          # be updated whenever a new major release is out", but the heredoc hardcodes the
+          # upgrading link and never reads the variable, so the instruction is misleading.
+          # Fixing that changes generated release-note output, which is the owning team's call,
+          # not something to slip into an infrastructure PR. Reported on DOCS-6471; drop the
+          # exception once it is resolved.
+          mapfile -t scripts < <(git ls-files '*.sh' \
+            ':(exclude,glob)release-notes/maxscale/script/*.sh')
+
+          if [ "${#scripts[@]}" -eq 0 ]; then
+            echo "::error::No shell scripts found to check -- the discovery step is broken, not the repo."
+            exit 1
+          fi
+
+          echo "Checking:"
+          printf '  %s\n' "${scripts[@]}"
+          echo
+
+          # Default severity, i.e. style-level and up: these are few, small and ours, so an
+          # info-level finding is worth fixing rather than filtering out.
+          set +e
+          shellcheck -f gcc "${scripts[@]}" > shellcheck.log 2>&1
+          rc=$?
+          set -e
+          cat shellcheck.log
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::shellcheck reported findings in the repo's shell scripts. Details in the job log and the run summary."
+          fi
+          exit "$rc"
+
+      - name: Record the shellcheck result in the run summary
+        if: always()
+        env:
+          RC: ${{ steps.shellcheck.outputs.rc }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## shellcheck"
+            echo
+            if [ ! -s shellcheck.log ]; then
+              echo "No output -- an earlier step failed before shellcheck ran."
+            elif [ "${RC:-}" = "0" ]; then
+              echo "Clean at shellcheck ${SHELLCHECK_VERSION:-v0.11.0}."
+            else
+              echo "Findings below. Reproduce locally with:"
+              echo
+              echo '````bash'
+              echo "shellcheck \$(git ls-files '*.sh' ':(exclude,glob)release-notes/maxscale/script/*.sh')"
+              echo '````'
+              echo
+              # Fenced with four backticks: the log embeds source lines from the PR, which are
+              # author-controlled, and this summary is a GFM rendering surface. Same reasoning
+              # as fragcheck-pr.yml and nightly-unlabeled-prs.yml.
+              echo '````text'
+              cat shellcheck.log
+              echo '````'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  doc-lint-test:
+    strategy:
+      # Run both platforms to completion. A bash-3.2-only failure is precisely the thing this
+      # matrix exists to surface, so cancelling macOS the moment Ubuntu goes red would hide it.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    # The suite is a few seconds of shell. 10 minutes is headroom; without an explicit value the
+    # job inherits the 6-hour default, and a wedged lychee would end as *cancelled*, which
+    # `if: failure()` does not catch.
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        # Again no fetch-depth: 0 -- the suite builds its own git repository in the sandbox and
+        # never looks at this checkout's history.
+
+      # codespell and lychee are installed on Linux only, and only so the suite can prove
+      # doc-lint.sh REACHES them: a script that dies in its own plumbing before the first
+      # `command -v` passes every SKIP-branch assertion and still checks nothing. That is
+      # exactly how DOCS-6409 hid. Installing them on both platforms would buy nothing extra,
+      # since what differs between the runners is bash and coreutils, not the checkers.
+      - name: Install codespell
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          # pipx, matching the install line doc-lint.sh prints in its own SKIP notice.
+          pipx install codespell
+          # Assert it landed on PATH. Without this the suite would report the codespell cases as
+          # SKIPPED and still exit 0 -- DOC_LINT_TEST_REQUIRE_ALL below is the backstop, but a
+          # failure here names the cause directly.
+          command -v codespell
+          codespell --version
+
+      - name: Install a pinned lychee
+        if: runner.os == 'Linux'
+        env:
+          LYCHEE_VERSION: lychee-v0.24.2
+          # Cross-checked against the publisher's own
+          # lychee-x86_64-unknown-linux-gnu.tar.gz.sha256 sidecar for this tag.
+          LYCHEE_SHA256: 1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
+        run: |
+          set -euo pipefail
+          # A binary, not lycheeverse/lychee-action: the suite needs `lychee` on PATH so
+          # doc-lint.sh's own `command -v lychee` finds it, which the action does not provide.
+          # Note what this does and does not pin. link-check-pr.yml gates the LINK CHECK, at
+          # whatever lychee its action ships; this pins only the binary the fixture suite runs
+          # against, so the two are independent by design and need not be bumped together.
+          tarball="$RUNNER_TEMP/lychee.tar.gz"
+          curl -fsSL -o "$tarball" \
+            "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${LYCHEE_SHA256}  ${tarball}" | sha256sum --check --strict
+          tar -xzf "$tarball" -C "$RUNNER_TEMP"
+          install -m 0755 "$RUNNER_TEMP/lychee-x86_64-unknown-linux-gnu/lychee" /usr/local/bin/lychee
+          command -v lychee
+          lychee --version
+
+      - name: Run the doc-lint fixture suite
+        id: suite
+        env:
+          # Linux installs both optional tools, so a case group opting out there means an install
+          # silently failed -- turn that into a red run rather than a green one that tested less.
+          # macOS installs neither, so five cases legitimately report SKIP there.
+          DOC_LINT_TEST_REQUIRE_ALL: ${{ runner.os == 'Linux' && '1' || '' }}
+        run: |
+          set -uo pipefail
+          echo "bash: $BASH_VERSION"
+          # NOT PIPED. Per DOCS-6409 impact note 4, piping the script under test returns the
+          # pipe's exit status, so a hard failure reads as a clean 0 -- which is how that
+          # regression stayed hidden for 135 commits. Redirect and read $? directly, the same
+          # rule the suite itself follows for every case.
+          set +e
+          .claude/hooks/doc-lint-test.sh > doc-lint-test.log 2>&1
+          rc=$?
+          set -e
+          cat doc-lint-test.log
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          case "$rc" in
+            0) ;;
+            1) echo "::error::A doc-lint.sh regression test failed on ${{ matrix.os }}. Details in the job log and the run summary." ;;
+            2) echo "::error::The fixture suite could not set itself up on ${{ matrix.os }} -- the workflow or the runner image is at fault, not the PR." ;;
+            *) echo "::error::doc-lint-test.sh exited $rc (crash) on ${{ matrix.os }}." ;;
+          esac
+          exit "$rc"
+
+      - name: Record the suite result in the run summary
+        if: always()
+        env:
+          RC: ${{ steps.suite.outputs.rc }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## doc-lint fixture suite (${{ matrix.os }})"
+            echo
+            if [ ! -s doc-lint-test.log ]; then
+              echo "No output -- an earlier step failed before the suite ran."
+            else
+              case "${RC:-}" in
+                0) echo "All cases passed." ;;
+                1) echo "A regression test failed. doc-lint.sh hosts the only checks for dead GitBook includes and for silently gutted pages, so a failure here means one of those gates is not working -- see the failing case name for which." ;;
+                2) echo "The suite could not set itself up (missing doc-lint.sh, or no git). Tooling failure, not a PR finding." ;;
+                *) echo "The suite exited ${RC:-unknown}. Tooling failure, not a PR finding." ;;
+              esac
+              echo
+              # Four backticks: fixture paths and doc-lint's own messages are echoed here and
+              # this is a GFM rendering surface.
+              echo '````text'
+              cat doc-lint-test.log
+              echo '````'
+              echo
+              echo "Run it locally with:"
+              echo
+              echo '````bash'
+              echo ".claude/hooks/doc-lint-test.sh          # --keep to inspect the sandbox, --verbose for output"
+              echo '````'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -170,3 +170,19 @@ samples legitimately contain `{`, `%`, and raw URLs.
   `doc-lint.sh` on staged files when **Claude Code** runs `git commit`, blocking on real
   failures and warning (without blocking) if a tool isn't installed. It does **not** gate human
   or GitBook-UI commits — see `.claude/README.md`.
+
+## Changing the linter itself
+
+Editing `doc-lint.sh` means editing the only gate for dead GitBook includes and for gutted
+pages, so run its regression suite before you commit:
+
+```bash
+.claude/hooks/doc-lint-test.sh              # --keep to inspect the sandbox, --verbose for output
+```
+
+It builds its own fixtures in a throwaway git repo under `TMPDIR` and asserts both the exit code
+and the message for every check above, including the "tool not installed" SKIP branches. CI runs
+it on every PR on Linux **and** macOS (`.github/workflows/doc-lint-test.yml`) — the two-platform
+matrix is not ceremony: both of the plumbing bugs found in this script so far were visible on
+exactly one of the two (DOCS-6409 on Linux only, an empty-array expansion on macOS bash 3.2
+only). Added in DOCS-6471.


### PR DESCRIPTION
[DOCS-6471](https://mariadbcorp.atlassian.net/browse/DOCS-6471)

Nothing in CI ran `.claude/hooks/doc-lint.sh`, and its only caller is a Claude Code `PreToolUse(Bash)` hook that — as `pre-commit.sh`'s own header says — "only gates commits that Claude Code makes via the Bash tool. Human `git commit`, IDE commits, and GitBook-UI edits bypass it entirely." So the script hosting the **only** checks for dead GitBook includes (DOCS-6372) and silently gutted pages (DOCS-6470, for the DOCS-6442 class) was covered by nothing at all.

DOCS-6409 is what that cost: a `mktemp` template with no `X` characters made the script exit 2 on every GNU-coreutils run for **135 commits**, and because the failing line sat *before* the checks, it silently took the include resolver down with it — so a feature added the same day never ran on Linux even once.

This is **Part 1** of the ticket, the primary ask. Part 2 is deliberately split out (see below).

## What's here

**`.claude/hooks/doc-lint-test.sh`** — 33 fixture cases, runnable locally, building their fixtures in a throwaway git repo under `TMPDIR`. It asserts both the exit code and the message for the ticket's whole table plus rather more: the include resolver (resolvable, dead, cross-space, `https`, the `dev-docs/`+`.claude/` exemption, multiple failures in one run), the shrink guard (gutted, `DOC_LINT_ALLOW_SHRINK` by path / by list / `=all`, absent from the base rev, each of the three thresholds isolated one at a time, an unresolvable `DOC_LINT_BASE`), the repo-root guard, the argument filter, and every "tool not installed" SKIP branch.

Two rules come straight from how DOCS-6409 hid, both of which the ticket calls for:

- **Nothing is piped.** Per DOCS-6409 impact note 4, `doc-lint.sh … | tail` returns the *pipe's* status, so a hard failure reads as a clean 0. Every case redirects to files and reads `$?` directly — and so does the workflow step that runs the suite.
- **The SKIP branches are asserted**, and so are the *tool-present* branches. A script that dies in its own plumbing before the first `command -v` passes every SKIP assertion and still checks nothing — that is exactly what DOCS-6409 did. Three cases prove codespell is actually reached (a misspelling fails, `-I .codespellignore` is honoured, `SUMMARY.md` is excluded as `codespell.yml` does) and three prove lychee is.

**`.github/workflows/doc-lint-test.yml`** — two jobs: shellcheck over every tracked shell script, and the suite on `ubuntu-latest` **and** `macos-latest`.

## Three design calls worth a look

**It runs on every PR, not only when the hooks change.** DOCS-6409 was not caused by an edit to the script — it was caused by the script meeting different coreutils. A `paths:` filter on `.claude/hooks/**` would have been green throughout those 135 commits. The suite reads nothing from the checkout (it builds its own repo in `TMPDIR`), so unlike a content check it cannot hand an unrelated PR's author a finding they are unable to clear from their own branch — the failure mode DOCS-6401 documents.

**Both platforms.** `macos-latest` still ships bash 3.2, which is the portability floor `doc-lint.sh` claims in its header. That claim was already broken — see below.

**shellcheck and lychee are pinned by version + sha256** rather than taken from the runner image, so a runner bump cannot add a new check and turn unrelated PRs red on files their author never touched. The shellcheck pin matches what the ticket measured clean (0.11.0). Note the lychee pin is independent of `link-check-pr.yml`'s: that workflow gates the link check at whatever its action ships, this one only feeds the fixture suite, so the two need not move together.

The shellcheck target list is **discovered** (`git ls-files '*.sh'`), not an allowlist, so a script added anywhere is gated the day it lands.

## The bug the suite found on its first run

Expanding `"${arr[@]}"` or `"${arr[*]}"` on an **empty** array is an "unbound variable" error under `set -u` before bash 4.4 — i.e. on the bash 3.2 that stock macOS still ships. In `norm_path`, a `..` that pops the last remaining segment emptied the array and the recompaction died, so the function returned the **empty string**:

```
$ /bin/bash -c 'set -u; ...; norm_path "server/../maxscale/included.md"'
line 185: out[@]: unbound variable
[]
```

Two consequences. Any include climbing out of its own directory was misreported as *unresolvable*. And since escaping the top-level directory is precisely what a cross-space include has to do, **the cross-space branch was unreachable on macOS entirely** — the check the ticket lists as its own fixture row had never once fired there.

The mirror image of DOCS-6409: same class of bug, opposite platform, invisible to a single-runner gate. Which is the argument for the matrix, made by the thing itself.

No page in the repo hits it today — I checked every `{% include %}` in the tree for one with as many leading `..` segments as its page has directory levels, and there are none — so this clears a latent defect rather than a live failure.

## Test plan

Ran locally on macOS (bash 3.2, shellcheck 0.11.0, codespell, lychee 0.24.2):

- `.claude/hooks/doc-lint-test.sh` → **33 passed, 0 failed, 0 skipped**
- `shellcheck` over the discovered list → clean; `actionlint` on the new workflow → clean
- `codespell` (CI-exact invocation) and `doc-lint.sh` over the two changed Markdown files → clean
- `fragcheck.py new origin/main` → no new dead anchors, no new stolen ids

**And the gate was proved to fail, not just to pass.** A check that has never gone red proves nothing (DOCS-6481, DOCS-6401), so I mutated `doc-lint.sh` twelve ways and confirmed each is caught:

| Mutation | Result |
|---|---|
| `mktemp` fails before the checks — the DOCS-6409 shape | 4 passed, **28 failed** |
| include resolver never tallies a failure | **4 failed** |
| cross-space branch removed | **2 failed** |
| the `norm_path` fix reverted | **2 failed** |
| shrink guard never fails | **2 failed** |
| `DOC_LINT_ALLOW_SHRINK` ignored | **3 failed** |
| repo-root guard removed | **1 failed** |
| a codespell SKIP notice turned into a hard failure | **18 failed** |
| lychee "No links were found" carve-out removed | **1 failed** |
| `SUMMARY.md` no longer excluded from codespell | **1 failed** |
| `dev-docs/` + `.claude/` include exemption removed | **1 failed** |
| the "file must exist" argument filter removed | **1 failed** |
| *(control: unmutated)* | 33 passed, 0 failed |

Two of those needed the suite tightened before they were caught, and both are worth knowing about:

- **The lychee carve-out is a compatibility shim.** `failIfEmpty: false` is a *lychee-action* option — the action runs its own emptiness check, while the lychee **binary** has exited 0 on a link-free file since ~0.16 (verified on 0.24.2). So no installed lychee can reach that branch. A stub `lychee` on `PATH` pins it, which keeps the shim from rotting into dead code that a future cleanup removes by accident rather than on purpose.
- **The argument filter's `[ -f "$f" ]` is load-bearing only when a checker is present.** Without it, a path deleted or renamed since it was staged reaches lychee, which exits 1 with "Input not found as file and not a valid URL" — reported to the author as a broken *link*, on a page that no longer exists. With both checkers absent the unfiltered path is inert, so only a tool-present case catches it.

## Deliberately not in this PR

**Part 2** — running the include resolver and the shrink guard as a PR gate over repo content. The ticket calls it optional and larger, and it is: `DOC_LINT_ALLOW_SHRINK` is an environment variable no PR author can set from a branch, so it needs an in-band acknowledgment path (a PR label, a commit-message trailer, or a checked-in allowlist), and choosing among those is a real decision rather than an implementation detail. Filing as a follow-up.

**`release-notes/maxscale/script/*.sh`** is excluded from the shellcheck gate, with the reason on the record in the workflow rather than as a bare exclusion. It carries 12 pre-existing findings, all info/warning-level, and one is more than style: `upgrade_version`'s comment says it "needs to be updated whenever a new major release is out", but the heredoc hardcodes the upgrading link and never reads the variable, so the instruction is misleading to whoever next cuts a release. Fixing it changes generated release-note output, which is the owning team's call, not something to slip into an infrastructure PR — reported on the ticket instead. Drop the exclusion once it is resolved.

**`actionlint` in CI** — adjacent and worth having (it embeds shellcheck for `run:` blocks and flags the untrusted-input class DOCS-6401 fixed by hand), but it needs its own decision about the 6 pre-existing findings on `main` and the known `SC2088` false positive in `link-check-pr.yml`. Separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6471]: https://mariadbcorp.atlassian.net/browse/DOCS-6471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ