### PR TITLE
DOCS-6586: gate GitBook includes in CI (includecheck-pr.yml)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -7,7 +7,8 @@ Code. It contains:
 |------|------------|
 | `settings.json` | Project settings, incl. the `PreToolUse(Bash)` hook wiring |
 | `settings.local.json` | **Personal** overrides — gitignored, never committed |
-| `hooks/doc-lint.sh` | Canonical codespell + lychee linter (single source of truth, mirrors CI), plus four checks with no CI counterpart: includes, heading anchors, orphaned pages, gutted pages |
+| `hooks/doc-lint.sh` | Canonical codespell + lychee linter (single source of truth, mirrors CI), plus four checks it delegates to their own scripts: includes (`includecheck.sh`), heading anchors (`fragcheck.py`), orphaned pages and gutted pages (`navcheck.py` and an inline guard) |
+| `hooks/includecheck.sh` | Resolves every relative GitBook `{% include %}`; fails on a dead or cross-space target. Also the entry point for `includecheck-pr.yml` (DOCS-6586), which runs it tree-wide |
 | `hooks/fragcheck.py` | GitBook-accurate heading-anchor checker, called by `doc-lint.sh` |
 | `hooks/navcheck.py` | Orphaned-page (nav coverage) checker, called by `doc-lint.sh` |
 | `hooks/pre-commit.sh` | PreToolUse hook: gates Claude-made `git commit`s by calling `doc-lint.sh` |
@@ -114,7 +115,11 @@ that could have noticed was a Linux one, and nothing on Linux ever ran the scrip
 `hooks/doc-lint-test.sh` is the gate for that class. It builds fixtures in a throwaway git repo
 under `TMPDIR` — it never reads this checkout's content — and asserts exit codes and messages for
 the include resolver, the gutted-page guard, the env-var knobs, the repo-root guard, and every
-"tool not installed" SKIP branch. Run it after any change to `doc-lint.sh`:
+"tool not installed" SKIP branch. Since DOCS-6586 it also covers `includecheck.sh` as its own
+entry point — its `--stdin0` mode, its usage errors, and the fact that a missing
+`includecheck.sh` FAILS `doc-lint.sh` rather than SKIPping (every other dependency is an external
+tool a contributor may not have; that one is checked in beside it, so its absence is a broken
+checkout). Run it after any change to `doc-lint.sh` or `includecheck.sh`:
 
 ```bash
 .claude/hooks/doc-lint-test.sh              # --keep to inspect the sandbox, --verbose for output

--- a/.claude/hooks/doc-lint-test.sh
+++ b/.claude/hooks/doc-lint-test.sh
@@ -137,6 +137,10 @@ build_sandbox() {
     > "$SANDBOX/server/remote-include.md"
   # Both directories are exempt from the include resolver: they document the syntax with
   # placeholders that are not meant to resolve.
+  # A path with a space in it, for the --stdin0 case. The whole point of NUL-delimiting is that
+  # this cannot split into two arguments, and a space is the cheapest way to prove it.
+  printf '# Spaced Name\n\n{%% include "../.gitbook/includes/nope.md" %%}\n' \
+    > "$SANDBOX/server/dead include with spaces.md"
   printf '# Docs About Includes\n\n{%% include "nope.md" %%}\n' > "$SANDBOX/dev-docs/exempt.md"
   printf '# Hook Notes\n\n{%% include "nope.md" %%}\n'          > "$SANDBOX/.claude/exempt.md"
 
@@ -232,6 +236,37 @@ lint() {
   fi
 }
 
+# inc <cwd> -- <includecheck args...>
+# The same contract as lint(), against includecheck.sh directly. It exists because the script is
+# now a CI entry point in its own right (includecheck-pr.yml), so its argument handling, its
+# --stdin0 mode and its exit codes are a public surface, not internals reachable only through
+# doc-lint.sh. Reads stdin from $INC_STDIN when that is set, so the --stdin0 branch is testable.
+INCLUDECHECK="$SCRIPT_DIR/includecheck.sh"
+INC_STDIN=''
+inc() {
+  local cwd="$1"; shift
+  [ "$1" = '--' ] && shift
+
+  set +e
+  if [ -n "$INC_STDIN" ]; then
+    ( cd "$SANDBOX/$cwd" && env -i "PATH=$MIN_PATH" "HOME=$SANDBOX" \
+        bash "$INCLUDECHECK" "$@" < "$INC_STDIN" ) > "$OUT" 2> "$ERR"
+  else
+    ( cd "$SANDBOX/$cwd" && env -i "PATH=$MIN_PATH" "HOME=$SANDBOX" \
+        bash "$INCLUDECHECK" "$@" < /dev/null ) > "$OUT" 2> "$ERR"
+  fi
+  RC=$?
+  set -e
+}
+
+# nul_list <path> <name...> — write NUL-delimited names, the way `git ls-files -z` emits them.
+nul_list() {
+  local out="$1"; shift
+  : > "$out"
+  local n
+  for n in "$@"; do printf '%s\0' "$n" >> "$out"; done
+}
+
 begin() { CURRENT="$1"; CASE_OK=1; }
 
 problem() {
@@ -270,6 +305,10 @@ want_err() {
 want_no_err() {
   grep -qF -- "$1" "$ERR" && problem "did NOT expect \"$1\" on stderr"
   return 0
+}
+
+want_out() {
+  grep -qF -- "$1" "$OUT" || problem "expected \"$1\" on stdout"
 }
 
 want_empty_stdout() {
@@ -318,7 +357,9 @@ want_no_err 'unresolvable include'
 want_no_err 'gutted page'
 end
 
-# ---- GitBook include resolver (DOCS-6372; no CI counterpart) ---------------------------------
+# ---- GitBook include resolver (DOCS-6372; gated in CI by includecheck-pr.yml, DOCS-6586) -----
+# These first cases go through doc-lint.sh, which is how the pre-commit hook reaches the
+# resolver. The block below them drives includecheck.sh directly, which is how CI does.
 
 begin 'a resolvable same-space include passes'
 lint . - "$NOFRAG" -- server/ok-include.md
@@ -355,6 +396,78 @@ lint . - "$NOFRAG" -- server/dead-include.md server/cross-space.md
 want_rc 1
 want_err 'unresolvable include'
 want_err 'cross-space include'
+end
+
+# ---- includecheck.sh as its own entry point (DOCS-6586) --------------------------------------
+# The resolver moved out of doc-lint.sh so that CI could run it WITHOUT the checks either side
+# of it. That makes the script's own CLI a contract: includecheck-pr.yml depends on --stdin0
+# reading the tree from `git ls-files -z`, and on exit 2 meaning "misconfigured workflow" rather
+# than "the PR is fine".
+
+begin 'includecheck.sh with no arguments is a usage error, not a silent pass'
+inc . --
+want_rc 2
+want_err 'usage:'
+end
+
+begin 'a dead include found through --stdin0'
+nul_list "$SANDBOX/.list" 'server/dead-include.md'
+INC_STDIN="$SANDBOX/.list" inc . -- --stdin0
+INC_STDIN=''
+want_rc 1
+want_err 'unresolvable include'
+end
+
+begin '--stdin0 does not split a path containing a space'
+nul_list "$SANDBOX/.list" 'server/dead include with spaces.md'
+INC_STDIN="$SANDBOX/.list" inc . -- --stdin0
+INC_STDIN=''
+want_rc 1
+# The whole name, in one piece. Split on the space, each half would be a nonexistent path,
+# get filtered out, and the run would pass green with nothing checked.
+want_err 'server/dead include with spaces.md'
+end
+
+begin '--stdin0 on clean input reports the counts on stdout'
+nul_list "$SANDBOX/.list" 'server/ok-include.md' 'server/clean.md'
+INC_STDIN="$SANDBOX/.list" inc . -- --stdin0
+INC_STDIN=''
+want_rc 0
+# A gate has to be able to prove it did something: "1 include across 2 files" and "0 includes
+# across 0 files" are the same exit code and must not be the same output.
+want_out '1 relative include(s) across 2 file(s)'
+end
+
+begin '--stdin0 on empty input says so rather than claiming a clean tree'
+nul_list "$SANDBOX/.list"
+INC_STDIN="$SANDBOX/.list" inc . -- --stdin0
+INC_STDIN=''
+want_rc 0
+want_out 'no Markdown or HTML files'
+end
+
+begin '--stdin0 rejects extra arguments'
+inc . -- --stdin0 server/clean.md
+want_rc 2
+want_err 'usage:'
+end
+
+begin 'a missing includecheck.sh fails doc-lint.sh — it is not a SKIP'
+# Every other dependency doc-lint.sh delegates to is an external TOOL a contributor may
+# legitimately not have, so those are SKIPs. This one is checked in beside it, so its absence
+# is a broken checkout, and a check that cannot run must not report success. Exercised by
+# copying doc-lint.sh somewhere with no sibling next to it.
+mkdir -p "$SANDBOX/lonely"
+cp "$DOC_LINT" "$SANDBOX/lonely/doc-lint.sh"
+set +e
+( cd "$SANDBOX" && env -i "PATH=$MIN_PATH" "HOME=$SANDBOX" "TMPDIR=${TMPDIR:-/tmp}" \
+    DOC_LINT_SKIP_FRAGMENTS=1 \
+    bash "$SANDBOX/lonely/doc-lint.sh" server/clean.md ) > "$OUT" 2> "$ERR"
+RC=$?
+set -e
+want_rc 1
+want_err 'cannot resolve GitBook includes'
+want_err 'broken checkout'
 end
 
 # ---- net line-loss guard (DOCS-6470 / DOCS-6442; no CI counterpart) --------------------------

--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 #
 # doc-lint.sh — the SINGLE SOURCE OF TRUTH for the codespell + lychee invocations that mirror
-# CI (.github/workflows/codespell.yml and link-check-pr.yml), plus four checks that have no CI
-# counterpart (see below): a GitBook include resolver, a heading-anchor gate, an orphaned-page
-# (nav coverage) gate, and a net line-loss guard.
+# CI (.github/workflows/codespell.yml and link-check-pr.yml), plus four checks it delegates to
+# their own scripts: a GitBook include resolver (includecheck.sh, gated in CI by
+# includecheck-pr.yml since DOCS-6586), a heading-anchor gate (fragcheck.py, gated by
+# fragcheck-pr.yml), an orphaned-page/nav-coverage gate and a net line-loss guard — the last
+# two still have NO CI counterpart, which is the rest of DOCS-6586.
 #
 # The pre-commit hook, the /precommit command, the docs-check skill, and dev-docs/cookbook-pre-pr.md
 # all delegate here instead of re-spelling the flags, so the CI-mirroring options live in exactly
@@ -154,97 +156,39 @@ else
   echo "doc-lint: lychee not installed — SKIPPED (CI will run it). Install: https://github.com/lycheeverse/lychee" >&2
 fi
 
-# --- GitBook include resolver — NO CI counterpart -------------------------------------------
-# `{% include "../.gitbook/includes/foo.md" %}` is GitBook template syntax, not a Markdown link,
-# so lychee cannot see it: a dead include renders as *nothing* and the page silently loses a
-# section. DOCS-6372 found two live cases that way (a 13.1 post-download page missing its
-# "most recent release" bullet, and a MaxScale CVE page missing its copyright footnote).
+# --- GitBook include resolver — HAS a CI counterpart since DOCS-6586 ------------------------
+# The resolver itself now lives in .claude/hooks/includecheck.sh, which is also what
+# .github/workflows/includecheck-pr.yml runs; that header carries the full rationale. It was
+# extracted rather than duplicated because routing the workflow through THIS script would have
+# dragged in the checks either side of it — codespell and lychee, which have their own
+# workflows, and the orphan guard, which is still waiting on DOCS-6586's acknowledgment-path
+# decision and has no skip flag to hold it back with.
 #
-# Two failure modes are checked:
-#   1. target does not exist;
-#   2. target exists but lies in a different space. Each top-level directory is a separate
-#      GitBook space with its own Git-sync root, so a relative include may not cross that
-#      boundary even though the path resolves fine on disk. Cross-space reuse must instead use
-#      the by-ID form, `{% include "https://app.gitbook.com/s/<space>/~/reusable/<id>/" %}`.
-#
-# Needs no external tool, so unlike the two checks above it can never be silently SKIPPED.
-# `.claude/` and `dev-docs/` are exempt: they document the syntax with deliberate placeholders
-# (`<snippet>.md`, `rc12345`) that are not meant to resolve.
-
-# Normalize a path's `.` and `..` segments textually — the target need not exist, which rules
-# out `realpath` (BSD realpath has no portable `-m`). A `..` that climbs above the repo root is
-# left in place, so the path simply fails the existence test below.
-#
-# Every array expansion below is guarded by a length test on purpose. Expanding "${arr[@]}" or
-# "${arr[*]}" on an EMPTY array is an "unbound variable" error under `set -u` before bash 4.4 —
-# i.e. on the bash 3.2 that stock macOS still ships, which is the portability floor this script
-# claims in its header. Unguarded, norm_path returned the EMPTY STRING for any include that
-# climbs out of its own directory ("server/../maxscale/x.md"): the `..` emptied the array, the
-# recompaction died, and every such include was then misreported as *unresolvable* while the
-# cross-space branch below became unreachable. The mirror image of DOCS-6409, which only bit on
-# Linux — same class, opposite platform. Found by doc-lint-test.sh (DOCS-6471).
-norm_path() {
-  local seg out=() n
-  local IFS='/'
-  for seg in $1; do
-    case "$seg" in
-      ''|.) ;;
-      ..) n=${#out[@]}
-          if [ "$n" -gt 0 ] && [ "${out[$((n-1))]}" != ".." ]; then
-            unset "out[$((n-1))]"                      # bash 3.2 leaves a hole
-            if [ "${#out[@]}" -gt 0 ]; then
-              out=("${out[@]}")                        # compact it, but only if anything is left
-            fi
-          else
-            out+=("..")
-          fi ;;
-      *) out+=("$seg") ;;
-    esac
-  done
-  if [ "${#out[@]}" -eq 0 ]; then
-    return 0                                           # nothing left: the empty path
-  fi
-  printf '%s' "${out[*]}"
-}
-
-# Space = first path component (`server/...` -> `server`); a file at the repo root has none.
-space_of() {
-  case "$1" in
-    */*) printf '%s' "${1%%/*}" ;;
-    *)   printf '%s' '<root>' ;;
-  esac
-}
-
-# `grep | while` puts the loop body in a subshell, so it cannot set `rc` directly — failures are
-# tallied in a temp file instead.
-# Use a positional template, not `-t <prefix>`: GNU coreutils rejects a `-t` template with no
-# X's ("too few X's in template"), which made this exit 2 on every Linux run — and since it sits
-# before the checks below, it took the include resolver and the shrink guard down with it. The
-# positional form works on both GNU and BSD/macOS mktemp. (Regression from DOCS-6372, f2b5e332c.)
-inc_fail="$(mktemp "${TMPDIR:-/tmp}/doclint-inc.XXXXXX")" || { echo "doc-lint: mktemp failed" >&2; exit 2; }
-trap 'rm -f "$inc_fail"' EXIT
-
-for f in "${files[@]}"; do
-  f="${f#./}"
-  case "$f" in .claude/*|dev-docs/*) continue ;; esac
-  grep -n -o '{%[[:space:]]*include[[:space:]]*"[^"]*"' "$f" 2>/dev/null | while IFS= read -r hit; do
-    lineno="${hit%%:*}"
-    target="${hit#*\"}"; target="${target%\"}"   # strip both quotes, not just the opening one
-    case "$target" in http*) continue ;; esac
-    dir="${f%/*}"; [ "$dir" = "$f" ] && dir='.'
-    resolved="$(norm_path "$dir/$target")"
-    if [ ! -f "$resolved" ]; then
-      echo "doc-lint: unresolvable include at $f:$lineno -> $target (no such file: $resolved)" >&2
-      echo x >>"$inc_fail"
-    elif [ "$(space_of "$resolved")" != "$(space_of "$f")" ]; then
-      echo "doc-lint: cross-space include at $f:$lineno -> $target" >&2
-      echo "          resolves into space '$(space_of "$resolved")' but the page is in '$(space_of "$f")';" >&2
-      echo "          use the by-ID form instead: {% include \"https://app.gitbook.com/s/<space>/~/reusable/<id>/\" %}" >&2
-      echo x >>"$inc_fail"
-    fi
-  done
-done
-[ -s "$inc_fail" ] && rc=1
+# Needs no external tool, so unlike every other check here it can never be SKIPPED. The one
+# difference between the two callers is scope, and it is deliberate: this passes the caller's
+# files (a pre-commit hook has no business scanning 9,700 pages), while CI runs the whole tree,
+# because deleting one shared target breaks every page that includes it and a changed-files
+# check cannot see those pages. Measured: removing platform/.gitbook/includes/most-recent-10.11.md
+# breaks 20 post-download pages the commit never touches.
+# Resolved relative to THIS script, not the working directory. The two are the same in every
+# real invocation (both CI and the hooks run from the repo root), but they are not the same in
+# doc-lint-test.sh, which runs this script from the repo while CWD is a throwaway sandbox. A
+# CWD-relative path would have made the resolver unreachable there — i.e. the six include cases
+# would have gone on passing while testing the "script missing" branch instead of the resolver.
+# The other two delegated scripts are deliberately left CWD-relative: the suite depends on their
+# being absent to exercise their SKIP branches.
+INCLUDECHECK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/includecheck.sh"
+if [ ! -f "$INCLUDECHECK" ]; then
+  # NOT a SKIP. Every other missing dependency here is a missing external TOOL, which a
+  # contributor may legitimately not have; this script is checked in next to this one, so its
+  # absence means a broken checkout, and a check that cannot run must not report success.
+  echo "doc-lint: $INCLUDECHECK not found — cannot resolve GitBook includes." >&2
+  echo "          It is checked in beside this script, so this is a broken checkout, not a" >&2
+  echo "          missing tool. Nothing else can catch a dead include." >&2
+  rc=1
+else
+  bash "$INCLUDECHECK" "${files[@]}" >/dev/null || rc=1
+fi
 
 # --- GitBook heading anchors — NO CI counterpart --------------------------------------------
 # A link to `page.md#some-heading` can rot in two ways that every other gate here is blind

--- a/.claude/hooks/includecheck.sh
+++ b/.claude/hooks/includecheck.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# includecheck.sh — resolve every relative GitBook `{% include %}` and fail on a dead or
+# cross-space target. Extracted from .claude/hooks/doc-lint.sh (DOCS-6586) so that CI can run
+# THIS check without running the ones next to it; doc-lint.sh now delegates here, so the
+# resolver still lives in exactly one place.
+#
+# `{% include "../.gitbook/includes/foo.md" %}` is GitBook template syntax, not a Markdown link,
+# so lychee cannot see it: a dead include renders as *nothing* and the page silently loses a
+# section. DOCS-6372 found two live cases that way (a 13.1 post-download page missing its
+# "most recent release" bullet, and a MaxScale CVE page missing its copyright footnote).
+#
+# Two failure modes are checked:
+#   1. target does not exist;
+#   2. target exists but lies in a different space. Each top-level directory is a separate
+#      GitBook space with its own Git-sync root, so a relative include may not cross that
+#      boundary even though the path resolves fine on disk. Cross-space reuse must instead use
+#      the by-ID form, `{% include "https://app.gitbook.com/s/<space>/~/reusable/<id>/" %}`.
+#
+# Needs no external tool — no python3, no network, no git — so unlike codespell, lychee,
+# fragcheck and navcheck it can never be SKIPPED, in CI or locally. That is why it is the half
+# of DOCS-6586 that could ship on its own: it also has no legitimate exceptions (a dead include
+# is always a bug), so it needs no acknowledgment path, which is the open design question
+# holding up the orphan and shrink guards.
+#
+# `.claude/` and `dev-docs/` are exempt: they document the syntax with deliberate placeholders
+# (`<snippet>.md`, `rc12345`) that are not meant to resolve.
+#
+# Usage:   .claude/hooks/includecheck.sh <file> [<file> ...]
+#          .claude/hooks/includecheck.sh --stdin0     # NUL-delimited paths on stdin
+#          Paths are repo-root-relative and the check must be run FROM the repo root — the
+#          space-boundary test reads the first path component as the space name.
+#
+#          Use --stdin0 for a whole-tree run: `git ls-files -z -- '*.md' '*.html'` is ~9,700
+#          paths, which is over ARG_MAX once xargs gets it, and xargs then splits the run into
+#          several invocations. That is not just cosmetic — each invocation prints its own
+#          summary line and returns its own status, so the counts stop being the tree's counts
+#          and a caller reading `$?` off a pipeline sees only the LAST batch. One invocation,
+#          one verdict.
+# Exit:    0 = every relative include resolves inside its own space
+#          1 = at least one dead or cross-space include
+#          2 = usage error (no arguments)
+# Output:  findings on stderr; a single "all resolve" line on stdout, so a caller can tell
+#          "nothing to check" apart from "checked and clean". Mirrors navcheck.py.
+#
+# Portability: no `mapfile` — takes files as args — so it runs under bash 3.2 (macOS) too.
+
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <file> [<file> ...]" >&2
+  exit 2
+fi
+
+# Collect the candidate paths, from stdin or from the argument list. No `mapfile` in the stdin
+# branch — bash 3.2 does not have it.
+raw=()
+if [ "$1" = '--stdin0' ]; then
+  if [ "$#" -ne 1 ]; then
+    echo "usage: $0 --stdin0   (reads NUL-delimited paths on stdin; takes no other arguments)" >&2
+    exit 2
+  fi
+  while IFS= read -r -d '' p; do
+    raw+=("$p")
+  done
+else
+  raw=("$@")
+fi
+
+# Keep only existing Markdown/HTML paths. A path that was deleted by the commit under test is
+# dropped here rather than reported: its includes went with it.
+files=()
+if [ "${#raw[@]}" -gt 0 ]; then
+  for f in "${raw[@]}"; do
+    case "$f" in
+      *.md|*.html) [ -f "$f" ] && files+=("$f") ;;
+    esac
+  done
+fi
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "includecheck: no Markdown or HTML files to check."
+  exit 0
+fi
+
+# Normalize a path's `.` and `..` segments textually — the target need not exist, which rules
+# out `realpath` (BSD realpath has no portable `-m`). A `..` that climbs above the repo root is
+# left in place, so the path simply fails the existence test below.
+#
+# Every array expansion below is guarded by a length test on purpose. Expanding "${arr[@]}" or
+# "${arr[*]}" on an EMPTY array is an "unbound variable" error under `set -u` before bash 4.4 —
+# i.e. on the bash 3.2 that stock macOS still ships, which is the portability floor this script
+# claims in its header. Unguarded, norm_path returned the EMPTY STRING for any include that
+# climbs out of its own directory ("server/../maxscale/x.md"): the `..` emptied the array, the
+# recompaction died, and every such include was then misreported as *unresolvable* while the
+# cross-space branch below became unreachable. The mirror image of DOCS-6409, which only bit on
+# Linux — same class, opposite platform. Found by doc-lint-test.sh (DOCS-6471).
+norm_path() {
+  local seg out=() n
+  local IFS='/'
+  for seg in $1; do
+    case "$seg" in
+      ''|.) ;;
+      ..) n=${#out[@]}
+          if [ "$n" -gt 0 ] && [ "${out[$((n-1))]}" != ".." ]; then
+            unset "out[$((n-1))]"                      # bash 3.2 leaves a hole
+            if [ "${#out[@]}" -gt 0 ]; then
+              out=("${out[@]}")                        # compact it, but only if anything is left
+            fi
+          else
+            out+=("..")
+          fi ;;
+      *) out+=("$seg") ;;
+    esac
+  done
+  if [ "${#out[@]}" -eq 0 ]; then
+    return 0                                           # nothing left: the empty path
+  fi
+  printf '%s' "${out[*]}"
+}
+
+# Space = first path component (`server/...` -> `server`); a file at the repo root has none.
+space_of() {
+  case "$1" in
+    */*) printf '%s' "${1%%/*}" ;;
+    *)   printf '%s' '<root>' ;;
+  esac
+}
+
+# Read the grep output through a process substitution rather than a pipe, so the loop body runs
+# in THIS shell and can tally straight into a variable. The pipe form could not — it put the
+# body in a subshell — and needed a `mktemp` scratch file to carry the count back out, which is
+# where DOCS-6372's f2b5e332c regression lived: a `-t` template with no X's is rejected by GNU
+# coreutils but accepted by BSD, so every Linux run exited 2 before reaching this check at all.
+# No temp file, no platform-specific mktemp contract.
+findings=0
+checked=0
+
+for f in "${files[@]}"; do
+  f="${f#./}"
+  case "$f" in .claude/*|dev-docs/*) continue ;; esac
+  while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    lineno="${hit%%:*}"
+    target="${hit#*\"}"; target="${target%\"}"   # strip both quotes, not just the opening one
+    case "$target" in http*) continue ;; esac
+    checked=$((checked + 1))
+    dir="${f%/*}"; [ "$dir" = "$f" ] && dir='.'
+    resolved="$(norm_path "$dir/$target")"
+    if [ ! -f "$resolved" ]; then
+      echo "doc-lint: unresolvable include at $f:$lineno -> $target (no such file: $resolved)" >&2
+      findings=$((findings + 1))
+    elif [ "$(space_of "$resolved")" != "$(space_of "$f")" ]; then
+      echo "doc-lint: cross-space include at $f:$lineno -> $target" >&2
+      echo "          resolves into space '$(space_of "$resolved")' but the page is in '$(space_of "$f")';" >&2
+      echo "          use the by-ID form instead: {% include \"https://app.gitbook.com/s/<space>/~/reusable/<id>/\" %}" >&2
+      findings=$((findings + 1))
+    fi
+  done < <(grep -n -o '{%[[:space:]]*include[[:space:]]*"[^"]*"' "$f" 2>/dev/null)
+done
+
+if [ "$findings" -gt 0 ]; then
+  exit 1
+fi
+
+# On stdout, and it names the counts. A gate needs to be able to prove it did something: an
+# invocation whose file list turned out to hold no includes at all is indistinguishable from a
+# clean one by exit code alone.
+echo "includecheck: ${checked} relative include(s) across ${#files[@]} file(s), all resolve."

--- a/.claude/skills/docs-check/SKILL.md
+++ b/.claude/skills/docs-check/SKILL.md
@@ -57,13 +57,20 @@ on the file set, from the repo root:
   expand them.
 - It also resolves every relative `{% include %}` and fails on a **missing target** or one that
   **crosses a space boundary** (each top-level directory is a separate GitBook space, so a
-  relative include may not leave it — cross-space reuse must use the by-ID form). This check has
-  **no CI counterpart** and needs no external tool, so it never reports SKIPPED. It matters
+  relative include may not leave it — cross-space reuse must use the by-ID form). It needs no
+  external tool, so it never reports SKIPPED. It matters
   because a dead include renders as *nothing* — the page silently loses a section, and lychee
   cannot see `{% include %}` at all since it is template syntax, not a Markdown link. To fix,
   correct the `../` depth, or switch to
   `{% include "https://app.gitbook.com/s/<spaceId>/~/reusable/<reusableId>/" %}` when the snippet
-  genuinely lives in another space. Added in DOCS-6372.
+  genuinely lives in another space. Added in DOCS-6372; gated in CI by `includecheck-pr.yml`
+  since DOCS-6586, which is also when the resolver moved into its own
+  `.claude/hooks/includecheck.sh`. **CI scans the whole tree while this runs on the changed
+  files**, because deleting one shared `<space>/.gitbook/includes/` target breaks every page that
+  includes it and none of those pages are in the diff — so expect CI to be able to fail on a page
+  the author never opened, and reproduce it with
+  `git ls-files -z -- '*.md' '*.html' | .claude/hooks/includecheck.sh --stdin0`. There is no
+  acknowledgment path and should not be one: a dead include is always a bug.
 - It also gates **GitBook heading anchors** — a link to `page.md#some-heading` whose anchor no
   longer exists. No CI counterpart, and unlike every other check here it is *history-aware*: it
   reports only anchors that resolved at `DOC_LINT_BASE` (default `HEAD`) and are dead now, so the

--- a/.github/workflows/includecheck-pr.yml
+++ b/.github/workflows/includecheck-pr.yml
@@ -1,0 +1,184 @@
+name: Check GitBook Includes in PR
+
+# Gates dead and cross-space GitBook `{% include %}` targets. Part of DOCS-6586, which is
+# DOCS-6471 Part 2: putting the doc-lint checks that have no CI counterpart behind a PR gate.
+#
+# `{% include "../.gitbook/includes/foo.md" %}` is GitBook TEMPLATE syntax, not a Markdown link.
+# lychee cannot see it -- it is not a link -- and codespell has no opinion about it, so a dead
+# include has no failing signal anywhere: GitBook renders it as *nothing*, the page silently
+# loses a section, and the markup around it stays perfectly valid. DOCS-6372 found two live
+# cases exactly that way, both by eye: a 13.1 post-download page missing its "most recent
+# release" bullet, and a MaxScale CVE page missing its copyright footnote.
+#
+# Until now the only entry points were local -- the /precommit command, the docs-check skill,
+# and the Claude Code PreToolUse(Bash) hook, whose own header records the limit: it "only gates
+# commits that Claude Code makes via the Bash tool. Human git commit, IDE commits, and
+# GitBook-UI edits bypass it entirely."
+#
+# WHY THIS RUNS THE SCRIPT DIRECTLY AND NOT doc-lint.sh
+#   doc-lint.sh is the single source of truth for the codespell and lychee FLAG sets, so CI
+#   mirrors those by calling it. It cannot be the entry point here, for two reasons: it would
+#   re-run codespell and lychee, which already have their own workflows, and it would run the
+#   orphaned-page guard, which is the other half of DOCS-6586 and is still waiting on that
+#   ticket's acknowledgment-path decision (DOC_LINT_ALLOW_ORPHAN is an environment variable, and
+#   no PR author can set one from a branch). There is no skip flag to hold it back with.
+#
+#   So the resolver was EXTRACTED into .claude/hooks/includecheck.sh rather than duplicated
+#   here, and doc-lint.sh now delegates to the same script. One implementation, two callers.
+#
+# WHY THE WHOLE TREE, AND WHY NO BASELINE
+#   Every other history-aware check in doc-lint.sh diffs against a base revision, because the
+#   repo carries a large backlog of the thing being checked -- ~1,272 dead heading anchors, 219
+#   orphaned pages -- and an absolute check would fail every unrelated PR on breakage it did not
+#   introduce. This check needs none of that: swept at 8e21bff62, main has ZERO dead or
+#   cross-space includes across 4,287 relative includes in 9,696 files. With no backlog there is
+#   nothing to grandfather, so the check is absolute, and that makes this workflow markedly
+#   simpler than fragcheck-pr.yml -- no fetch-depth: 0, no throwaway worktree, no base-revision
+#   assertion step, and no way for a missing baseline to turn the gate silently green.
+#
+#   Tree-wide rather than changed-files scoped, and this is the substantive design point.
+#   Deleting or renaming ONE shared include target breaks every page that includes it, and those
+#   pages are not in the PR's diff. Measured on main: removing
+#   platform/.gitbook/includes/most-recent-10.11.md breaks 20 post-download pages that such a
+#   commit never touches, and a changed-files gate reports exactly nothing. Shared targets under
+#   .gitbook/includes/ are the norm here, not an edge case, so the changed-files scoping that is
+#   right for codespell (a typo is local to its own page) is wrong for this check.
+#
+# WHY THERE IS NO ACKNOWLEDGMENT PATH
+#   Unlike the shrink and orphan guards, this check has no legitimate exceptions. A large page
+#   shrink can be correct and a deliberately unlisted page can be correct, so both of those need
+#   a way for an author to say "yes, on purpose". A dead include is always a bug, and a
+#   cross-space one always has the by-ID form as its answer. Nothing to acknowledge, so no
+#   escape hatch to add, and none to be quietly overused later. That is why this half of
+#   DOCS-6586 could ship while the rest waits.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+# A second push supersedes the first.
+concurrency:
+  group: includecheck-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  includecheck:
+    runs-on: ubuntu-latest
+    # A tree-wide pass measured ~28s locally. 10 minutes is generous headroom; without it the
+    # job inherits the 6-hour default, and a wedged run would end as *cancelled*, which
+    # `if: failure()` does not catch.
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        # No fetch-depth here on purpose. The check is absolute, so it needs the working tree
+        # and no history at all -- the default shallow clone is both sufficient and faster.
+        # Contrast fragcheck-pr.yml, which requires fetch-depth: 0 because it checks the PR base
+        # out into a worktree, and would SKIP-and-pass without it.
+
+      # Deliberately NOT gated on a changed-files filter, unlike codespell.yml and
+      # link-check-pr.yml. Those scope to the PR's own files because their findings are local to
+      # a page; this check is tree-wide by design (see the header), so a filter could only
+      # decide WHETHER to run -- and every filter is a chance to be wrong about what can break
+      # an include. A deleted target, a renamed space directory, a moved .gitbook/includes/
+      # folder, or an edit to the resolver itself all break includes in pages the PR never
+      # names. One ~30s job on every PR is a better trade than a filter that has to be right
+      # about all of those.
+      - name: Resolve every GitBook include in the tree
+        id: includecheck
+        run: |
+          set -uo pipefail
+          # NUL-delimited through --stdin0, not xargs. `git ls-files` is ~9,700 paths, which is
+          # over ARG_MAX once xargs has it: xargs would then split the run into several
+          # invocations, each printing its own summary and returning its own status, and `$?`
+          # off the pipeline would report only the LAST batch. Measured -- the first draft of
+          # this step did exactly that, and it also means a tree with findings in the first
+          # batch only can exit 0. One invocation, one verdict.
+          #
+          # Findings go to stderr, the clean summary to stdout; capture both in order so the
+          # run summary reads the way a local run does.
+          set +e
+          git ls-files -z -- '*.md' '*.html' \
+            | .claude/hooks/includecheck.sh --stdin0 > includecheck.log 2>&1
+          rc=$?
+          set -e
+          cat includecheck.log
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          # rc 2 is a usage error from the script itself, which can only mean this workflow is
+          # calling it wrongly. Distinct message so that is obvious from the annotation alone
+          # and nobody goes looking through the PR's diff for the cause.
+          case "$rc" in
+            0) ;;
+            1) echo "::error::This PR leaves a GitBook include pointing at a file that does not exist, or at a file in another space. A dead include renders as NOTHING -- the page silently loses a section -- and no other check can see it. Details in the job log and the run summary." ;;
+            2) echo "::error::includecheck.sh rejected its arguments -- this workflow is misconfigured, not the PR." ;;
+            *) echo "::error::includecheck.sh exited $rc (crash). This is a tooling failure, not a PR finding." ;;
+          esac
+          exit "$rc"
+
+      # The gate has to be able to prove it looked at something. `git ls-files` returning
+      # nothing, a wrong working directory, or a pathspec typo would all leave the script with
+      # an empty file list -- and its exit code for "checked 9,696 files, all clean" and
+      # "checked nothing at all" is the same 0. The script prints the counts precisely so this
+      # can be asserted rather than assumed; without this step the whole workflow could go
+      # permanently, silently green.
+      - name: Assert the check was not vacuous
+        if: steps.includecheck.outputs.rc == '0'
+        run: |
+          set -euo pipefail
+          if grep -q 'no Markdown or HTML files' includecheck.log; then
+            echo "::error::includecheck reported that it had no files to check, in a repository with ~9,700 tracked Markdown files. The file list is broken, not the tree, and a pass here would mean nothing."
+            exit 1
+          fi
+          # Pull the include count out of "includecheck: N relative include(s) across M file(s)".
+          # A floor of 1 rather than a fixed expected count: the point is that the run examined
+          # real content, and any specific number would rot on the next page that adds or drops
+          # an include.
+          count="$(sed -n 's/^includecheck: \([0-9]\{1,\}\) relative include.*/\1/p' includecheck.log)"
+          if [[ -z "$count" || "$count" -lt 1 ]]; then
+            cat includecheck.log
+            echo "::error::Could not read a nonzero include count out of includecheck's output, so this run examined no includes. Either the summary line changed shape (update this assertion with it) or the file list is empty."
+            exit 1
+          fi
+          echo "Resolved $count relative include(s) -- the check ran against real content."
+
+      - name: Record the result in the run summary
+        # always(): the default is an implicit success(), which would skip exactly the runs
+        # worth recording.
+        if: always()
+        env:
+          RC: ${{ steps.includecheck.outputs.rc }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## GitBook include check"
+            echo
+            if [[ ! -s includecheck.log ]]; then
+              echo "No output was produced -- an earlier step failed before the scan ran."
+            else
+              case "${RC:-}" in
+                0) echo "Every relative GitBook include in the tree resolves, and none crosses a space boundary." ;;
+                1) echo "This PR leaves a broken GitBook include. A dead include renders as nothing, so the page loses a section with no other check able to notice: either restore the target, fix the relative path, or -- if the target really is in another space -- switch to the by-ID form, \`{% include \"https://app.gitbook.com/s/<space>/~/reusable/<id>/\" %}\`." ;;
+                *) echo "The check did not complete (exit ${RC:-unknown}). This is a tooling failure, not a PR finding." ;;
+              esac
+              echo
+              # Fenced, and with four backticks. This summary is a GFM rendering surface and the
+              # output embeds file paths and include targets from the PR, which are
+              # author-controlled: unfenced, a crafted path could forge a heading, plant a link,
+              # or open an HTML comment that swallows the rest of the page. Four backticks so
+              # content containing three cannot close the fence. Same reasoning as
+              # fragcheck-pr.yml and nightly-unlabeled-prs.yml.
+              echo '````text'
+              cat includecheck.log
+              echo '````'
+              echo
+              echo "Run the same check locally with:"
+              echo
+              echo '````bash'
+              echo "git ls-files -z -- '*.md' '*.html' | .claude/hooks/includecheck.sh --stdin0"
+              echo '````'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/dev-docs/cookbook-pre-pr.md
+++ b/dev-docs/cookbook-pre-pr.md
@@ -11,13 +11,15 @@ skill, which runs them for you; this page documents what it does and how to run 
 | Spelling (content + filenames) | `codespell` | `codespell.yml` |
 | Broken links | `lychee` | `link-check-pr.yml` |
 | Heading anchors | `fragcheck.py new` | `fragcheck-pr.yml` |
+| GitBook includes | `includecheck.sh --stdin0` | `includecheck-pr.yml` |
 | Alias expansion | sed (auto-commit) | `expand-gitbook-aliases.yml` |
 | Help-tables regen | Python | `generate-help-tables.yml` |
 
-Only the first three can fail your PR; aliases and help-tables are regenerated automatically.
+Only the first four can fail your PR; aliases and help-tables are regenerated automatically.
 
-The heading-anchor gate arrived in DOCS-6524 and closed the one rot class that used to have no
-CI counterpart at all. Two consequences worth knowing:
+The heading-anchor gate arrived in DOCS-6524, and the include gate in DOCS-6586; between them
+they close two of the four rot classes that used to be checked only on your own machine. Two
+consequences worth knowing:
 
 - **It is no longer only a local check.** Before, the anchor gate ran only via `/precommit`, the
   `docs-check` skill, and the Claude Code pre-commit hook — and that hook covers only commits
@@ -49,10 +51,28 @@ only in that script), exits non-zero on a real failure, and prints a `SKIPPED` n
 tool that isn't installed (CI still runs it).
 
 It also resolves every relative `{% include %}` in the file set and fails on a **missing target**
-or one that **crosses a space boundary**. That check has **no CI counterpart** — `{% include %}`
-is GitBook template syntax, not a Markdown link, so lychee is blind to it and a dead include just
-renders as nothing, silently dropping a section from the page. It needs no external tool, so it
-never SKIPs. (Added in DOCS-6372, which found two live cases this way.)
+or one that **crosses a space boundary**. `{% include %}` is GitBook template syntax, not a
+Markdown link, so lychee is blind to it and a dead include just renders as nothing, silently
+dropping a section from the page. It needs no external tool, so it never SKIPs. (Added in
+DOCS-6372, which found two live cases this way.)
+
+Since DOCS-6586 this one **is** gated in CI, by `includecheck-pr.yml`, and the resolver itself
+lives in `.claude/hooks/includecheck.sh` — `doc-lint.sh` delegates to it so both callers share
+one implementation. Two differences from the local run are worth knowing:
+
+* **CI checks the whole tree, not your changed files.** Deleting or renaming one shared target
+  under `<space>/.gitbook/includes/` breaks every page that includes it, and those pages are not
+  in your diff — removing `platform/.gitbook/includes/most-recent-10.11.md` breaks 20
+  post-download pages. So CI can fail on a page you never opened; that is the point, not a bug.
+  Reproduce it exactly with:
+
+  ```bash
+  git ls-files -z -- '*.md' '*.html' | .claude/hooks/includecheck.sh --stdin0
+  ```
+
+* **There is no acknowledgment path, deliberately.** Unlike the shrink and orphan guards, a dead
+  include has no legitimate form — fix the path, restore the target, or use the by-ID form for a
+  genuinely cross-space snippet.
 
 It also gates **heading anchors** — links of the form `page.md#some-heading`. This one is
 history-aware: it reports only anchors that resolved at `DOC_LINT_BASE` (default `HEAD`) and are
@@ -131,8 +151,9 @@ just the new ones. (Added in DOCS-6567.)
 
 Finally, it flags a **gutted page**: any file in the set that lost more than **40%** of its lines
 *net* (deletions minus additions, minimum 20 lines lost, pre-image at least 30 lines) against
-`DOC_LINT_BASE` (default `HEAD`). This has no CI counterpart either, and it exists because the
-other checks are blind to it — when a page loses most of its body but the surviving markup is
+`DOC_LINT_BASE` (default `HEAD`). Like the orphan gate above it, this one still has no CI
+counterpart; both are the remainder of DOCS-6586. It exists because the other checks are blind
+to it: when a page loses most of its body but the surviving markup is
 valid and the remaining links resolve, codespell and lychee both PASS. That is exactly what
 happened in DOCS-6442: a retirement campaign meant to delete one `{% columns %}` content-ref
 block from the Storage Engines landing page and deleted 23 of 24 instead (298 lines → 22,


### PR DESCRIPTION
Part of **DOCS-6586** (DOCS-6471 Part 2). This is the half that had no open design question, so it ships on its own; the orphan and gutted-page guards stay behind the acknowledgment-path decision.

## Why this one first

A dead `{% include %}` has **no failing signal anywhere**. It is GitBook *template* syntax, not a Markdown link, so lychee cannot see it, codespell has no opinion, and the page renders with the section silently missing while all the surrounding markup stays valid. DOCS-6372 found two live cases *by eye* — a 13.1 post-download page missing its "most recent release" bullet, and a MaxScale CVE page missing its copyright footnote — and added a resolver. Every entry point to that resolver was local: `/precommit`, the `docs-check` skill, and a hook that by its own header covers "only commits that Claude Code makes via the Bash tool."

It is also the only one of the three checks with **no legitimate exceptions**. A large shrink can be correct and a deliberately unlisted page can be correct, so both of those need a way for an author to say "yes, on purpose" — which is the `DOC_LINT_ALLOW_*` env-var problem the ticket is blocked on. A dead include is always a bug, so there is nothing to acknowledge and no hatch to be quietly overused later.

## What changed

The resolver was **extracted** into `.claude/hooks/includecheck.sh`, not duplicated — `doc-lint.sh` now delegates to it, so one implementation serves both callers. It could not simply call `doc-lint.sh`: that would re-run codespell and lychee (which have their own workflows) and the orphan guard, which has no skip flag to hold it back with.

## Two design calls, made and evidenced

Both are implemented and measured; neither is an open question. They are called out because each **departs from what the ticket's description prescribed**, so they are where review effort is best spent. The one genuinely open decision on DOCS-6586 — the acknowledgment path for `DOC_LINT_ALLOW_ORPHAN` / `DOC_LINT_ALLOW_SHRINK` — affects only the orphan and gutted-page guards, which are *not* in this PR.

**1. CI scans the whole tree; the hook still scans the caller's files.** Deleting or renaming one shared target under `<space>/.gitbook/includes/` breaks every page that includes it — and none of those pages are in the diff. Measured on `main`: removing `platform/.gitbook/includes/most-recent-10.11.md` breaks **20** post-download pages, and a changed-files gate reports exactly nothing. Shared targets are the norm here, so the scoping that is right for codespell (a typo is local to its page) is wrong for this check. The cost is one ~30s job.

**2. The check is absolute, with no baseline.** Every other history-aware check here diffs against a base because of a large pre-existing backlog — ~1,272 dead anchors, 219 orphans. Here the backlog is **zero**: 4,287 relative includes across 9,696 files, all resolving. Nothing to grandfather, so no `fetch-depth: 0`, no throwaway worktree, no base-revision assertion — and no way for a missing baseline to turn the gate silently green, which is the failure mode `fragcheck-pr.yml` needs a whole extra step to prevent.

## The non-vacuity assertion

`includecheck.sh` prints its counts, and the workflow asserts a nonzero one. "Checked 9,696 files, all clean" and "checked nothing at all" are the same exit code, so without this an empty file list — a pathspec typo, a wrong working directory — would leave the gate permanently and silently green. Same lesson as DOCS-6587's actionlint self-test: assert *behaviour*, not presence.

## Drive-by fixes

* **`--stdin0` instead of `xargs`.** `git ls-files` is over ARG_MAX; xargs splits the run into batches that each print their own summary and return their own status, so `$?` off the pipeline reports only the **last** batch — findings in an earlier batch could exit 0. Caught by running it, not by reading it.
* **`mktemp` retired.** The subshell tally moved to a process substitution, so the loop body runs in the parent shell. That removes the platform-specific `mktemp` contract that DOCS-6372's `f2b5e332c` regression lived in (a `-t` template with no X's: fine on BSD, exit 2 on every GNU-coreutils run, for 135 commits).
* **`doc-lint.sh` resolves the sibling relative to itself, not `$PWD`.** Those differ in `doc-lint-test.sh`, which runs the script from the repo with CWD in a sandbox. A CWD-relative path would have left the six existing include cases passing while actually exercising the "script missing" branch.
* **A missing `includecheck.sh` fails `doc-lint.sh` rather than SKIPping.** Every other dependency is an external *tool* a contributor may legitimately not have; this one is checked in beside it, so its absence means a broken checkout, and a check that cannot run must not report success.
* Stale "no CI counterpart" claims corrected in `.claude/README.md`, `.claude/skills/docs-check/SKILL.md` and `dev-docs/cookbook-pre-pr.md`.

## Test plan

* **Suite: 33 → 40 cases, 40/40 passing**, `0 skipped` (codespell and lychee both present). The seven new cases cover `--stdin0`, a path containing a space (the NUL-delimiting claim), the counts on stdout, empty input, both usage errors, and the missing-script hard failure.
* **Each new case proven red by mutation**, per DOCS-6471's discipline: dropping `-d ''` fails 3, making a zero-arg call exit 0 fails 1, dropping the counts from the summary line fails 1. Restored: 40/40.
* **Every rendered `run:` block executed locally** — extracted with `ruby -ryaml` — on both paths. Green: exit 0, `rc=0`, 4,287 includes, the summary renders. Red: a deleted shared target gives exit 1 plus the annotation and the 20 findings; a "no files to check" log fails the vacuity assertion; a reshaped summary line fails it too.
* `actionlint` clean (exit 0) across every workflow — including the gate added yesterday in DOCS-6587, which is what checked the shell in these new `run:` blocks. `shellcheck` clean on every tracked script plus the new one. `codespell` clean.
* Tree restored to clean after every destructive probe (`git status` verified).
