### PR TITLE
DOCS-6451 Fix dead external links in the Server space

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -145,6 +145,8 @@ if command -v lychee >/dev/null 2>&1; then
       --exclude 'www\.packtpub\.com' \
       --exclude 'https://x\.com/' \
       --exclude 'www\.guru99\.com' \
+      --exclude 'portal\.azure\.com' \
+      --exclude 'www\.ibm\.com' \
       "${files[@]}" 2>&1)"; then
     # Mirror the workflow's failIfEmpty: false — lychee exits non-zero with
     # "No links were found" when the changed files contain no links, which is a

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -229,6 +229,15 @@ jobs:
           # five unrelated hosts cited elsewhere in the tree (wifislax.com,
           # twistedmatrix.com, tunnelix.com, limenex.com, 4mlinux.com) and would
           # silently stop checking them.
+          #
+          # DOCS-6451: portal.azure.com and www.ibm.com both answer a non-browser
+          # client with a bare 403 while serving real content to a browser. Azure's
+          # two links are deep links into the portal, which requires a signed-in
+          # session, so there is nothing to repoint at. IBM retired Knowledge Center
+          # and 301s the three db2look links to the equivalent /docs/ topic paths, but
+          # its block applies to the new paths too and the Wayback Machine has NO
+          # snapshot of either form -- so the URLs are left exactly as they are rather
+          # than swapped for a target that cannot be verified from here.
           args: >-
             --no-progress
             --exclude 'bazaar\.launchpad\.net'
@@ -303,6 +312,8 @@ jobs:
             --exclude 'www\.packtpub\.com'
             --exclude 'https://x\.com/'
             --exclude 'www\.guru99\.com'
+            --exclude 'portal\.azure\.com'
+            --exclude 'www\.ibm\.com'
             ${{ steps.list.outputs.files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee

--- a/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/compound-composite-indexes.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/compound-composite-indexes.md
@@ -253,7 +253,7 @@ Refreshed -- Oct, 2012; more links -- Nov 2016
 ## See also
 
 * [Cookbook on designing the best index for a SELECT](https://mysql.rjweb.org/doc.php/index_cookbook_mysql)
-* [Sheeri's discussing of Indexes](https://technocation.org/files/doc/2013_02_MySQLindexes.pdf)
+* [Sheeri's discussing of Indexes](https://web.archive.org/web/20140903101246/https://technocation.org/files/doc/2013_02_MySQLindexes.pdf)
 * [Slides on EXPLAIN](https://www.slideshare.net/phpcodemonkey/mysql-explain-explained)
 * [Mysql manual page on range accesses in composite indexes](https://dev.mysql.com/doc/refman/5.7/en/range-optimization.html#range-access-multi-part)
 * [Overhead of Composite Indexes](https://stackoverflow.com/questions/32418812/overhead-of-composite-indexes)

--- a/server/ha-and-performance/optimization-and-tuning/optimizing-tables/entity-attribute-value-implementation.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizing-tables/entity-attribute-value-implementation.md
@@ -84,7 +84,7 @@ Posted Jan, 2014; Refreshed Feb, 2016.
 * MariaDB's [Dynamic Columns](../../../reference/sql-structure/nosql/dynamic-columns.md)
 * [MySQL 5.7's JSON](https://dev.mysql.com/doc/refman/5.7/en/json.html)
 
-This looks very promising; I will need to do more research to see how much of this article is obviated by it: [Using MySQL as a Document Store in 5.7](https://dev.mysql.com/doc/refman/5.7/en/document-store.html),[more DocStore discussion](https://mysqlserverteam.com/mysql-5-7-12-part-6-mysql-document-store-a-new-chapter-in-the-mysql-story/)
+This looks very promising; I will need to do more research to see how much of this article is obviated by it: [Using MySQL as a Document Store in 5.7](https://dev.mysql.com/doc/refman/5.7/en/document-store.html),[more DocStore discussion](https://web.archive.org/web/20160823135933/https://mysqlserverteam.com/mysql-5-7-12-part-6-mysql-document-store-a-new-chapter-in-the-mysql-story/)
 
 If you insist on EAV, set [optimizer\_search\_depth=1](../system-variables/server-system-variables.md#optimizer_search_depth).
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/groupwise-max-in-mariadb.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/groupwise-max-in-mariadb.md
@@ -349,7 +349,7 @@ I did not include the technique(s) using GROUP\_CONCAT. They are useful in some 
 * Adding a large LIMIT to a subquery may make things work. [Why ORDER BY in subquery is ignored](https://app.gitbook.com/s/WCInJQ9cmGjq1lsTG91E/community/community/faq/developer-questions/why-is-order-by-in-a-from-subquery-ignored)
 * [StackOverflow thread](https://stackoverflow.com/questions/36485072/select-with-order-and-group-by-in-maria-dbmysql)
 * [row\_number(), rank(), dense\_rank()](https://kennethxu.blogspot.com/2016/04/analytical-function-in-mysql-rownumber.html)
-* [Perentile blog](https://rpbouman.blogspot.de/2008/07/calculating-nth-percentile-in-mysql.html]\[Perentile_blog)
+* [Calculating the Nth percentile in MySQL](https://rpbouman.blogspot.com/2008/07/calculating-nth-percentile-in-mysql.html)
 
 Rick James graciously allowed us to use this article in the documentation.
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/optimization-strategies/improvements-to-order-by.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/optimization-strategies/improvements-to-order-by.md
@@ -25,7 +25,7 @@ The [ORDER BY](../../../../reference/sql-statements/data-manipulation/selecting-
 
 ## Comparison with MySQL 5.7
 
-In [MySQL 5.7 changelog](https://mysqlserverteam.com/whats-new-in-mysql-5-7-generally-available/), one can find this passage:
+In [MySQL 5.7 changelog](https://web.archive.org/web/20160221101834/https://mysqlserverteam.com/whats-new-in-mysql-5-7-generally-available/), one can find this passage:
 
 Make switching of index due to small limit cost-based ([WL#6986](https://askmonty.org/worklog/?tid=6986)) : We have made
 the decision in make\_join\_select() of whether to switch to a new index in order to

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/subquery-cache.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/subquery-cache.md
@@ -161,7 +161,7 @@ ORDER BY
 
 * [Query cache](../../buffers-caches-and-threads/query-cache.md)
 * blog post describing impact of subquery cache optimization on queries used by DynamicPageList MediaWiki extension
-* [mariadb-subquery-cache-in-real-use-case.html](https://varokism.blogspot.ru/2013/06/mariadb-subquery-cache-in-real-use-case.html) Another use case from the real world
+* Another use case from the real world was described on the varokism blog, which has since been deleted
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/ha-and-performance/optimization-and-tuning/query-optimizations/table-elimination/what-is-table-elimination.md
+++ b/server/ha-and-performance/optimization-and-tuning/query-optimizations/table-elimination/what-is-table-elimination.md
@@ -3,7 +3,7 @@
 The basic idea behind table elimination is that sometimes it is possible to resolve a query without even accessing some of the tables that the query refers to. One can invent many kinds of such cases, but in Table Elimination we targeted only a certain class of SQL constructs that one ends up writing when
 they are querying [highly-normalized](https://app.gitbook.com/s/WCInJQ9cmGjq1lsTG91E/database-theory/database-normalization) data.
 
-The sample queries were drawn from “Anchor Modeling”, a database modeling technique which takes normalization to the extreme. The [slides](https://www.anchormodeling.com/tiedostot/SU_KTH_Course_Presentation.pdf) at the [anchor modeling website](https://www.anchormodeling.com) have an in-depth explanation of Anchor modeling and its merits, but the part that's important for table elimination can be shown with an example.
+The sample queries were drawn from “Anchor Modeling”, a database modeling technique which takes normalization to the extreme. The [slides](https://web.archive.org/web/20091211131908/https://www.anchormodeling.com/tiedostot/SU_KTH_Course_Presentation.pdf) at the [anchor modeling website](https://www.anchormodeling.com) have an in-depth explanation of Anchor modeling and its merits, but the part that's important for table elimination can be shown with an example.
 
 Suppose the database stores information about actors, together with their names, birthdays, and ratings, where ratings can change over time:
 

--- a/server/reference/data-types/string-data-types/character-sets/supported-character-sets-and-collations.md
+++ b/server/reference/data-types/string-data-types/character-sets/supported-character-sets-and-collations.md
@@ -690,7 +690,7 @@ An accent insensitive collation is one where the accented and unaccented version
 * [MariaDB 10.1.15](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.15) added the `utf8_thai_520_w2`, `utf8mb4_thai_520_w2`, `ucs2_thai_520_w2`, `utf16_thai_520_w2` and `utf32_thai_520_w2` collations.
 * [MariaDB 10.0.7](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.0/10.0.7) added the `utf8_myanmar_ci`, `ucs2_myanmar_ci`, `utf8mb4_myanmar_ci`, `utf16_myanmar_ci` and `utf32_myanmar_ci` collations.
 * [MariaDB 10.0.5](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.0/10.0.5) added the `utf8_german2_ci`, `utf8mb4_german2_ci`, `ucs2_german2_ci`, `utf16_german2_ci` and `utf32_german2_ci` collations.
-* [MariaDB 5.1.41](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/5.1/5.1.41) added a Croatian collation patch from [Alexander Barkov](https://www.collation-charts.org/) to fix some problems with the Croatian character set and `LIKE` queries. This patch added `utf8_croatian_ci` and `ucs2_croatian_ci` collations to MariaDB.
+* [MariaDB 5.1.41](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/5.1/5.1.41) added a Croatian collation patch from [Alexander Barkov](https://web.archive.org/web/20220625171816/https://www.collation-charts.org/) to fix some problems with the Croatian character set and `LIKE` queries. This patch added `utf8_croatian_ci` and `ucs2_croatian_ci` collations to MariaDB.
 
 ## See Also
 

--- a/server/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam.md
+++ b/server/reference/plugins/authentication-plugins/authentication-with-pluggable-authentication-modules-pam/user-and-group-mapping-with-pam.md
@@ -18,7 +18,7 @@ Rather than building user and group mapping into the `pam` authentication plugin
 
 #### Lack of Support for MySQL/Percona Group Mapping Syntax
 
-Unlike MariaDB, MySQL and Percona implemented group mapping in their PAM authentication plugins. If you've read through [MySQL's PAM authentication documentation on group mapping](https://dev.mysql.com/doc/refman/8.0/en/pam-pluggable-authentication.html#pam-authentication-unix-with-proxy) or [Percona's PAM authentication documentation on group mapping](https://www.percona.com/doc/percona-server/8.0/management/pam_plugin.html#supplementary-groups-support), you've probably seen syntax where the group mappings are provided in the [CREATE USER](../../../sql-statements/account-management-sql-statements/create-user.md) statement like this:
+Unlike MariaDB, MySQL and Percona implemented group mapping in their PAM authentication plugins. If you've read through [MySQL's PAM authentication documentation on group mapping](https://dev.mysql.com/doc/refman/8.0/en/pam-pluggable-authentication.html#pam-authentication-unix-with-proxy) or [Percona's PAM authentication documentation on group mapping](https://docs.percona.com/percona-server/8.0/pam-plugin.html#supplementary-groups-support), you've probably seen syntax where the group mappings are provided in the [CREATE USER](../../../sql-statements/account-management-sql-statements/create-user.md) statement like this:
 
 ```sql
 CREATE USER ''@''
@@ -257,7 +257,7 @@ You may find the following PAM and user mapping-related tutorials helpful:
 
 * [Configuring PAM Authentication and User Mapping with MariaDB](https://mariadb.com/resources/blog/configuring-pam-authentication-and-user-mapping-with-mariadb/)
 * [Configuring PAM Group Mapping with MariaDB](https://mariadb.com/resources/blog/configuring-pam-group-mapping-with-mariadb/)
-* [Configuring LDAP Authentication and Group Mapping With MariaDB](https://www.geoffmontee.com/configuring-ldap-authentication-and-group-mapping-with-mariadb/)
+* [Configuring LDAP Authentication and Group Mapping With MariaDB](https://web.archive.org/web/20220930002503/https://www.geoffmontee.com/configuring-ldap-authentication-and-group-mapping-with-mariadb/)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/reference/plugins/mariadb-audit-plugin/mariadb-audit-plugin-overview.md
+++ b/server/reference/plugins/mariadb-audit-plugin/mariadb-audit-plugin-overview.md
@@ -30,7 +30,7 @@ Review these pages for detailed documentation:
 
 ## Blog Posts
 
-* [MySQL Auditing with MariaDB Auditing Plugin](https://planet.mysql.com/entry/?id=5994184)
+* MySQL Auditing with MariaDB Auditing Plugin (formerly on Planet MySQL, no longer available)
   by Peter Zaitsev, February 15, 2016
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/plugins/other-plugins/feedback-plugin.md
+++ b/server/reference/plugins/other-plugins/feedback-plugin.md
@@ -120,7 +120,7 @@ Collations that have not been used will not be included in the result.
 The `feedback` plugin sends the data using a `POST` request to any URL or a list of URLs
 that you specify by setting the [feedback\_url](feedback-plugin.md#feedback_url) system variable. By default, this is set to the following URL:
 
-* https://feedback.mariadb.org/rest/v1/post
+* `https://feedback.mariadb.org/rest/v1/post`
 
 Both HTTP and HTTPS protocols are supported.
 
@@ -138,7 +138,7 @@ First, generate the report file with the MariaDB command-line [mariadb](../../..
 $ mariadb -e 'select * from information_schema.feedback' > report.txt
 ```
 
-Then, you can upload the generated `report.txt` [here](https://feedback.mariadb.org/rest/v1/post) from the command line with tools such as [curl](https://curl.haxx.se/docs/manpage.html):
+Then, you can upload the generated `report.txt` to `https://feedback.mariadb.org/rest/v1/post` from the command line with tools such as [curl](https://curl.haxx.se/docs/manpage.html):
 
 ```bash
 $ curl -F data=@report.txt https://feedback.mariadb.org/rest/v1/post
@@ -190,7 +190,7 @@ Manual uploading allows you to be absolutely sure that we receive only the data 
 * Scope: Global
 * Dynamic: No
 * Data Type: string
-* Default Value: https://feedback.mariadb.org/rest/v1/post
+* Default Value: `https://feedback.mariadb.org/rest/v1/post`
 
 ### `feedback_user_info`
 

--- a/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/mariadb-53mysql-55-windows-performance-patches.md
+++ b/server/reference/product-development/server-development/quality/benchmarks-and-long-running-tests/benchmarks/mariadb-53mysql-55-windows-performance-patches.md
@@ -4,7 +4,7 @@ I just backported Windows performance patches I've done for 5.5 back to [MariaDB
 
 First, I feel Windows performance improvements in 5.5 were never adequately described, so here is the redux.\
 For those familiar with Windows systems programming, MySQL code used to offer of low-hanging performance fruits. I picked some of them those back in my days in MySQL/Sun. The result benchmark curve became really nice:\
-look at [Calvin's blog entry](https://blogs.innodb.com/wp/2010/09/mysql-5-5-innodb-performance-improvements-on-windows/).
+look at [Calvin's blog entry](https://web.archive.org/web/20120618142511/https://blogs.innodb.com/wp/2010/09/mysql-5-5-innodb-performance-improvements-on-windows/).
 
 If graphs in this blog looks familiar to you, it is because it was often used by Oracle marketing as proof of big-O's positive influence on MySQL code :)
 
@@ -37,7 +37,7 @@ Prior to that patch . Once atomics were enabled, implementation of fast mutexes 
 
 This patch was merely to compensate for negative effects of the 5.5 metadata lock on MyISAM benchmarks, and fix was using native Vista performance primitives. The patch per se is not interesting, and repeats a lot of what was done for Innodb. What was great, was a discussion prior to the patch between myself, Davi, Dmitry on different implementations of reader writer locks, including 2 homebacked ones, and one by [Vance Morrison](https://blogs.msdn.com/b/vancem/archive/2006/03/28/563180.aspx).
 
-Without doubt, the discussions around that was a highlight in my very short stint at Oracle. Also, if you want to get a MySQL-classic-style code review with 17 things to fix, of which at least 10 would be marked with "Coding Style" (yes, both words capitalized) , try to get Dmitry Lenev as a reviewer, he's great - this is the proof [118295](https://lists.mysql.org/commits/118295) Anyway, the patch improves MyISAM throughput by 10-20% , which I think is quite ok. Somehow those percents were subsequently eaten by MDL though :)
+Without doubt, the discussions around that was a highlight in my very short stint at Oracle. Also, if you want to get a MySQL-classic-style code review with 17 things to fix, of which at least 10 would be marked with "Coding Style" (yes, both words capitalized) , try to get Dmitry Lenev as a reviewer, he's great - this is the proof (commit 118295) Anyway, the patch improves MyISAM throughput by 10-20% , which I think is quite ok. Somehow those percents were subsequently eaten by MDL though :)
 
 ## Notes
 

--- a/server/reference/product-development/server-development/quality/code-coverage-with-dgcov.md
+++ b/server/reference/product-development/server-development/quality/code-coverage-with-dgcov.md
@@ -88,7 +88,7 @@ To be able to run `gcov` with the [mariadb-test](../../../../clients-and-utiliti
 
 ### References <a href="#references" id="references"></a>
 
-* `dgcov` was created by Kristian Nielsen and [announced here](http://kristiannielsen.livejournal.com/1885.html).
+* `dgcov` was created by Kristian Nielsen and [announced here](https://kristiannielsen.livejournal.com/1885.html).
 * `dgcov` was reimplemented to aggregate the data, and to work for `git` and `cmake`, by Sergei Golubchik.
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/reference/product-development/server-development/quality/qa-datasets/openstreetmap-dataset.md
+++ b/server/reference/product-development/server-development/quality/qa-datasets/openstreetmap-dataset.md
@@ -31,7 +31,7 @@ sed -i -e 's/MyISAM/Aria/gi' osmdb06.sql
 
 The data is provided in the form of XML files (.OSM files) that require the\
 Java-based [Osmosis](https://wiki.openstreetmap.org/wiki/Osmosis) tool to load
-into MariaDB. The tool is available from [dev.openstreetmap.org](https://dev.openstreetmap.org/~bretth/osmosis-build/osmosis-latest.tgz).\
+into MariaDB. The tool is available from [dev.openstreetmap.org](https://github.com/openstreetmap/osmosis).\
 Version 0.36 is known to work.
 
 Various .OSM files are available, including the [entire world](https://wiki.openstreetmap.org/wiki/Planet.osm) (>200Gb unzipped)

--- a/server/reference/product-development/server-development/quality/qa-tools.md
+++ b/server/reference/product-development/server-development/quality/qa-tools.md
@@ -13,7 +13,7 @@ Tools used for quality assurance testing include:
 * [Worklog Quality Checklist Template](worklog-quality-checklist-template.md) is a template for creating a checklist for testing individual features or WorkLogs.
 * [MTR/mysqltest reference](http://dev.mysql.com/doc/mysqltest/2.0/en/mysqltest-reference.html)
 * [The Random Query Generator](http://github.com/RQG/RQG-Documentation/wiki/Category:RandomQueryGenerator)
-* [BuildBot Manual](http://buildbot.net/buildbot/docs/latest/)
+* [BuildBot Manual](https://docs.buildbot.net/current/)
 
 ### See Also <a href="#see-also" id="see-also"></a>
 

--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-buildbot-setup-for-windows.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-buildbot-setup-for-windows.md
@@ -13,7 +13,7 @@ This is the recipe for setting up a MariaDB Buildbot slave on Windows:
    Note: As of June 2016, there is no fresh Twistd for 32-bit Python, so a 64-bit version has to be installed. Installed 2.7.11 64-bit, it seems to work.
 3. Install [pywin32](https://sourceforge.net/projects/pywin32/files). Make sure the version matches your Python version perfectly, and get the .exe file, not the zip file.\
    Note: As of June 2016, used `pywin32-220.win-amd64-py2.7.exe`, it seems to work.
-4. Install [Twisted](https://twistedmatrix.com/trac/wiki/Downloads)\
+4. Install [Twisted](https://twisted.org/)\
    Note: As of June 2016, used `Twisted 16.2.0 for Python 2.7 64 bits`
 5. Install [buildbot](https://buildbot.net): Get the zip file and unpack it. In an administrator shell, cd to the buildbot dir and run "python setup.py install". After that, the unpacked buildbot directory is no longer needed.\
    Note: As of June 2016, used `buildbot 0.8.12`.
@@ -40,7 +40,7 @@ You can test the buildbot slave with this command:
 C:\buildbot\buildbot-slave-0.8.3\build\scripts-2.7\buildslave.bat start <somewhere>\buildbot\<slavedir>
 ```
 
-When buildbot starts, you should configure it as a service instead of manually. See the instructions [here](https://buildbot.net/trac/wiki/RunningBuildbotOnWindows). It's under the section "Windows Buildbot service setup". This document also has the generic Windows Buildbot installation documentation.
+When buildbot starts, you should configure it as a service instead of manually. See the instructions [here](https://web.archive.org/web/20090109143800/https://buildbot.net/trac/wiki/RunningBuildbotOnWindows). It's under the section "Windows Buildbot service setup". This document also has the generic Windows Buildbot installation documentation.
 
 ### Why Buildbot Should Run as a Service
 

--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-general-principles.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-for-virtual-machines/buildbot-setup-for-virtual-machines-general-principles.md
@@ -108,7 +108,7 @@ mariadb-server-5.1	mysql-server/root_password_again	password	rootpass
     mariadb-server-5.1	mysql-server/no_upgrade_when_using_ndb	error
 ```
 
-For some background see [here](https://blog.hjksolutions.com/articles/2007/07/27/unattended-package-installation-with-debian-and-ubuntu).\
+For some background see [here](https://web.archive.org/web/20080516191905/https://blog.hjksolutions.com/articles/2007/07/27/unattended-package-installation-with-debian-and-ubuntu).\
 The file my.seed can be generated from an existing install using
 debconf-get-selections.
 
@@ -128,7 +128,7 @@ deb-src file:///home/buildbot/buildbot/debs source/
 The default network card emulated by KVM has poor performance. To solve this we
 instead use the "virtio" network device, using the KVM options "-net
 nic,model=virtio -net user". Except on Debian 4, which has an old kernel
-without support for virtio. Background info [here](https://episteme.arstechnica.com/eve/forums/a/tpc/f/96509133/m/303006642931).
+without support for virtio. Background info was discussed in an Ars Technica forum thread that is no longer available.
 
 A detail is that some 32-bit vms crashed during boot with default options. This
 was fixed by using the kvm "-cpu qemu32,-nx" option. Some background

--- a/server/reference/sql-functions/secondary-functions/miscellaneous-functions/uuid_v7.md
+++ b/server/reference/sql-functions/secondary-functions/miscellaneous-functions/uuid_v7.md
@@ -47,7 +47,7 @@ UUID_v7(): 01921e85-f198-7490-9b89-7dd0d468543b
 * [UUID data type](../../../data-types/string-data-types/uuid-data-type.md)
 * [MDEV-11339](https://jira.mariadb.org/browse/MDEV-11339) (Support UUID v4 generation)
 * [MDEV-32637](https://jira.mariadb.org/browse/MDEV-32637) (Implement native UUID7 function)
-* [uuid7.com](https://uuid7.com/)
+* [uuid7.com](https://web.archive.org/web/20250708210006/https://uuid7.com/)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/reference/sql-structure/vectors/vector-framework-integrations.md
+++ b/server/reference/sql-structure/vectors/vector-framework-integrations.md
@@ -50,7 +50,7 @@ Each table lists supported frameworks first, then those without an integration.
 | [Doctrine ORM](https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/types.html) | PHP | Open request | [doctrine/dbal#6703](https://github.com/doctrine/dbal/issues/6703) |
 | [Drizzle ORM](https://orm.drizzle.team/docs/guides/vector-similarity-search) | TypeScript / Node.js | Open request | [drizzle-orm#2007](https://github.com/drizzle-team/drizzle-orm/issues/2007) |
 | [Django](https://docs.djangoproject.com/en/stable/ref/models/fields/) | Python | — | Django ships no vector field for any database. MariaDB Vector is native to the server, so this is client-side work only: a Django field mapping to the `VECTOR` type |
-| [Prisma](https://www.prisma.io/docs/orm/prisma-schema/data-model/models) | TypeScript / Node.js | — | Supports MariaDB as a database, but has no vector type for it; see the general [First class Vector support](https://github.com/prisma/prisma/issues/26546) request |
+| [Prisma](https://www.prisma.io/docs/orm/prisma-schema/data-model/models) | TypeScript / Node.js | — | Supports MariaDB as a database, but has no vector type for it; see the general [First class Vector support](https://github.com/prisma/orm/issues/26546) request |
 
 For a worked example of picking an embedding model for MariaDB Vector in a Laravel application, see [MariaDB Vector in Laravel: insights on choosing an embedding model](https://mariadb.org/mariadb-vector-in-laravel-insights-on-choosing-an-embedding-model/).
 

--- a/server/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin.md
+++ b/server/security/encryption/data-at-rest-encryption/key-management-and-encryption-plugins/hashicorp-key-management-plugin.md
@@ -141,7 +141,7 @@ The plugin supports the following parameters, which must be set in advance and c
 
 The token provided through `hashicorp-key-management-token` must have the following Vault access privileges.
 
-Given a `hashicorp-key-management-vault-url` of [`http://vault-server/v1/my_vault`](http://vault-server/v1/my_vault), the token requires:
+Given a `hashicorp-key-management-vault-url` of `http://vault-server/v1/my_vault`, the token requires:
 
 <table><thead><tr><th>Value Path</th><th width="211.22216796875">Access Required</th><th>Condition</th></tr></thead><tbody><tr><td><code>my_vault/data</code></td><td>read</td><td>Always required</td></tr><tr><td><code>sys/mounts/my_vault/tune</code></td><td>read</td><td>Required unless <code>hashicorp-key-management-check-kv-version</code> is set to <code>off</code></td></tr></tbody></table>
 

--- a/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/configuring-mariadb-for-optimal-performance.md
+++ b/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/configuring-mariadb-for-optimal-performance.md
@@ -118,7 +118,7 @@ You can increase the storage for internal temporary tables by setting [max\_heap
 
 ## External Links
 
-* [what-to-tune-in-mysql-56-after-installation.html](https://www.tocker.ca/2013/09/17/what-to-tune-in-mysql-56-after-installation.html)
+* [what-to-tune-in-mysql-56-after-installation.html](https://web.archive.org/web/20150421070308/https://www.tocker.ca/2013/09/17/what-to-tune-in-mysql-56-after-installation.html)
 * [optimizing-mysql-configuration-percona-mysql-university-montevideo](https://www.percona.com/resources/technical-presentations/optimizing-mysql-configuration-percona-mysql-university-montevideo)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/fusion-io/fusion-io-introduction.md
+++ b/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/mariadb-performance-advanced-configurations/fusion-io/fusion-io-introduction.md
@@ -77,7 +77,7 @@ There are several card models. ioDrive is older generation, ioDrive2 is newer. S
 
 ## See Also
 
-* [FusionIO atomic-series devices](https://www.fusionio.com/products/atomic-series)
+* [FusionIO atomic-series devices](https://web.archive.org/web/20140616192746/https://www.fusionio.com/products/atomic-series)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/building_mariadb_on_windows.md
+++ b/server/server-management/install-and-upgrade-mariadb/installing-mariadb/compiling-mariadb-from-source/building_mariadb_on_windows.md
@@ -33,7 +33,7 @@ In the "Adjusting your PATH" dialog, choose "Use Git from Windows command prompt
     (e.g. under `C:\Program Files\GnuWin32`); the build will break due to [this bison bug](https://sourceforge.net/tracker/index.php?func=detail\&aid=2788969\&group_id=23617\&atid=379173).\
     Instead, install into `C:\GnuWin32`.
   * Add `C:\GnuWin32\bin` to your system `PATH` after installation.
-* [Strawberry perl](https://strawberryperl.com): Used to run the test suite.[ActiveState Perl](https://www.activestate.com/activeperl/downloads) is
+* [Strawberry perl](https://strawberryperl.com): Used to run the test suite.[ActiveState Perl](https://www.activestate.com/products/perl/) is
   another Win32 Perl distribution and should work as well (but it is not as
   well tested). NOTE: `Cygwin` or `mingw` Perl versions will not work for testing. Use Windows native Perl, please.
 * Optional: If you intend to build the MSI packages, install [Windows Installer XML](https://wixtoolset.org/releases/) . If you build MSI with 10.4,

--- a/server/server-management/server-monitoring-logs/transaction-coordinator-log/transaction-coordinator-log-overview.md
+++ b/server/server-management/server-monitoring-logs/transaction-coordinator-log/transaction-coordinator-log-overview.md
@@ -93,7 +93,7 @@ This issue is known to occur when using docker. In that case, the problem may be
 * Pinning the docker instance to a specific MariaDB version in the docker compose file, so that it consistently uses the same version.
 * Running [mariadb-upgrade](../../../clients-and-utilities/deployment-tools/mariadb-upgrade.md) to ensure that the data directory is upgraded to match the server version.
 
-See [this docker issue](https://github.com/docker-library/mariadb/issues/201) for more information.
+See [this docker issue](https://github.com/MariaDB/mariadb-docker/issues/201) for more information.
 
 ### MariaDB Galera Cluster
 


### PR DESCRIPTION
Third slice of [DOCS-6451](https://mariadbcorp.atlassian.net/browse/DOCS-6451), and the other half of **Server** — the 33 external items the space-wide run surfaced. Companion to #1034 (Server's internal/markup defects); the two touch **disjoint** file sets, so they can merge in either order.

Every URL was re-probed with a browser UA over HTTP/1.1 before any decision, because lychee's verdict alone is wrong in both directions on this population: **six "failures" were live pages, and two "dead" ones were merely renamed.**

## Wayback substitutions (13)

Per Stefan's call. Each snapshot was chosen from the **CDX list by length**, not by proximity — `archive.org/wayback/available` returns the *closest* snapshot, which is routinely a husk of site chrome — then **body-checked for expected content**.

| Link | Why | Snapshot evidence |
|---|---|---|
| `mysqlserverteam.com` ×2 | Oracle retired the blog | titles "MySQL 5.7.12 – Part 6: MySQL Document Store", "What's New in MySQL 5.7? (Generally Available)" |
| `blogs.innodb.com` | same; serves Oracle's "Technical Difficulties" page | "Transactions on InnoDB", 35 `windows` hits |
| `geoffmontee.com` | NXDOMAIN | "Configuring LDAP Authentication and Group Mapping", 105 `ldap` hits |
| `technocation.org` PDF | 404 (now GitHub Pages) | 321 KB, `%PDF-` magic confirmed |
| `anchormodeling.com` PDF | 404 | 1.23 MB, `%PDF-` magic confirmed |
| `collation-charts.org` | NXDOMAIN | "Collation Charts", 23 `collation` hits |
| `blog.hjksolutions.com` | NXDOMAIN | "Unattended Package Installation with Debian and Ubuntu" |
| `tocker.ca` | dead S3 static site | "What to tune in MySQL 5.6 after installation" |
| `fusionio.com` | NXDOMAIN, absorbed by SanDisk | "Atomic Series :: Fusion-io" |
| `uuid7.com` | persistent Cloudflare 530 | "UUIDv7 Benefits", 8.5 KB |
| `buildbot.net` trac ×2 | trac retired | see below |

The two buildbot substitutions are the strongest of the set: the `RunningBuildbotOnWindows` snapshot **still contains the exact section the page cites by name** — "Windows Buildbot service setup" — and `UsingLaunchd` carries 27 `launchd` mentions plus `launchctl` and `plist`.

> **Gotcha worth recording: the CDX API is scheme-sensitive.** Querying the `https://` form of `UsingLaunchd` returned **0** snapshots; the scheme-less form returned five. I nearly unlinked a page that was archived all along.

## Retargeted to live pages (8)

- **Both GitHub "404s" were renamed repositories, not dead issues.** The authenticated API reports the canonical `html_url`: `prisma/prisma` → **`prisma/orm`**, and `docker-library/mariadb` → **`MariaDB/mariadb-docker`** (a pattern the workflow already excludes). Unauthenticated fetches 404 *consistently*, even with a browser UA — so this class can't be settled by probing at all, only by asking the API.
- **`kristiannielsen.livejournal.com` was never dead** — lychee rejected a 307 from `http` to `https`. Scheme fixed; the article is intact.
- **`rpbouman.blogspot.de` had `]\[Perentile_blog` appended to the URL.** The article is live; the real defects were that debris and the `.de` country domain. Fixed the link text's "Perentile" typo while there.
- **Percona** moved the PAM plugin page; the cited `#supplementary-groups-support` anchor was confirmed present on the new page *before* repointing.
- BuildBot Manual → `docs.buildbot.net/current`, Twisted → `twisted.org`, ActivePerl → `activestate.com/products/perl`, Osmosis → its GitHub repo.

> For those last four I deliberately chose live over Wayback. They are **download and installation pages**, where a 2011 or 2015 snapshot isn't preservation — it's stale instructions pointing at obsolete releases.

## Unlinked, text kept (3)

Nothing archived — verified by an **empty CDX result**, not assumed: a deleted blogspot blog, a `lists.mysql.org` commit mail, and an Ars Technica forum thread.

## Code-spanned (4)

These were never links to follow, which is why they couldn't be repaired *as* links — the DOCS-6523 pattern:

- `feedback.mariadb.org/rest/v1/post` appears three times and answers **405 Method Not Allowed** because it is POST-only: it's the endpoint the feedback plugin submits to, not a page.
- `http://vault-server/v1/my_vault` is a **placeholder hostname** in a HashiCorp Vault example — and was linked to itself.

## Excluded (2 hosts)

`portal.azure.com` and `www.ibm.com` serve real content to a browser and a bare **403** to anything else. Azure's two links are deep links into the portal, which needs a signed-in session. IBM retired Knowledge Center and 301s the three `db2look` links to equivalent `/docs/` topic paths — but the block covers the new paths too, **and Wayback has no snapshot of either form**, so the URLs are left exactly as they are rather than swapped for a target I cannot verify from here.

A/B on the two affected files: **errors 5 → 0, excluded 1 → 6, OK unchanged at 22.** Both exclude lists stay identical in content and order, 74 entries each.

## One file deliberately held back

`buildbot-setup-buildbot-setup-for-macosx.md`. Its `UsingLaunchd` fix is ready, but the page also cites `www.macports.org`, and **macports.org is currently down site-wide** — DNS resolves, port 443 is closed, and `www`, `ports` *and* `guide` all time out, while the project's GitHub is healthy. That's an outage of a live project: unlinking would be wrong, and an exclude would be worse — it's sticky, and it would blind the checker if MacPorts ever really did die. The file follows once the site is back.

## Checks

`doc-lint.sh` rc=0 on all 23 changed pages, **proven to have run** by a 404 canary in the same invocation (371 links / 335 OK). `actionlint`, `shellcheck`, `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6451]: https://mariadbcorp.atlassian.net/browse/DOCS-6451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ