### PR TITLE
DOCS-6593 Document the parked runs the alias bot's push creates

### DIFF
--- a/dev-docs/link-aliases.md
+++ b/dev-docs/link-aliases.md
@@ -85,3 +85,24 @@ Markdown files your own PR changes, so that follow-up commit never edits a file 
   reported, because no PR changed that file. **So don't commit an aliased link directly to
   `main`**: GitBook will publish the alias verbatim as a `github.com/...` URL that 404s. If
   one gets there anyway, touching the file in any PR expands it.
+- **The bot's own expansion commit is never checked automatically, and that needs a manual
+  approve.** The push fires a `synchronize` event, GitHub attributes the resulting runs to
+  `github-actions[bot]`, and parks every one of them in `action_required` — created, but not
+  started. So the green checks on a PR whose last commit is `docs: expand GitBook aliases`
+  belong to the commit *before* it. Unblock them by hand:
+
+  ```sh
+  gh run list -R mariadb-corporation/mariadb-docs -b <BRANCH> -L 8
+  gh api -X POST /repos/mariadb-corporation/mariadb-docs/actions/runs/<ID>/approve
+  ```
+
+  This is GitHub's recursion guard on `GITHUB_TOKEN`-triggered events, **not** a repository
+  setting, so there is no dropdown that turns it off. The repository's approval option is
+  *Require approval for first-time contributors*, which governs fork pull requests and cannot
+  reach a same-repository push; and the parking hits 100% of bot-triggered `pull_request` runs
+  across every branch and month on record, where a contributor policy would spare an identity
+  that has commits merged — which `github-actions[bot]` does (DOCS-6593). Two symptoms not to
+  misread. `gh pr checks` prints **no checks reported on the branch** and `statusCheckRollup`
+  comes back `[null, null]`; that is the parked state, not a tooling glitch. And a parked run
+  that is never approved flips to **failure with zero jobs** once the PR is closed or the branch
+  deleted, so a red run of that shape on an abandoned branch never ran and is nothing to chase.


### PR DESCRIPTION
Closes DOCS-6593.

The alias workflow's `docs: expand GitBook aliases` push fires a `synchronize` event that GitHub attributes to `github-actions[bot]`, and every resulting workflow run is parked in `action_required` — created, but never started. The green checks on such a PR therefore belong to the commit *before* the bot's. We have been approving those runs by hand since PR #820 / DOCS-6366 (2026-07-30); nothing wrote it down.

This adds one bullet to `dev-docs/link-aliases.md` with the `gh run list` / `gh api ... /approve` recipe, plus the two symptoms that read as tooling glitches rather than as the parked state:

- `gh pr checks` prints *no checks reported on the branch* and `statusCheckRollup` comes back `[null, null]`.
- A parked run that is never approved flips to **failure with zero jobs** once the PR is closed or the branch deleted — so a red run of that shape on an abandoned branch never ran, and is nothing to chase.

### Why no configuration change

Daniel Bartholomew read Settings → Actions → General for the ticket: the selected option is **Require approval for first-time contributors**. That governs fork pull requests, so it cannot reach a same-repository push — and the parking hit 100% of bot-triggered `pull_request` runs on record (25 currently `action_required`, all `github-actions[bot]`; zero human-triggered), across every branch since mid-August. A contributor policy would spare an identity with merged commits, which `github-actions[bot]` has (it is in the repository's contributors list). This is GitHub's recursion guard on `GITHUB_TOKEN`-triggered events, not a setting, so there is no dropdown to change — and the approval control itself should be left as it is regardless, since loosening it is what protects the repository from outside-contributor fork PRs.

The heavier options in the ticket (self-approval from the job, re-dispatching the gates, pushing with a PAT or App token) were all declined: they either defeat the recursion guard or put a broader credential on a job that processes contributor content, which is the same trade-off DOCS-6589 declined for the fork path.

Docs-only, no workflow change.