### PR TITLE
DOCS-6441 Retire the last dead corporation-repo PR link

### DIFF
--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/migration-from-mysql-to-mariadb-cluster-node-by-node-in-place.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/migration-from-mysql-to-mariadb-cluster-node-by-node-in-place.md
@@ -398,6 +398,6 @@ Currently, migration from 8.0.x has been verified to work on a simple `sysbench`
 For developers or those compiling from source, the following changes were relevant to this migration path:
 
 * [codership-mariadb-server Pull Request #519](https://github.com/mariadb-corporation/codership-mariadb-server/pull/519)
-* [codership-mysql Pull Request #2062](https://github.com/mariadb-corporation/codership-mysql/pull/2062)
+* codership-mysql Pull Request #2062 (the `mariadb-corporation/codership-mysql` repository has been retired, so this change is no longer publicly browsable)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>


### PR DESCRIPTION
[DOCS-6441](https://mariadbcorp.atlassian.net/browse/DOCS-6441) asked for 475 links to the retired `docs-server` GitHub repo (217 files) to be mapped or removed. **That inventory is already at zero on `main`** — verified two ways:

```
git grep -n "docs-server" origin/main -- '*.md'   # 0
```

Not one `docs-server` mention of any shape survives, let alone the `blob/test` pattern. The work landed under other tickets:

| Where | What |
|---|---|
| #904 (DOCS-6385) | Community Server, Enterprise Server, ColumnStore/connector/MaxScale release notes, General Resources — four commits |
| #895 (DOCS-6430) | the remaining 450 occurrences, absorbed as a drive-by across 153 files |
| `f34d00961` (Tauseef) | the two links on the contribute FAQ that Monty reported and that opened the ticket |

## What this PR actually changes

Rather than close the ticket on someone else's work alone, I re-swept **every** `github.com/mariadb-corporation/*` link in the tree (23 distinct repos, ~10,700 links) and probed each repo root. Exactly one dead target of the same kind remains:

`server/.../moving-from-mysql/migration-from-mysql-to-mariadb-cluster-node-by-node-in-place.md` links to `mariadb-corporation/codership-mysql/pull/2062`.

- `mariadb-corporation/codership-mysql` → **404** anonymously *and* via authenticated `gh api` (not a permissions artifact).
- Its transferred successor `codership/mysql-wsrep` → `mariadb-corporation/mysql-wsrep`, whose highest PR is **#411**; no PR there carries the change.
- So there is no target to map this to.

Following the DOCS-6385 precedent, the reference is kept as plain text and the dead hyperlink removed. The sibling link on the same page, `codership-mariadb-server#519`, **is** live (open, "MGL-62 : Add parameter wsrep_sst_mysql_migrate") and is untouched.

## Checks

`doc-lint.sh <file>` → clean (rc=0). Standalone lychee flags one pre-existing 403 on a `dev.mysql.com` link, which the CI exclude set covers, so it is not a CI failure.

[DOCS-6441]: https://mariadbcorp.atlassian.net/browse/DOCS-6441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ