### PR TITLE
DOCS-6587 Add actionlint to CI, and clear the six findings first

### DIFF
--- a/.claude/hooks/fragcheck.py
+++ b/.claude/hooks/fragcheck.py
@@ -81,6 +81,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import pathlib
 import unicodedata
 import urllib.parse
@@ -88,6 +89,18 @@ from collections import Counter
 
 BASE_URL = 'https://mariadb.com/docs'
 CACHE = pathlib.Path(tempfile.gettempdir()) / 'fragcheck-cache'
+# `validate` compares computed anchors against the ids the LIVE site renders, so
+# it is only an oracle if what it reads is current. The on-disk cache used to
+# have no expiry, which made a snapshot taken before a deploy report a heading
+# that is live as dead: on DOCS-6590 it called `next-steps` missing while curl
+# on the same URL returned id="next-steps", and the fix was deleting one file.
+# Five minutes keeps the point of the cache (a re-run minutes later while you
+# iterate) and drops the failure mode. FRAGCHECK_CACHE_TTL=0 bypasses it.
+# Only `validate` fetches anything, so this cannot slow the `new` CI gate.
+try:
+    CACHE_TTL = int(os.environ.get('FRAGCHECK_CACHE_TTL', '300'))
+except ValueError:
+    CACHE_TTL = 300
 MAX_SLUG = 100
 
 # The levels GitBook renders as <h2>/<h3>/<h4 id="..."> — see the header comment.
@@ -686,7 +699,8 @@ CHROME = {'gb-trademark', 'mask-image', 'search-input', 'table-of-contents',
 
 def fetch(url):
     cached = CACHE / (re.sub(r'[^a-z0-9]+', '_', url) + '.html')
-    if cached.exists():
+    if (cached.exists() and CACHE_TTL > 0
+            and time.time() - cached.stat().st_mtime < CACHE_TTL):
         return cached.read_text(errors='replace')
     html = subprocess.run(['curl', '-sL', '--max-time', '60', url],
                           capture_output=True, text=True).stdout

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -60,6 +60,6 @@ jobs:
       - name: 📖 Help & Documentation
         if: failure()
         run: |
-          echo "### ❌ Spell Check Failed?" >> $GITHUB_STEP_SUMMARY
-          echo "👉 [**Read the SOP: How to Fix Spell Check Errors**](https://mariadbcorp.atlassian.net/wiki/spaces/DOCS/pages/3284140040/Pull+Requests#Method-1%3A-The-%22Quick-Fix%22-(Recommended))" >> $GITHUB_STEP_SUMMARY
+          echo "### ❌ Spell Check Failed?" >> "$GITHUB_STEP_SUMMARY"
+          echo "👉 [**Read the SOP: How to Fix Spell Check Errors**](https://mariadbcorp.atlassian.net/wiki/spaces/DOCS/pages/3284140040/Pull+Requests#Method-1%3A-The-%22Quick-Fix%22-(Recommended))" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/doc-lint-test.yml
+++ b/.github/workflows/doc-lint-test.yml
@@ -1,9 +1,14 @@
 name: Test the Doc Lint Hooks
 
-# Gates the repo's shell tooling: shellcheck over every tracked shell script, and a fixture
-# suite over .claude/hooks/doc-lint.sh -- the script that hosts the two documentation-rot
-# checks with NO CI counterpart anywhere else (the GitBook `{% include %}` resolver from
-# DOCS-6372, and the net line-loss "gutted page" guard from DOCS-6470).
+# Gates the repo's shell tooling: shellcheck over every tracked shell script, actionlint over
+# the shell inside the workflow files, and a fixture suite over .claude/hooks/doc-lint.sh --
+# the script that hosts the two documentation-rot checks with NO CI counterpart anywhere else
+# (the GitBook `{% include %}` resolver from DOCS-6372, and the net line-loss "gutted page"
+# guard from DOCS-6470).
+#
+# The shellcheck and actionlint jobs are one concern split only by where the shell lives: a
+# .sh file or a workflow's `run:` block. Twelve workflows against four standalone scripts, so
+# most of this repo's shell is in the half actionlint covers (DOCS-6587).
 #
 # WHY THIS EXISTS
 #   Until now nothing in CI ran doc-lint.sh at all, and its only caller is a Claude Code
@@ -268,6 +273,139 @@ jobs:
               echo
               echo '````bash'
               echo ".claude/hooks/doc-lint-test.sh          # --keep to inspect the sandbox, --verbose for output"
+              echo '````'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # actionlint covers what no other gate here can see: the shell inside `run:` blocks, plus
+  # workflow-specific checks -- untrusted-input interpolation above all. DOCS-6401's third defect
+  # was `github.event.pull_request.head.ref`, attacker-controlled on a public repo, interpolated
+  # straight into a `run:` block while the job held `contents: write`. actionlint names that by
+  # rule; it was found by hand, and the next one would not be. Also invalid `runs-on` labels,
+  # unknown contexts, bad `if:` expressions and action-input typos.
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Same pin, same reasoning, same version as the shellcheck job above -- and here it is not
+      # optional: actionlint shells out to shellcheck to lint `run:` blocks at all.
+      - name: Install a pinned shellcheck
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+        run: |
+          set -euo pipefail
+          tarball="$RUNNER_TEMP/shellcheck.tar.xz"
+          curl -fsSL -o "$tarball" \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          echo "${SHELLCHECK_SHA256}  ${tarball}" | sha256sum --check --strict
+          tar -xJf "$tarball" -C "$RUNNER_TEMP"
+          install -m 0755 "$RUNNER_TEMP/shellcheck-${SHELLCHECK_VERSION}/shellcheck" \
+            /usr/local/bin/shellcheck
+          shellcheck --version
+
+      - name: Install a pinned actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          # Cross-checked against the publisher's own actionlint_1.7.12_checksums.txt for this tag.
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          # Pinned rather than `go install` or the runner image, so a new actionlint release
+          # cannot turn unrelated PRs red on workflow files their author never touched -- the
+          # DOCS-6401 failure mode. Bumping the pin is then a deliberate PR that fixes whatever
+          # the new version finds.
+          tarball="$RUNNER_TEMP/actionlint.tar.gz"
+          curl -fsSL -o "$tarball" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum --check --strict
+          tar -xzf "$tarball" -C "$RUNNER_TEMP"
+          install -m 0755 "$RUNNER_TEMP/actionlint" /usr/local/bin/actionlint
+          command -v actionlint
+          actionlint --version
+
+      # MEASURED, not assumed: with shellcheck off PATH, actionlint exits 0 on a workflow whose
+      # `run:` block has a plain SC2086. It does not warn, it does not mention shellcheck -- it
+      # silently checks no shell and reports success. `command -v shellcheck` would not catch
+      # every way that happens (a version actionlint cannot drive, say), so assert the behaviour
+      # instead of the binary: this fixture MUST be reported, or the gate is vacuous.
+      - name: Prove actionlint is really running shellcheck
+        run: |
+          set -euo pipefail
+          probe="$RUNNER_TEMP/actionlint-selftest.yaml"
+          cat > "$probe" <<'PROBE'
+          name: selftest
+          on: push
+          jobs:
+            selftest:
+              runs-on: ubuntu-latest
+              steps:
+                - run: |
+                    echo hi >> $UNQUOTED
+          PROBE
+          # Redirect, then grep the file. NOT `... | tee log | grep -q`: grep -q exits on the
+          # first match and closes the pipe, tee dies of SIGPIPE, and `pipefail` turns the whole
+          # pipeline non-zero -- so the success path would report failure. Measured, not
+          # theorised: the first draft of this step failed with shellcheck plainly installed.
+          # actionlint exits 1 when it reports anything, hence the `|| true`.
+          actionlint -no-color "$probe" > "$RUNNER_TEMP/selftest.log" 2>&1 || true
+          if grep -q 'SC2086' "$RUNNER_TEMP/selftest.log"; then
+            echo "actionlint is driving shellcheck (SC2086 reported on the fixture)."
+          else
+            cat "$RUNNER_TEMP/selftest.log"
+            echo "::error::actionlint did not report SC2086 on a fixture that plainly has it. It is not driving shellcheck, so the shell in every run: block is unchecked and a green result here would mean nothing."
+            exit 1
+          fi
+
+      - name: Actionlint every workflow
+        id: actionlint
+        run: |
+          set -uo pipefail
+
+          # No file list: actionlint discovers .github/workflows/ itself, so a workflow added
+          # tomorrow is gated the day it lands. It reads only the workflow files, so it cannot
+          # report a finding an unrelated author is unable to clear -- which is why this runs on
+          # every PR rather than behind a paths: filter.
+          set +e
+          actionlint -no-color > actionlint.log 2>&1
+          rc=$?
+          set -e
+          cat actionlint.log
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::actionlint reported findings in .github/workflows. Details in the job log and the run summary."
+          fi
+          exit "$rc"
+
+      - name: Record the actionlint result in the run summary
+        if: always()
+        env:
+          RC: ${{ steps.actionlint.outputs.rc }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## actionlint"
+            echo
+            if [ ! -s actionlint.log ] && [ "${RC:-}" != "0" ]; then
+              echo "No output -- an earlier step failed before actionlint ran."
+            elif [ "${RC:-}" = "0" ]; then
+              echo "Clean at actionlint 1.7.12."
+            else
+              echo "Findings below. Reproduce locally with:"
+              echo
+              echo '````bash'
+              echo "actionlint          # needs shellcheck on PATH, or it checks no shell at all"
+              echo '````'
+              echo
+              # Four backticks: the log embeds source lines from the PR, which are
+              # author-controlled, and this summary is a GFM rendering surface. Same reasoning as
+              # the shellcheck job above.
+              echo '````text'
+              cat actionlint.log
               echo '````'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -93,7 +93,13 @@ jobs:
           if [[ -z "$REQUESTED" || "$REQUESTED" == "all" ]]; then
             spaces=$(python3 pdf/build.py --list-spaces)
           else
-            spaces=$(python3 pdf/build.py --list-spaces $REQUESTED)
+            # build.py takes the spaces as separate positional arguments
+            # (nargs="*"), so REQUESTED -- a space-separated input -- has to
+            # split. Quoting it would pass "server maxscale" as ONE space name
+            # and fail every multi-space run; splitting it explicitly says so,
+            # and unlike the bare $REQUESTED it cannot glob (DOCS-6587).
+            read -r -a requested_spaces <<< "$REQUESTED"
+            spaces=$(python3 pdf/build.py --list-spaces "${requested_spaces[@]}")
           fi
           echo "spaces=$spaces" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -26,6 +26,11 @@ jobs:
       # targets and appear on 58 pages.
       - name: Ban GitBook change-request preview URLs
         run: |
+          # The tilde is a literal character in a GitBook URL path, matched by
+          # this grep -- not a home directory the shell is asked to expand. So
+          # $HOME is not the fix here; shellcheck cannot tell a pattern from a
+          # path (DOCS-6587).
+          # shellcheck disable=SC2088
           if git grep -n -e '~/changes/' -- '*.md' '*.html' ':!agent-skills/topical/'; then
             echo "::error::A GitBook change-request preview URL is committed (listed above). It points at an unmerged change request, not published content. Replace it with a link to the published page, or unlink the text."
             exit 1
@@ -287,6 +292,6 @@ jobs:
       - name: 📖 Help & Documentation
         if: failure()
         run: |
-          echo "### ❌ Link Check Failed?" >> $GITHUB_STEP_SUMMARY
-          echo "👉 [**Read the SOP: How to Fix Link Errors**](https://mariadbcorp.atlassian.net/wiki/spaces/DOCS/pages/3284140040/Pull+Requests#Method-1%3A-The-%22Quick-Fix%22-(Recommended))" >> $GITHUB_STEP_SUMMARY
+          echo "### ❌ Link Check Failed?" >> "$GITHUB_STEP_SUMMARY"
+          echo "👉 [**Read the SOP: How to Fix Link Errors**](https://mariadbcorp.atlassian.net/wiki/spaces/DOCS/pages/3284140040/Pull+Requests#Method-1%3A-The-%22Quick-Fix%22-(Recommended))" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
Closes DOCS-6587. Also folds in a `fragcheck.py` fix found while closing DOCS-6590 (Stefan's call).

The `run:` blocks inside the twelve workflow files were the one part of the toolchain nothing linted — twelve workflows against the four standalone scripts DOCS-6471 put under shellcheck, so **most of this repo's shell was in the unchecked half.**

## The gate

New `actionlint` job in `doc-lint-test.yml`, pinned to **1.7.12** by sha256 cross-checked against the publisher's own `actionlint_1.7.12_checksums.txt`, with a pinned shellcheck beside it. Discovery rather than an allowlist, so a workflow added tomorrow is gated the day it lands; on every PR, since it reads only the workflow files and so cannot hand an unrelated author a finding they are unable to clear.

**What it buys beyond shellcheck:** DOCS-6401's third defect was `github.event.pull_request.head.ref` — attacker-controlled on a public repo — interpolated into a `run:` block while the job held `contents: write`. It was found by hand. Verified on a fixture that actionlint still names it by rule.

### The self-test, and why it isn't decoration

The ticket flagged that actionlint needs shellcheck on PATH or it skips `run:` blocks. **Measured, and it is worse than "skips":** with shellcheck off PATH, actionlint **exits 0** on a workflow whose `run:` block has a plain `SC2086` — no warning, no mention of shellcheck, just success. `command -v shellcheck` would not catch every way that happens (a version actionlint cannot drive, say), so the step asserts the *behaviour*: a fixture with a known SC2086 must be reported, or the job fails.

**And writing that step produced its own lesson.** The first draft was `actionlint … | tee log | grep -q SC2086` and it **failed with shellcheck plainly installed**: `grep -q` exits on the first match and closes the pipe, `tee` dies of SIGPIPE, and `pipefail` turns the pipeline non-zero — so the *success* path reported failure. It now redirects and greps the file, with the reason in a comment. Caught only by running the rendered step, not by reading it.

## The six findings — five nits and one that was not

| File | Finding | Action |
| --- | --- | --- |
| `codespell.yml:62` ×2, `link-check-pr.yml:289` ×2 | SC2086, unquoted `$GITHUB_STEP_SUMMARY` | Quoted. Genuinely trivial. |
| `generate-pdfs.yml:82` | SC2086, unquoted `$REQUESTED` | **Not a quoting fix — see below.** |
| `link-check-pr.yml:28` | SC2088, tilde in quotes | Annotated `# shellcheck disable=SC2088` with the reason. |

**`generate-pdfs.yml` is the one worth a look.** The ticket calls all five SC2086s "trivial and worth fixing: quote the variable". Quoting this one would have **broken every multi-space PDF run.** `pdf/build.py` takes the spaces as separate positional arguments (`ap.add_argument("spaces", nargs="*")`), so `REQUESTED` — a space-separated `workflow_dispatch` input — has to split; quoted, `"server maxscale"` arrives as one space name and `--list-spaces` fails it with *not a documentation space*.

Now `read -r -a requested_spaces <<< "$REQUESTED"` then `"${requested_spaces[@]}"`, which says the splitting is deliberate and, unlike the bare `$REQUESTED`, cannot glob. Verified identical argv for `"server maxscale"`, `"server"`, and a run of extra spaces — and `REQUESTED="*"` now reaches `build.py` as a literal `*` instead of expanding to whatever files sit in the working directory. The empty case differs (`argc=1` with an empty string vs `argc=0`) but is unreachable: the `[[ -z "$REQUESTED" ]]` branch takes it.

**SC2088** is a false positive as the ticket says, though for a slightly different reason than its wording suggests: the tilde is a literal character in a GitBook URL path that this `git grep` matches, not a home directory the shell is asked to expand. `$HOME` is not the fix, and shellcheck cannot tell a pattern from a path.

## Folded in: fragcheck's unexpiring cache (from DOCS-6590)

`fragcheck.py validate` cached fetched HTML with **no expiry**, so a run from before a deploy poisoned every run after it: on DOCS-6590 it reported `computed 'next-steps' is not among the live ids` while `curl -sL` on the same URL plainly returned `id="next-steps"`. Deleting one cached file gave 7/7. A checker confidently calling a live anchor dead is the worst failure mode an oracle has.

Now a **300-second mtime TTL**, with `FRAGCHECK_CACHE_TTL=0` to bypass. Only `validate` calls `fetch()`, so **this cannot slow the `new` CI gate**. Verified both directions: a poisoned cache with a fresh mtime is still honoured (1/7, so the cache still works), the same file aged an hour is refetched (7/7).

## Verification

- **Gate red:** un-quoting one `$GITHUB_STEP_SUMMARY` in `codespell.yml` → actionlint reports it and exits non-zero. Restored → exit 0.
- **Self-test red:** hiding shellcheck from PATH → the step fails with its own error. With shellcheck → passes.
- **Untrusted-input rule armed:** fixture with `${{ github.event.pull_request.head.ref }}` in a `run:` → reported by name.
- **An honest incident:** my own new `::error::` message contained backticks, which shellcheck read as legacy command substitution (`SC2006`) — the new gate caught it on its first run. Reworded.
- `actionlint` clean on `main` + this branch; `shellcheck` clean; `doc-lint-test.sh` **33/33**; `fragcheck new` clean.