### PR TITLE
DOCS-6451 Restore two lost page covers in the Platform space

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -147,6 +147,7 @@ if command -v lychee >/dev/null 2>&1; then
       --exclude 'www\.guru99\.com' \
       --exclude 'portal\.azure\.com' \
       --exclude 'www\.ibm\.com' \
+      --exclude 'www\.defense\.gov' \
       "${files[@]}" 2>&1)"; then
     # Mirror the workflow's failIfEmpty: false — lychee exits non-zero with
     # "No links were found" when the changed files contain no links, which is a

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -238,6 +238,12 @@ jobs:
           # its block applies to the new paths too and the Wayback Machine has NO
           # snapshot of either form -- so the URLs are left exactly as they are rather
           # than swapped for a target that cannot be verified from here.
+          #
+          # DOCS-6451: www.defense.gov answers every non-browser client with a bare
+          # 403 "Access Denied" -- Akamai bot/geo filtering in front of the US DoD
+          # homepage. The site is plainly live and it is cited once, as the referent
+          # of "DoD" beside the STIG certification press release, so there is nothing
+          # to repoint at.
           args: >-
             --no-progress
             --exclude 'bazaar\.launchpad\.net'
@@ -314,6 +320,7 @@ jobs:
             --exclude 'www\.guru99\.com'
             --exclude 'portal\.azure\.com'
             --exclude 'www\.ibm\.com'
+            --exclude 'www\.defense\.gov'
             ${{ steps.list.outputs.files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee

--- a/platform/mariadb-platform-quickstart-guides/mariadb-best-practices-guide.md
+++ b/platform/mariadb-platform-quickstart-guides/mariadb-best-practices-guide.md
@@ -1,5 +1,5 @@
 ---
-cover: broken-reference
+cover: ../.gitbook/assets/Group 15569 (2).png
 coverY: 0
 ---
 

--- a/platform/mariadb-platform-quickstart-guides/mariadb-overview-guide.md
+++ b/platform/mariadb-platform-quickstart-guides/mariadb-overview-guide.md
@@ -1,5 +1,5 @@
 ---
-cover: broken-reference
+cover: ../.gitbook/assets/Group 15570.png
 coverY: 0
 ---
 


### PR DESCRIPTION
Fourth slice of [DOCS-6451](https://mariadbcorp.atlassian.net/browse/DOCS-6451), after General Resources (#1033) and Server (#1034, #1035). **Platform** was picked next because it carries 200k views over 3 months behind only 11 external links — the cheapest remaining win — and it turned out that way.

## Measurement

| Check | Result |
|---|---|
| Links | 6,589 total / 1,701 unique across **841** pages |
| External errors | **1** |
| Relative link targets | 826 checked, **0** unresolvable |
| Dead heading anchors | **0** |
| `/broken/` | 0 |
| `broken-reference` | 2 → **0** |

Its 5,741 `app.gitbook.com` cross-space links all resolve. So the whole slice is two frontmatter lines and one exclude.

## Two lost page covers

Both quickstart guides carried `cover: broken-reference` — GitBook's marker for an asset it can no longer resolve — and **both pages emitted that literal string into their published HTML**. The sibling `security.md`, whose cover survived, does not. That asymmetry is what identified this as breakage rather than an author dropping a cover: a page with no cover has no `cover:`/`coverY:` field at all, as `README.md` in the same folder shows.

The history is a two-step accident spanning a month:

| When | Commit | What |
|---|---|---|
| 2025-11-18 | `c96916b76` — GITBOOK-135 "minor update" | **deleted** both PNGs and rewrote both `cover:` values to `broken-reference` |
| 2025-12-17 | `be8bfe933` — "GitBook: No commit message" | **re-added** both PNGs, but left the frontmatter pointing at nothing |

So the images have been sitting in the repo for **nine months** while the two pages referencing them rendered a broken cover.

This restores the exact paths `c96916b76` replaced, taken from that commit's own diff rather than guessed:

- `mariadb-overview-guide.md` → `Group 15570.png` (1,379,333 bytes)
- `mariadb-best-practices-guide.md` → `Group 15569 (2).png` (1,226,007 bytes)

Both assets are confirmed present in `HEAD` and byte-identical to the pre-deletion blobs by sha256, so **this PR adds no binaries** — it is two lines.

## One exclude

`www.defense.gov` answers every non-browser client with a bare **403 "Access Denied"** — Akamai filtering in front of the US DoD homepage — while plainly being live. It is cited once, as the referent of "DoD" beside the STIG certification press release, so there is nothing to repoint at.

A/B on `platform/README.md`: **errors 1 → 0, excluded 0 → 1, OK unchanged at 34.** Both exclude lists stay identical in content and order, 75 entries each.

## Checks

`doc-lint.sh` rc=0 on both changed pages, **proven to have run** by a 404 canary in the same invocation. `actionlint`, `shellcheck`, `bash -n` clean. 0 `broken-reference` occurrences remain anywhere in `platform`.

## Campaign status

| Space | Errors before | After |
|---|---|---|
| general-resources | 29 | 17, all on the vendor page held for the Foundation |
| home | 0 | 0 (swept, no PR needed) |
| server | 38 + 4 timeouts | 0, bar one file blocked on the MacPorts outage |
| **platform** | **1** | **0** |

Seven spaces to go. Suggested order: `galera-cluster`, `connectors`, `analytics`, `maxscale`, `tools`; `mariadb-cloud` measured-and-filed rather than fixed since it's Tauseef and Daria's; `release-notes` last — 67,421 links across 2,885 files at 6 views per link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOCS-6451]: https://mariadbcorp.atlassian.net/browse/DOCS-6451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ