### PR TITLE
DOCS-6581 Document the replica gate on automatic binlog purge

### DIFF
--- a/server/ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md
+++ b/server/ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md
@@ -857,7 +857,7 @@ Also see [mariadbd replication options](../../server-management/starting-and-sto
 * Dynamic: Yes
 * Data Type: `numeric`
 * Default Value: `1`; `0` on Galera cluster nodes.
-* Range: `0` to `18446744073709551615`
+* Range: `0` to `4294967295`
 * Introduced: [MariaDB 11.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/11.4/what-is-mariadb-114)
 
 #### `slave_ddl_exec_mode`

--- a/server/mariadb-quickstart-guides/mariadb-datetime-guide.md
+++ b/server/mariadb-quickstart-guides/mariadb-datetime-guide.md
@@ -248,8 +248,8 @@ Common format specifiers:
 * `%Y`: Year, 4 digits
 * `%y`: Year, 2 digits
 * `%c`: Month, numeric (1-12)
-* `%r`: Time in 12-hour format (hh:mm:ss AM/PM)
-* `%T`: Time in 24-hour format (hh:mm:ss)
+* `%r`: Time in 12-hour format (`hh:mm:ss AM/PM`)
+* `%T`: Time in 24-hour format (`hh:mm:ss`)
 * `%H`: Hour (00-23)
 * `%h` or `%I`: Hour (01-12)
 * `%i`: Minutes (00-59)

--- a/server/reference/sql-statements/administrative-sql-statements/purge-binary-logs.md
+++ b/server/reference/sql-statements/administrative-sql-statements/purge-binary-logs.md
@@ -17,11 +17,15 @@ PURGE { BINARY | MASTER } LOGS
 
 ## Description
 
-The `PURGE BINARY LOGS` statement deletes all the [binary log](../../../server-management/server-monitoring-logs/binary-log/) files listed in the log index file prior to the specified log file name ordate. `BINARY` and `MASTER` are synonyms.Deleted log files also are removed from the list recorded in the index file, sothat the given log file becomes the first in the list.
+The `PURGE BINARY LOGS` statement deletes all the [binary log](../../../server-management/server-monitoring-logs/binary-log/) files listed in the log index file prior to the specified log file name or date. `BINARY` and `MASTER` are synonyms. Deleted log files are also removed from the list recorded in the index file, so that the given log file becomes the first in the list.
 
-The datetime expression is in the format `YYYY-MM-DD hh:ss`.
+The datetime expression is in the format `YYYY-MM-DD hh:mm:ss`.
 
 If a replica is active but has yet to read from a binary log file you attempt to delete, the statement will fail with an error. However, if the replica is not connected and has yet to read from a log file you delete, the file will be deleted, but the replica will be unable to continue replicating once it connects again.
+
+From [MariaDB 11.4.3](https://jira.mariadb.org/browse/MDEV-34504), `PURGE BINARY LOGS` ignores [slave\_connections\_needed\_for\_purge](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#slave_connections_needed_for_purge), the minimum number of connected replicas that [automatic purging](../../../server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log.md#purging-log-files) requires. In MariaDB 11.4.1 and 11.4.2, `PURGE BINARY LOGS BEFORE` observed that limit while `PURGE BINARY LOGS TO` did not.
+
+If an automatic purge has already been refused for a file because too few replicas had processed it, a manual purge of that same file is refused as well, reporting the file as the current active binary log even when it is not. The server clears that state when a replica moves on to a new binary log file, or when [slave\_connections\_needed\_for\_purge](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#slave_connections_needed_for_purge) or [max\_binlog\_total\_size](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#max_binlog_total_size) is set.
 
 This statement has no effect if the server was not started with the [--log-bin](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#log_bin) option to enable binary logging.
 
@@ -35,7 +39,7 @@ To list the binary log files on the server, use [SHOW BINARY LOGS](show/show-bin
 {% endtab %}
 {% endtabs %}
 
-To delete all binary log files, use [RESET MASTER](replication-statements/reset-master.md).To move to a new log file (for example if you want to remove the current log file), use [FLUSH LOGS](flush-commands/flush.md) before you execute `PURGE LOGS`.
+To delete all binary log files, use [RESET MASTER](replication-statements/reset-master.md). To move to a new log file (for example if you want to remove the current log file), use [FLUSH LOGS](flush-commands/flush.md) before you execute `PURGE LOGS`.
 
 If the [expire\_logs\_days](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#expire_logs_days) server system variable is not set to 0, the server automatically deletes binary log files after the given number of days. From MariaDB 10.6, the [binlog\_expire\_logs\_seconds](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#binlog_expire_logs_seconds) variable allows more precise control over binlog deletion, and takes precedence if both are non-zero.
 

--- a/server/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log.md
+++ b/server/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log.md
@@ -23,6 +23,20 @@ Logs can also be removed automatically with the [expire\_logs\_days](../../../ha
 
 From [MariaDB 10.6](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/10.6), the [binlog\_expire\_logs\_seconds](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#binlog_expire_logs_seconds) variable allows more precise control over binlog deletion and takes precedence if both are non-zero.
 
+{% hint style="warning" %}
+**Automatic Purging Requires Connected Replicas**
+
+All three automatic mechanisms — [max\_binlog\_total\_size](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#max_binlog_total_size), [binlog\_expire\_logs\_seconds](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#binlog_expire_logs_seconds) and [expire\_logs\_days](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#expire_logs_days) — refuse to delete a binary log file until at least [slave\_connections\_needed\_for\_purge](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#slave_connections_needed_for_purge) replicas have processed it. The default is `1` (`0` on Galera cluster nodes), so a primary with no connected replica never purges automatically, and its disk can fill up even when expiry is configured correctly.
+
+Each refused attempt writes a note to the [error log](../error-log.md):
+
+```
+[Note] Binary log 'mariadb-bin.000001' is not purged because less than 'slave_connections_needed_for_purge' slaves have processed it
+```
+
+Set [slave\_connections\_needed\_for\_purge](../../../ha-and-performance/standard-replication/replication-and-binary-log-system-variables.md#slave_connections_needed_for_purge) to `0` to purge regardless of replica connections. `PURGE BINARY LOGS` is not subject to this limit; see [PURGE BINARY LOGS](../../../reference/sql-statements/administrative-sql-statements/purge-binary-logs.md).
+{% endhint %}
+
 {% include "../../../.gitbook/includes/innodb-based-binlog-from-12.3.md" %}
 
 If the binary log index file has been removed, or incorrectly manually edited, all of the above forms of purging logs fail. The .index file is a plain text file and can be manually recreated or edited so that it lists only the binary log files that are present, in numeric/age order.


### PR DESCRIPTION
Reported by Shawn Green in `#docs-talk`, filed by Tauseef Khan as DOCS-6581. Both items in the ticket, plus two drive-by fixes the verification turned up.

## 1. The binlog maintenance page never mentioned the gate

`slave_connections_needed_for_purge` gates **every** automatic purge [Using and Maintaining the Binary Log](https://mariadb.com/docs/server/server-management/server-monitoring-logs/binary-log/using-and-maintaining-the-binary-log) describes — `max_binlog_total_size`, `binlog_expire_logs_seconds` and `expire_logs_days` alike — and appeared nowhere on it. The default is `1`, so **a primary with no connected replica never purges automatically** and its disk can fill up even when expiry is configured correctly.

Added a warning that names the three mechanisms, the default (`1`, and `0` on Galera cluster nodes), the error-log note each refusal writes, and the escape hatch.

Executed rather than reasoned about, on the live 12.3.3 server with zero dump threads and 34 binlogs: `SET GLOBAL binlog_expire_logs_seconds=60; FLUSH BINARY LOGS;` deleted nothing, and the error log got exactly the note the page now quotes.

## 2. The `:mm:` emoji — already "fixed" by deleting the minutes

GITBOOK-2395 (`adc902e87`, 2026-09-03) removed the Hungarian flag from the format string by removing `mm`, leaving `` `YYYY-MM-DD hh:ss` `` — no emoji, and no minutes either. Restored to `` `YYYY-MM-DD hh:mm:ss` ``, code-spanned so the shortcode cannot parse.

The ticket asked for a grep for other unfenced occurrences: two, both in the datetime guide's format-specifier list (`%r`, `%T`), now code-spanned. Every other `hh:mm:ss` in the repo is already inside a fence or a code span.

## 3. Manual purge vs. the gate — the ticket's version claim was wrong twice

The ticket said manual `PURGE BINARY LOGS` was blocked in 11.4.0–11.4.2. Both bounds are wrong and so is the scope:

- The variable arrives with `18dfcfdecf4` (MDEV-31404), first released in **11.4.1** — there is no 11.4.0 behavior to describe.
- Per MDEV-34504's own commit message, only `PURGE BINARY LOGS BEFORE` observed the limit; `TO` ignored it from the start.
- `dd997809679` (MDEV-34504) first ships in **11.4.3**, after which `can_purge_log()` passes `0` for an interactive purge.

But it does not end there, and this is the part a reader hitting it needs: the short circuit at `sql/log.cc:6592` sits **before** the `interactive` check and caches the last failed purge, so a manual purge of a file whose *automatic* purge was just refused is refused too — reported as `it is the current active binlog` when it is not. Reproduced live (two refusals against `…-bin.000001` while `…-bin.000035` was active), and cleared by writing to the variable, after which the same statement purged. Documented as observed.

**Server-side finding, not fixed here:** that wrong reason string looks like an MDEV worth filing.

## Drive-by fixes

- `slave_connections_needed_for_purge`'s documented range carried a **ulonglong** max (`18446744073709551615`). It is a `Sys_var_uint` with `VALID_RANGE(0, UINT_MAX)`, and the live server reports `4294967295`.
- Three missing spaces on the PURGE BINARY LOGS page, KB→GitBook migration debris: "name ordate", "synonyms.Deleted", "MASTER).To".

## Verification

Source: `mariadb-server @ b2a8c2234dbc276fe3947633c9ffea454badf48f` (ref `main`). Oracle: live `12.3.3-MariaDB-log`. Eleven claims — 8 VERIFIED, 3 CORRECTED, 0 UNVERIFIED; the full fact-check report goes on the ticket at handoff.

Local checks: `doc-lint.sh` (4 files) clean, `codespell` clean, `lychee` 401 links / 0 errors, `fragcheck new origin/main` reports no new dead anchors.

Not verified: the passing side of the gate (enough replicas connected → purge proceeds) is source-read only, since there is no replica here.