### PR TITLE
DOCS-6589 don't push alias expansions to a fork PR

### DIFF
--- a/.github/workflows/expand-gitbook-aliases.yml
+++ b/.github/workflows/expand-gitbook-aliases.yml
@@ -73,6 +73,11 @@ jobs:
           tr '\0' '\n' < "$CHANGED_MD"
 
       - name: Expand GitBook aliases (Stable Version)
+        # Same-repository pull requests only. A pull request from a fork cannot
+        # be expanded at all, so it must not be expanded here either: the check
+        # step below is what reports the alias to its author, and it can only
+        # see an alias this step has left alone (DOCS-6589).
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           set -eu
 
@@ -118,6 +123,17 @@ jobs:
           git status --short
 
       - name: Commit and push changes back to PR branch
+        # Same-repository pull requests only, for two independent reasons
+        # (DOCS-6589). GITHUB_TOKEN is read-only on a pull_request event whose
+        # head is a fork, whatever the permissions block above says, so the
+        # push 403s. And "origin" is the BASE repository, not the fork -- given
+        # a write token this would create a branch named after the
+        # contributor's branch inside mariadb-corporation/mariadb-docs, while
+        # the fork branch the pull request actually tracks stayed unexpanded.
+        # A wrong-target push, not a failed one. The auto-commit is a
+        # convenience; the check step below is the control, so forks get the
+        # check and no push.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           # Not interpolated into the script body: a branch name is
           # attacker-controlled on a public repository, and this job holds
@@ -141,6 +157,8 @@ jobs:
           git push origin "HEAD:refs/heads/$HEAD_REF"
 
       - name: Fail on an unexpanded alias
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           set -eu
 
@@ -153,7 +171,9 @@ jobs:
           # here, which is the only place an author sees it.
           #
           # This runs after the push so the legitimate expansions are still
-          # committed to the PR branch when it fails.
+          # committed to the PR branch when it fails. On a fork pull request
+          # neither the expansion nor the push runs, and this step is the whole
+          # of the workflow's behaviour (DOCS-6589).
           #
           # It reads the same file list as the expansion step, which also keeps
           # it from failing a PR over an unknown alias in a file that PR never
@@ -175,11 +195,27 @@ jobs:
             < "$CHANGED_MD" || true)
 
           if [ -n "$LEFTOVER" ]; then
-            echo "::error::Unknown GitBook alias left unexpanded in a link target"
+            echo "::error::GitBook alias left unexpanded in a link target"
             echo "$LEFTOVER"
             echo
-            echo "An alias must be one of the names in dev-docs/link-aliases.md."
-            echo "To add a space, add it to the expansion step in this workflow."
+
+            # On a fork the expansion step above did not run, so this is any
+            # alias, not only an unknown one -- and the author cannot get it
+            # expanded from their own branch. Say so, rather than sending them
+            # to a list their alias may well already be on (DOCS-6589).
+            if [ "$IS_FORK" = "true" ]; then
+              echo "This pull request comes from a fork, and aliases are not expanded"
+              echo "on a fork pull request: the workflow has no write access to your"
+              echo "branch, and pushing to this repository instead would not touch it."
+              echo
+              echo "Replace each alias above with the full"
+              echo "https://app.gitbook.com/o/<org>/s/<space>/... URL for that space,"
+              echo "listed in dev-docs/link-aliases.md, or ask a maintainer to expand"
+              echo "them for you after review."
+            else
+              echo "An alias must be one of the names in dev-docs/link-aliases.md."
+              echo "To add a space, add it to the expansion step in this workflow."
+            fi
             exit 1
           fi
 

--- a/dev-docs/link-aliases.md
+++ b/dev-docs/link-aliases.md
@@ -106,3 +106,11 @@ Markdown files your own PR changes, so that follow-up commit never edits a file 
   comes back `[null, null]`; that is the parked state, not a tooling glitch. And a parked run
   that is never approved flips to **failure with zero jobs** once the PR is closed or the branch
   deleted, so a red run of that shape on an abandoned branch never ran and is nothing to chase.
+- **Aliases are not expanded on a pull request from a fork** — the `expand-links` check
+  reports every alias in a link target, with its file and line, and fails. Two things stop the
+  auto-commit there: `GITHUB_TOKEN` is read-only on a `pull_request` from a fork whatever the
+  workflow's `permissions` block says, and `origin` is this repository rather than the fork, so
+  a push would create a contributor-named branch here and leave the fork branch untouched
+  (DOCS-6589). If you work from a fork, either write the full
+  `https://app.gitbook.com/o/<org>/s/<space>/...` URL yourself, or push the branch to this
+  repository instead, where expansion runs normally.


### PR DESCRIPTION
Jira: [DOCS-6589](https://mariadbcorp.atlassian.net/browse/DOCS-6589)

`expand-gitbook-aliases.yml` auto-commits expanded aliases back onto the PR branch. On a pull request from a **fork** that push has two independent defects, the second worse than the first.

1. **The token is read-only.** `GITHUB_TOKEN` is read-only on a `pull_request` event whose head is a fork, whatever the `permissions:` block says, so the push 403s. And because the step runs under `set -eu`, the job aborts *before* `Fail on an unexpanded alias` runs — the contributor gets a raw git error instead of the actionable message naming file and line.
2. **`origin` is the base repository, not the fork.** Given a write token, the push would create a branch named after the contributor's branch inside `mariadb-corporation/mariadb-docs`, while the fork branch the PR actually tracks stayed unexpanded. A wrong-target push, not a failed one. Defect 1 is the only thing preventing it today.

## What this does

Gates the expansion **and** the push on `github.event.pull_request.head.repo.full_name == github.repository`, so a fork PR gets the read-only check and no push at all. The auto-commit is a convenience; the check is the control.

The expansion is skipped too, deliberately — not just the push. The check can only report an alias the expansion step left alone, so skipping both makes the check the whole of the workflow's behaviour on a fork, and every alias in a link target is reported with its file and line.

That makes the old message wrong on a fork ("an alias must be one of the names in `dev-docs/link-aliases.md`" — theirs probably is), so the message is now fork-aware: replace the alias with the full `https://app.gitbook.com/…` URL, or ask a maintainer, or push the branch here instead.

Documented in `dev-docs/link-aliases.md`, next to the existing direct-to-`main` note — the other write path this workflow structurally cannot cover.

## Latent, not live

10 of the last 100 PRs are cross-repository (#1012, #1011, #1007, #986, #968, #966, #963, #960, #951, #944) and **all 10 passed** `expand-links` — not because forks are handled, but because none needed an expansion. #1012's run log shows `No alias replacements needed.` before the push: the step returns 0 at `git diff --quiet` and never reaches it. The bug fires the first time a fork PR carries an alias in a link target, and the realistic trigger is staff working from forks, who know the convention exists.

## Verification

- `actionlint` clean on the file; YAML re-parsed and the two `if:` conditions confirmed on the expansion and push steps only.
- The check step's shell was rehearsed locally on a two-file NUL list (one file with a space in its name, one known alias, one unknown): both message branches print, `grep -nHE` keeps the `file:line:` prefix, exit 1 on a hit and 0 on a clean tree.
- A **fork PR exercising the path that fires** — the acceptance criterion this ticket insists on — is the one thing local rehearsal cannot give. Doing that next, on a throwaway fork; will report the run here before merge.
- This PR itself exercises the same-repository path: `expand-links` must stay green and must not push anything (the two changed files are both on the exclusion list).


[DOCS-6589]: https://mariadbcorp.atlassian.net/browse/DOCS-6589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ