### PR TITLE
DOCS-6590 Rescope the two overreaching MaxScale install guides

### DIFF
--- a/.claude/hooks/navcheck.py
+++ b/.claude/hooks/navcheck.py
@@ -139,20 +139,44 @@ def spaces_for(root, paths):
     return sorted(hit)
 
 
+def tree_pages(root, space):
+    """Pages of `space` in the working tree, as git sees them.
+
+    Enumerated with `git ls-files --cached --others --exclude-standard` rather
+    than os.walk, and the distinction is the whole point: the base side of the
+    `new` gate is read with git ls-tree, so walking the filesystem here compares
+    a set that includes IGNORED and untracked litter against one that cannot.
+    Any stray Markdown in a space -- a /graphify GRAPH_REPORT.md, a scratch page,
+    an editor backup -- then reports as newly orphaned by whatever PR runs the
+    gate next, and it does not reproduce in CI, which runs on a clean checkout.
+    `--others --exclude-standard` keeps the case the gate exists for (a page you
+    just wrote and have not listed) while dropping what .gitignore covers.
+    """
+    ok, listing = git(root, 'ls-files', '--cached', '--others',
+                      '--exclude-standard', '-z', '--', space + '/')
+    if not ok:
+        # No git (a tarball, say). Fall back to the filesystem: over-reporting
+        # beats silently checking nothing.
+        pages = set()
+        for dirpath, dirnames, filenames in os.walk(pathlib.Path(root) / space):
+            dirnames[:] = [d for d in dirnames if d != '.gitbook']
+            for fn in filenames:
+                rel = os.path.relpath(os.path.join(dirpath, fn),
+                                      root).replace(os.sep, '/')
+                if is_page(rel, space):
+                    pages.add(rel)
+        return pages
+    # NUL-delimited, so a path containing a space or a newline cannot split.
+    return {ln for ln in listing.split('\0') if is_page(ln, space)}
+
+
 def orphans_now(root, space):
     """Pages of `space` in the working tree with no SUMMARY.md entry."""
     sm = pathlib.Path(root) / space / SUMMARY
     if not sm.is_file():
         return set()
     refs = parse_refs(sm.read_text(encoding='utf-8', errors='replace'), space)
-    pages = set()
-    for dirpath, dirnames, filenames in os.walk(pathlib.Path(root) / space):
-        dirnames[:] = [d for d in dirnames if d != '.gitbook']
-        for fn in filenames:
-            rel = os.path.relpath(os.path.join(dirpath, fn), root).replace(os.sep, '/')
-            if is_page(rel, space):
-                pages.add(rel)
-    return pages - refs
+    return tree_pages(root, space) - refs
 
 
 def orphans_at(root, rev, space):

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ research/
 /dist/
 /pdf/__pycache__/
 /.claude/hooks/__pycache__/
+
+# /graphify output (knowledge-graph artifacts, written next to the pages it read).
+# Unanchored: the skill writes one of these per directory it is pointed at, and
+# its GRAPH_REPORT.md otherwise trips doc-lint's navcheck as an unlisted page.
+graphify-out/

--- a/maxscale/SUMMARY.md
+++ b/maxscale/SUMMARY.md
@@ -3,7 +3,7 @@
 * [MariaDB MaxScale](README.md)
 * [Quickstart Guides](maxscale-quickstart-guides/README.md)
   * [MariaDB MaxScale Beginner's Guide](maxscale-quickstart-guides/maxscale-beginner-guide.md)
-  * [MariaDB MaxScale Installation Guide](maxscale-quickstart-guides/mariadb-maxscale-installation-guide.md)
+  * [MaxScale Getting Started Guide](maxscale-quickstart-guides/maxscale-getting-started-guide.md)
   * [MariaDB MaxScale Authenticators Guide](maxscale-quickstart-guides/mariadb-maxscale-authenticators-guide.md)
 * [MaxScale Architecture](maxscale-architecture/README.md)
   * [About MariaDB MaxScale](maxscale-architecture/mariadb-maxscale-guide.md)

--- a/maxscale/mariadb-maxscale-tutorials/mariadb-maxscale-exasolrouter.md
+++ b/maxscale/mariadb-maxscale-tutorials/mariadb-maxscale-exasolrouter.md
@@ -32,7 +32,7 @@ This architecture allows applications to use a single connection endpoint for bo
 ## Prerequisites
 
 * MariaDB MaxScale **25.10.1 or later** must be installed (CDC to Exasol requires **25.10.3 or later**).\
-  See the [installation guide](../maxscale-quickstart-guides/mariadb-maxscale-installation-guide.md) if required.
+  See the [getting started guide](../maxscale-quickstart-guides/maxscale-getting-started-guide.md) if required.
 * MaxScale running on x86\_64 architecture
   * The Exasolrouter module uses the Exasol ODBC driver to establish communication with Exasol.
   * The Exasol ODBC driver currently requires x86\_64.

--- a/maxscale/maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md
+++ b/maxscale/maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md
@@ -3081,6 +3081,27 @@ maxscale --export-config=/tmp/maxscale.cnf.combined
 
 This will create the `/tmp/maxscale.cnf.combined` file and write the current configuration into the it. This allows new MaxScale instances to be easily set up without requiring copying of all runtime configuration files. The user executing the command must be able to read all MaxScale configuration files as well as create and write the provided filename.
 
+## Backing Up a MaxScale Installation
+
+The section above covers the runtime configuration alone. To copy or back up a whole MaxScale
+installation, include its static configuration and the data its modules keep on disk.
+
+The main configuration file for MaxScale is in `/etc/maxscale.cnf` and additional user-created configuration files are in `/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in `/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in `/var/lib/maxscale/` named after the module or the configuration object.
+
+The simplest way to back up the configuration and runtime data of a MaxScale installation is to create an archive from the following files and directories:
+
+* `/etc/maxscale.cnf`
+* `/etc/maxscale.cnf.d/`
+* `/var/lib/maxscale/`
+
+This can be done with the following command:
+
+```bash
+tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
+```
+
+If MaxScale is configured to store data in custom locations, these should be included in the backup as well.
+
 ## Encryption Key Managers
 
 The encryption key managers are how MaxScale retrieves symmetric encryption keys from a key management system. Some parts of MaxScale require the `key_manager` to be configured in order to work. The key manager that is used is selected with the [key\_manager](maxscale-configuration-guide.md#key_manager) parameter and the key manager itself is configured by placing the parameters in the `[maxscale]` section.

--- a/maxscale/maxscale-management/installation-and-configuration/maxscale-installation-guide.md
+++ b/maxscale/maxscale-management/installation-and-configuration/maxscale-installation-guide.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Install MariaDB MaxScale on Linux using official package repositories or
-  RPM/DEB files. This guide details setup for RHEL, Debian, and SLES, plus
-  essential memory and backup configuration.
+  Install MariaDB MaxScale on Linux using official package repositories, RPM/DEB
+  files, or a tarball. This guide details setup for RHEL, Debian, and SLES, plus
+  the kernel memory-overcommit setting MaxScale assumes.
 ---
 
 # MaxScale Installation Guide
@@ -65,39 +65,14 @@ Alternatively, use this command:
 cat /proc/sys/vm/overcommit_memory
 ```
 
-### Configuring MariaDB MaxScale
+### Next Steps
 
-[The MaxScale Tutorial](../../mariadb-maxscale-tutorials/setting-up-mariadb-maxscale.md) covers the first steps in configuring your MariaDB MaxScale installation. Follow this tutorial to learn how to configure and start using MaxScale.
+MaxScale is installed. Configuring, administering and backing it up are covered in full elsewhere,
+so this guide only points at them:
 
-For a detailed list of all configuration parameters, refer to the [Configuration Guide](../deployment/installation-and-configuration/maxscale-configuration-guide.md) and the module specific documents found in the [reference](../../reference/).
-
-### Encrypting Passwords
-
-Read the [Encrypting Passwords](../deployment/installation-and-configuration/maxscale-configuration-guide.md#encrypting-passwords) section of the configuration guide to set up password encryption for the configuration file.
-
-### Administration Of MariaDB MaxScale
-
-There are various administration tasks that may be done with MariaDB MaxScale. A command line tools is available, [maxctrl](../../reference/maxscale-maxctrl.md), that interacts with a running MariaDB MaxScale and allows the status of MariaDB MaxScale to be monitored and give some control of the MariaDB MaxScale functionality.
-
-The [administration tutorial](../../mariadb-maxscale-tutorials/maxscale-administration-tutorial.md) covers the common administration tasks that need to be done with MariaDB MaxScale.
-
-### Copying or Backing Up MaxScale
-
-The main configuration file for MaxScale is in `/etc/maxscale.cnf` and additional user-created configuration files are in `/etc/maxscale.cnf.d/`. Objects created or modified at runtime are stored in `/var/lib/maxscale/maxscale.cnf.d/`. Some modules also store internal data in `/var/lib/maxscale/` named after the module or the configuration object.
-
-The simplest way to back up the configuration and runtime data of a MaxScale installation is to create an archive from the following files and directories:
-
-* `/etc/maxscale.cnf`
-* `/etc/maxscale.cnf.d/`
-* `/var/lib/maxscale/`
-
-This can be done with the following command:
-
-```bash
-tar -caf maxscale-backup.tar.gz /etc/maxscale.cnf /etc/maxscale.cnf.d/ /var/lib/maxscale/
-```
-
-If MaxScale is configured to store data in custom locations, these should be included in the backup as well.
+* [The MaxScale Tutorial](../../mariadb-maxscale-tutorials/setting-up-mariadb-maxscale.md) covers the first steps in configuring your installation — follow it to configure and start using MaxScale.
+* The [Configuration Guide](../deployment/installation-and-configuration/maxscale-configuration-guide.md) is the complete parameter reference, including [Encrypting Passwords](../deployment/installation-and-configuration/maxscale-configuration-guide.md#encrypting-passwords) for the configuration file, [Administration](../deployment/installation-and-configuration/maxscale-configuration-guide.md#administration), and [Backing Up a MaxScale Installation](../deployment/installation-and-configuration/maxscale-configuration-guide.md#backing-up-a-maxscale-installation). Module-specific parameters are in the [reference](../../reference/).
+* [maxctrl](../../reference/maxscale-maxctrl.md) is the command line client for a running MaxScale, and the [administration tutorial](../../mariadb-maxscale-tutorials/maxscale-administration-tutorial.md) covers the common administration tasks.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/maxscale/maxscale-quickstart-guides/maxscale-getting-started-guide.md
+++ b/maxscale/maxscale-quickstart-guides/maxscale-getting-started-guide.md
@@ -1,11 +1,11 @@
 ---
 description: >-
-  Follow step-by-step instructions to install MariaDB MaxScale on major Linux
-  distributions. This guide covers repository configuration and package
-  installation.
+  Get MariaDB MaxScale running on major Linux distributions: key concepts,
+  package installation, and a first working configuration with servers, a
+  monitor, a service, and a listener.
 ---
 
-# MariaDB MaxScale Installation Guide
+# MaxScale Getting Started Guide
 
 ## Quickstart Guide: MariaDB MaxScale
 
@@ -230,6 +230,5 @@ mariadb -h 127.0.0.1 -P 3306 -u my-user -p
 
 * [MariaDB MaxScale Installation Guide](../maxscale-management/installation-and-configuration/maxscale-installation-guide.md)
 * [MariaDB MaxScale Configuration Guide](../maxscale-management/deployment/installation-and-configuration/maxscale-configuration-guide.md)
-* [MariaDB MaxScale GitHub Repository](https://github.com/mariadb-corporation/MaxScale)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage.md
+++ b/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage.md
@@ -580,7 +580,7 @@ To install MariaDB on Red Hat Enterprise Linux (RHEL) and equivalents, see the i
 sudo dnf install MariaDB-server MariaDB-client MariaDB-backup
 ```
 
-To install MariaDB MaxScale on Red Hat Enterprise Linux (RHEL) and equivalents, see the instructions at [MaxScale Installation Guide]({maxscale}/maxscale-management/deployment/installation-and-configuration/maxscale-installation-guide). For example:
+To install MariaDB MaxScale on Red Hat Enterprise Linux (RHEL) and equivalents, see the instructions at [MaxScale Installation Guide](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/installation-and-configuration/maxscale-installation-guide). For example:
 
 ```bash
 sudo dnf install maxscale
@@ -612,7 +612,7 @@ To install MariaDB on SUSE Linux Enterprise Server (SLES), see the instructions 
 sudo zypper install MariaDB-server MariaDB-client MariaDB-backup
 ```
 
-To install MariaDB MaxScale on SUSE Linux Enterprise Server (SLES), see the instructions at [MaxScale Installation Guide]({maxscale}/maxscale-management/deployment/installation-and-configuration/maxscale-installation-guide). For example:
+To install MariaDB MaxScale on SUSE Linux Enterprise Server (SLES), see the instructions at [MaxScale Installation Guide](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/maxscale-management/deployment/installation-and-configuration/maxscale-installation-guide). For example:
 
 ```bash
 sudo zypper install maxscale

--- a/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage.md
+++ b/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage.md
@@ -580,7 +580,7 @@ To install MariaDB on Red Hat Enterprise Linux (RHEL) and equivalents, see the i
 sudo dnf install MariaDB-server MariaDB-client MariaDB-backup
 ```
 
-To install MariaDB MaxScale on Red Hat Enterprise Linux (RHEL) and equivalents, see the instructions at [MariaDB MaxScale Installation Guide](https://app.gitbook.com/s/0pSbu5DcMSW4KwAkUcmX/other-maxscale-versions/mariadb-maxscale-mariadb-maxscale-23/maxscale-23-getting-started/mariadb-maxscale-23-mariadb-maxscale-installation-guide). For example:
+To install MariaDB MaxScale on Red Hat Enterprise Linux (RHEL) and equivalents, see the instructions at [MaxScale Installation Guide]({maxscale}/maxscale-management/deployment/installation-and-configuration/maxscale-installation-guide). For example:
 
 ```bash
 sudo dnf install maxscale
@@ -612,7 +612,7 @@ To install MariaDB on SUSE Linux Enterprise Server (SLES), see the instructions 
 sudo zypper install MariaDB-server MariaDB-client MariaDB-backup
 ```
 
-To install MariaDB MaxScale on SUSE Linux Enterprise Server (SLES), see the instructions at [MariaDB MaxScale Installation Guide](https://app.gitbook.com/s/0pSbu5DcMSW4KwAkUcmX/other-maxscale-versions/mariadb-maxscale-mariadb-maxscale-23/maxscale-23-getting-started/mariadb-maxscale-23-mariadb-maxscale-installation-guide). For example:
+To install MariaDB MaxScale on SUSE Linux Enterprise Server (SLES), see the instructions at [MaxScale Installation Guide]({maxscale}/maxscale-management/deployment/installation-and-configuration/maxscale-installation-guide). For example:
 
 ```bash
 sudo zypper install maxscale


### PR DESCRIPTION
Closes DOCS-6590 — DOCS-6525's judgment calls 2 and 3, which #1014 never touched. Both pages had the same defect: **the title claimed less than the content delivered.**

**⚠️ One redirect must be loaded with or before the merge** — see *Before merging* at the bottom.

## Call 2 — the quickstart page

`maxscale-quickstart-guides/mariadb-maxscale-installation-guide.md` → `maxscale-getting-started-guide.md`, H1 → **MaxScale Getting Started Guide**. Its own H2 is *Quickstart Guide: MariaDB MaxScale* and it configures servers, a monitor, a service, a listener and threads — well past installation. The H2 and the body are otherwise untouched, per the call.

- **Two** true inbound references updated: `maxscale/SUMMARY.md:6` and the ExasolRouter tutorial. The other 15 substring matches are the four old-version namesake pages plus their nav entries — separate versioned pages, not links to this one. Not touched.
- The **one** link to the abandoned public `mariadb-corporation/MaxScale` repo is gone. The page's three other "repository" mentions are MariaDB **package** repositories and are its core instruction (*Add MariaDB Repository*, the Repository Configuration Tool) — a sweep on the word would have gutted the install steps.
- Its `description` promised only installation too; it now describes what the page does.

## Call 3 — the management install guide, section by section

Checked one at a time against the 3,482-line configuration guide rather than in bulk:

| Section | Verdict | Evidence |
| --- | --- | --- |
| `### Configuring MariaDB MaxScale` | delete → link | Pointers only: the setup tutorial, the configuration guide, the module reference. No unique prose. |
| `### Encrypting Passwords` | delete → link | One sentence linking that guide's own `#encrypting-passwords`, which carries the `maxkeys` detail and the 2.5 format change. Fully subsumed. |
| `### Administration Of MariaDB MaxScale` | delete → link | `maxctrl` plus a tutorial link, against that guide's `## Administration` — MaxCtrl credentials, dynamic configuration, the admin audit file. Fully subsumed. |
| `### Copying or Backing Up MaxScale` | **moved** | **Not** subsumed. `tar -caf` and `maxscale-backup` appear **0** times in the configuration guide, and the `/etc/maxscale.cnf` + `/etc/maxscale.cnf.d/` + `/var/lib/maxscale/` inventory is nowhere in it. Its `### Backing Up Configuration Changes` covers `--export-config` for the *runtime* configuration only. |

The first three collapse into one `### Next Steps` list. The fourth becomes `## Backing Up a MaxScale Installation` in the configuration guide, immediately after `### Backing Up Configuration Changes`, with a sentence tying the two together — at H2 so it is not misfiled under `## Runtime Configuration Changes`. Page goes 104 → 79 lines (24% net, under doc-lint's gutted-page threshold). No inbound anchor pointed at any of the four headings, so nothing breaks.

### The ticket's structural premise was wrong, and it makes call 3 simpler

DOCS-6590 says the two pages are not siblings, one being under `deployment/`. **True in Git, false live.** The nav node *Installation & Configuration* is `maxscale-management/installation-and-configuration/README.md` on disk but sits under *Deployment* in `SUMMARY.md`, and GitBook derives URLs from nav — so the install guide's Git path **307s** to `maxscale-management/deployment/installation-and-configuration/maxscale-installation-guide`, where the configuration guide already lives. They are live siblings, in the same nav folder, and that also answers the nav question the ticket raised: everything is already under `deployment/`.

## Drive-by — two hard 404s in a published Server page

`mariadb-package-repository-setup-and-usage.md:583` and `:615` sent RHEL/equivalent and SLES readers to a MaxScale **2.3** install guide under `other-maxscale-versions/`, a path segment that exists nowhere in the tree. Both 404 in both slash forms.

They now point at the **maintained** install guide, not at the renamed getting-started page as the ticket proposed — the surrounding sentence is *"see the instructions … `sudo dnf install maxscale`"*, which is exactly that page's content, and it links back to this very package-repository page. Written as `{maxscale}` aliases; destination verified 200 in both slash forms.

## Drive-by — navcheck enumerated the filesystem against a git tree

`navcheck.py` read "now" with `os.walk` and the base side with `git ls-tree`, so **ignored and untracked** Markdown in a space reported as *newly orphaned* by whatever PR ran the gate next — and never in CI, which runs on a clean checkout. Two stale `/graphify` `GRAPH_REPORT.md` files failed this PR's own local gate.

Now `git ls-files --cached --others --exclude-standard`, which keeps the case the gate exists for (a page you just wrote and have not listed) and drops what `.gitignore` covers. `.gitignore` gained `graphify-out/`. **Proved all three ways:** an untracked unignored page still FAILS, the same page ignored PASSES, and de-listing a real page from `SUMMARY.md` still FAILS. `doc-lint-test.sh` is 33/33 — it has no navcheck fixtures at all, which is DOCS-6586's scope; those three probes stand in for them, and 6586 should add one for this enumeration behaviour.

`fragcheck new`: clean (15 pre-existing dead anchors, unchanged).

## Before merging

One redirect, **not yet loaded** — a live-site write held for Stefan:

| Source | Destination |
| --- | --- |
| `/maxscale/maxscale-quickstart-guides/mariadb-maxscale-installation-guide` | `kind: "path"` → `maxscale-quickstart-guides/maxscale-getting-started-guide` |

**It cannot be pre-loaded, and the "pre-loading is safe" rule does not cover a rename.** `createSiteRedirect` with `kind: "path"` resolves the destination to a `pageId` at creation time, and the destination here is the page this PR creates — so it fails with **`Page not found`** until the merge has synced. (Pre-loading works for a *deletion*, where the destination already exists; a rename's destination is the thing that does not exist yet.) Rule count stayed at 1,953, so nothing was partially created.

So the order is: **merge → load the rule → probe both slash forms.** The maxscale space syncs within ~20 seconds, leaving a short window where the old URL 404s; GitBook's own move history may cover it anyway, but the rule goes in regardless rather than relying on that. Expect the first verification sweep to lie.

## Still outstanding

**Johan Wikman** never answered on DOCS-6525 and these are the two calls where his view was wanted. Nothing here forecloses him: the rename is reversible with a second redirect, and the moved backup section can move again.
