### PR TITLE
DOCS-6451 Fix broken links in the Galera Cluster space

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -148,6 +148,8 @@ if command -v lychee >/dev/null 2>&1; then
       --exclude 'portal\.azure\.com' \
       --exclude 'www\.ibm\.com' \
       --exclude 'www\.defense\.gov' \
+      --exclude 'cloud\.ibm\.com' \
+      --exclude 'www\.akamai\.com' \
       "${files[@]}" 2>&1)"; then
     # Mirror the workflow's failIfEmpty: false — lychee exits non-zero with
     # "No links were found" when the changed files contain no links, which is a

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -244,6 +244,13 @@ jobs:
           # homepage. The site is plainly live and it is cited once, as the referent
           # of "DoD" beside the STIG certification press release, so there is nothing
           # to repoint at.
+          #
+          # DOCS-6451 (Galera slice): cloud.ibm.com returns 404 to lychee but 200 to a
+          # browser User-Agent on the same URL -- UA-gated, so the pages are live and
+          # both citations are correct. www.akamai.com is the new home of the Linode
+          # docs library (www.linode.com/docs/guides/... now 301s there); it serves 403
+          # to every scripted client, which is why the old linode.com URL surfaced as a
+          # 403 rather than as the redirect it actually is.
           args: >-
             --no-progress
             --exclude 'bazaar\.launchpad\.net'
@@ -321,6 +328,8 @@ jobs:
             --exclude 'portal\.azure\.com'
             --exclude 'www\.ibm\.com'
             --exclude 'www\.defense\.gov'
+            --exclude 'cloud\.ibm\.com'
+            --exclude 'www\.akamai\.com'
             ${{ steps.list.outputs.files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee

--- a/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-guide.md
+++ b/analytics/mariadb-columnstore/columnstore-quickstart-guides/mariadb-columnstore-guide.md
@@ -93,7 +93,7 @@ SELECT COUNT(DISTINCT product_name) FROM sales_data;
 ## See Also
 
 * [MariaDB ColumnStore Overview](https://mariadb.com/products/columnstore/)
-* [DigitalOcean: How to Install MariaDB ColumnStore on Ubuntu 20.04](https://www.google.com/search?q=https://www.digitalocean.com/community/tutorials/how-to-install-mariadb-columnstore-on-ubuntu-20-04\&authuser=1)
+* [DigitalOcean: How to Install MariaDB ColumnStore on Ubuntu 20.04](https://www.digitalocean.com/community/tutorials/how-to-install-mariadb-columnstore-on-ubuntu-20-04)
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 

--- a/connectors/connectors-quickstart-guides/mariadb-connector-erlang-guide.md
+++ b/connectors/connectors-quickstart-guides/mariadb-connector-erlang-guide.md
@@ -59,7 +59,7 @@ mysql:stop(Pid).
 #### Further Resources:
 
 * [MySQL/OTP GitHub Repository](https://github.com/mysql-otp/mysql-otp)
-* [Erlang/OTP Documentation](https://www.google.com/search?q=http://erlang.org/doc/man/mysql.html\&authuser=1)
+* [Erlang/OTP Documentation](https://www.erlang.org/docs)
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 

--- a/connectors/connectors-quickstart-guides/mariadb-connector-r2dbc-guide.md
+++ b/connectors/connectors-quickstart-guides/mariadb-connector-r2dbc-guide.md
@@ -152,7 +152,7 @@ MariaDB Connector/R2DBC also integrates seamlessly with the Spring Data R2DBC fr
 
 * [MariaDB Connector/R2DBC GitHub Repository](https://github.com/mariadb-corporation/mariadb-connector-r2dbc)
 * [R2DBC Specification](https://r2dbc.io/spec/)
-* [Spring Data R2DBC Documentation](https://www.google.com/search?q=https://docs.spring.io/spring-data/relational/reference/r2dbc/index.html\&authuser=1)
+* [Spring Data R2DBC Documentation](https://docs.spring.io/spring-data/relational/reference/r2dbc.html)
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 

--- a/connectors/other/mariadb-connector-erlang-guide.md
+++ b/connectors/other/mariadb-connector-erlang-guide.md
@@ -134,7 +134,7 @@ io:format("Connection closed.~n").
 #### Further Resources:
 
 * [MySQL/OTP GitHub Repository](https://github.com/mysql-otp/mysql-otp)
-* [Erlang/OTP Documentation](https://www.google.com/search?q=http://erlang.org/doc/man/mysql.html\&authuser=1) (if available on the official Erlang docs)
+* [Erlang/OTP Documentation](https://www.erlang.org/docs)
 
 <sub>_This page is: Copyright © 2026 MariaDB. All rights reserved._</sub>
 

--- a/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-guide.md
+++ b/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-guide.md
@@ -181,8 +181,7 @@ This confirms synchronous replication is working.
 
 #### Further Resources:
 
-* [How to Set up MariaDB Galera Clusters on Ubuntu 22.04 (Linode)](https://www.linode.com/docs/guides/how-to-set-up-mariadb-galera-clusters-on-ubuntu-2204/)
-* [MariaDB Galera Cluster - Binary Installation (galeracluster.com)](https://galeracluster.com/documentation/html_docs_mariadb-installation/documentation/install-mariadb.html)
+* [How to Set up MariaDB Galera Clusters on Ubuntu 22.04 (Akamai Cloud)](https://www.akamai.com/cloud/guides/how-to-set-up-mariadb-galera-clusters-on-ubuntu-2204/)
 * [Getting Started with MariaDB Galera Cluster (MariaDB.com/kb)](../galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster.md)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-replication-guide.md
+++ b/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-replication-guide.md
@@ -36,8 +36,7 @@ Galera Replication essentially transforms a set of individual MariaDB servers in
 
 #### Further Resources:
 
-* [MariaDB Galera Cluster Guide](https://mariadb.com/docs/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-guides)
-* [Galera Cluster Documentation (Primary Site)](https://www.google.com/search?q=https://galeracluster.com/documentation/html_docs_galera/galera-overview.html\&authuser=1)
+* [MariaDB Galera Cluster Guide](mariadb-galera-cluster-guide.md)
 * [MariaDB documentation - Galera Cluster](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-usage-guide.md
+++ b/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-usage-guide.md
@@ -150,7 +150,7 @@ By following these guidelines, you can effectively manage and operate your Maria
 ## Further Resources:
 
 * [MariaDB Galera Cluster Guide](https://mariadb.com/docs/galera-cluster/galera-cluster-quickstart-guides/mariadb-galera-cluster-guide)
-* [Galera Cluster Documentation - Operational Aspects](https://www.google.com/search?q=https://galeracluster.com/documentation/html_docs_galera/operational_aspects.html\&authuser=1)
+* [Performing Schema Upgrades in Galera Cluster](../galera-management/general-operations/performing-schema-upgrades-in-galera-cluster.md)
 * [MariaDB documentation - Galera Cluster Best Practices](mariadb-galera-cluster-usage-guide.md#application-best-practices)
 * [MariaDB documentation - Galera Cluster Monitor](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/reference/maxscale-monitors/galera-monitor)
 

--- a/galera-cluster/galera-management/configuration/galera-arbitrator-daemon-garbd.md
+++ b/galera-cluster/galera-management/configuration/galera-arbitrator-daemon-garbd.md
@@ -149,7 +149,7 @@ GALERA_NODES="192.168.1.1:4567 192.168.1.2:4567"
 GALERA_GROUP="example_wsrep_cluster"
 
 # Optional Galera internal options string (such as SSL settings)
-# see https://galeracluster.com/documentation/galera-parameters.html
+# see https://mariadb.com/docs/galera-cluster/reference/galera-cluster-system-variables
 GALERA_OPTIONS="socket.ssl=yes;socket.ssl_cert=/etc/galera/cert/cert.pem;socket.ssl_key=/$"
 
 # Log file for garbd. Optional, by default logs to syslog

--- a/galera-cluster/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster.md
+++ b/galera-cluster/galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster.md
@@ -237,7 +237,7 @@ The cluster nodes can be configured to invoke a command when cluster membership 
 * [About Galera Replication](../../readme/about-galera-replication.md)
 * [Galera Use Cases](../../galera-use-cases.md)
 * [Galera Cluster documentation: Notification Command](../configuration/using-the-notification-command-wsrep_notify_cmd.md)
-* [Introducing the “Safe-To-Bootstrap” feature in Galera Cluster](https://galeracluster.com/2016/11/introducing-the-safe-to-bootstrap-feature-in-galera-cluster/)
+* [Introducing the “Safe-To-Bootstrap” feature in Galera Cluster](https://web.archive.org/web/20250701212656/https://galeracluster.com/2016/11/introducing-the-safe-to-bootstrap-feature-in-galera-cluster/)
 * [Github - galera](https://github.com/codership/galera/)
 * [Github - mysql-wsrep](https://github.com/codership/mysql-wsrep/)
 

--- a/galera-cluster/galera-management/installation-and-deployment/tips-on-converting-to-galera.md
+++ b/galera-cluster/galera-management/installation-and-deployment/tips-on-converting-to-galera.md
@@ -146,7 +146,7 @@ GRANTs and related operations act on the MyISAM tables in the database `mysql`. 
 
 Many DDL changes on Galera can be achieved without downtime, even if they take a long time.
 
-[RSU vs TOI](https://galeracluster.com/documentation-webpages/documentation/schema-upgrades.html):
+[RSU vs TOI](../general-operations/performing-schema-upgrades-in-galera-cluster.md):
 
 * Rolling Schema Upgrade (RSU): manually execute the DDL on each node in the cluster. The node will desync while executing the DDL.
 * Total Order Isolation (TOI): Galera automatically replicates the DDL to each node in the cluster, and it synchronizes each node so that the statement is executed at same time (in the replication sequence) on all nodes.

--- a/galera-cluster/galera-management/state-snapshot-transfers-ssts-in-galera-cluster/mariabackup-sst-method.md
+++ b/galera-cluster/galera-management/state-snapshot-transfers-ssts-in-galera-cluster/mariabackup-sst-method.md
@@ -191,7 +191,7 @@ This should allow your SSTs to be encrypted.
 
 ### TLS Using OpenSSL Encryption with Galera-compatible Certificates and Keys
 
-To generate keys compatible with this encryption method, you can follow [Certificate Creation With OpenSSL]({server}/security/encryption/data-in-transit-encryption/certificate-creation-with-openssl).
+To generate keys compatible with this encryption method, you can follow [Certificate Creation With OpenSSL](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/certificate-creation-with-openssl).
 
 For example:
 

--- a/galera-cluster/galera-management/state-snapshot-transfers-ssts-in-galera-cluster/mariabackup-sst-method.md
+++ b/galera-cluster/galera-management/state-snapshot-transfers-ssts-in-galera-cluster/mariabackup-sst-method.md
@@ -191,7 +191,7 @@ This should allow your SSTs to be encrypted.
 
 ### TLS Using OpenSSL Encryption with Galera-compatible Certificates and Keys
 
-To generate keys compatible with this encryption method, you can follow [these directions](https://galeracluster.com/library/documentation/ssl-cert.html).
+To generate keys compatible with this encryption method, you can follow [Certificate Creation With OpenSSL]({server}/security/encryption/data-in-transit-encryption/certificate-creation-with-openssl).
 
 For example:
 
@@ -286,8 +286,8 @@ In some cases, if Galera Cluster's automatic SSTs repeatedly fail, then it can b
 * [Percona XtraBackup SST Configuration](https://www.percona.com/doc/percona-xtradb-cluster/5.7/manual/xtrabackup_sst.html)
 * [Encrypting PXC Traffic:\
   ENCRYPTING SST TRAFFIC](https://www.percona.com/doc/percona-xtradb-cluster/5.7/security/encrypt-traffic.html#encrypt-sst)
-* [XTRABACKUP PARAMETERS](https://galeracluster.com/library/documentation/xtrabackup-options.html)
-* [SSL FOR STATE SNAPSHOT TRANSFERS: ENABLING SSL FOR XTRABACKUP](https://galeracluster.com/library/documentation/ssl-sst.html#ssl-xtrabackup)
+* [MariaDB Backup SST Method](../../high-availability/state-snapshot-transfers-ssts-in-galera-cluster/mariadb-backup-sst-method.md)
+* [Securing Communications in Galera Cluster](../../galera-security/securing-communications-in-galera-cluster.md)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/introduction-to-state-snapshot-transfers-ssts.md
+++ b/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/introduction-to-state-snapshot-transfers-ssts.md
@@ -217,10 +217,6 @@ SST scripts can't currently read the mysqld<#> [option group](https://app.gitboo
 
 See [MDEV-18863](https://jira.mariadb.org/browse/MDEV-18863) for more information.
 
-## See Also
-
-* [Galera Cluster documentation: STATE SNAPSHOT TRANSFERS](https://galeracluster.com/library/documentation/sst.html)
-
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 
 {% @marketo/form formId="4316" %}

--- a/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/mariadb-backup-sst-method.md
+++ b/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/mariadb-backup-sst-method.md
@@ -305,7 +305,7 @@ Make sure to replace the paths with whatever is relevant on your system. This sh
 
 ### TLS Using OpenSSL Encryption With Galera-Compatible Certificates and Keys <a href="#tls-using-openssl-encryption-with-galera-compatible-certificates-and-keys" id="tls-using-openssl-encryption-with-galera-compatible-certificates-and-keys"></a>
 
-To generate keys compatible with this encryption method, follow [these directions](https://galeracluster.com/library/documentation/ssl-cert.html).
+To generate keys compatible with this encryption method, follow [Certificate Creation With OpenSSL]({server}/security/encryption/data-in-transit-encryption/certificate-creation-with-openssl).
 
 First, generate the keys and certificates:
 
@@ -427,8 +427,7 @@ If Galera Cluster's automatic SSTs repeatedly fail, it can be helpful to perform
 
 * [Percona XtraBackup SST Configuration](https://www.percona.com/doc/percona-xtradb-cluster/5.7/manual/xtrabackup_sst.html)
 * [Encrypting PXC Traffic: ENCRYPTING SST TRAFFIC](https://docs.percona.com/percona-xtradb-cluster/5.7/security/encrypt-traffic.html#encrypt-sst)
-* [XTRABACKUP PARAMETERS](https://galeracluster.com/library/documentation/xtrabackup-options.html)
-* [SSL FOR STATE SNAPSHOT TRANSFERS: ENABLING SSL FOR XTRABACKUP](https://galeracluster.com/library/documentation/ssl-sst.html#ssl-xtrabackup)
+* [Securing Communications in Galera Cluster](../../galera-security/securing-communications-in-galera-cluster.md)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/mariadb-backup-sst-method.md
+++ b/galera-cluster/high-availability/state-snapshot-transfers-ssts-in-galera-cluster/mariadb-backup-sst-method.md
@@ -305,7 +305,7 @@ Make sure to replace the paths with whatever is relevant on your system. This sh
 
 ### TLS Using OpenSSL Encryption With Galera-Compatible Certificates and Keys <a href="#tls-using-openssl-encryption-with-galera-compatible-certificates-and-keys" id="tls-using-openssl-encryption-with-galera-compatible-certificates-and-keys"></a>
 
-To generate keys compatible with this encryption method, follow [Certificate Creation With OpenSSL]({server}/security/encryption/data-in-transit-encryption/certificate-creation-with-openssl).
+To generate keys compatible with this encryption method, follow [Certificate Creation With OpenSSL](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/security/encryption/data-in-transit-encryption/certificate-creation-with-openssl).
 
 First, generate the keys and certificates:
 

--- a/galera-cluster/readme/about-galera-replication.md
+++ b/galera-cluster/readme/about-galera-replication.md
@@ -32,7 +32,7 @@ Galera's replication is not completely synchronous. It is sometimes called **vir
 An alternative approach to synchronous replication that uses group communication and transaction ordering techniques was suggested by a number of researchers. For example:
 
 * [Database State Machine Approach](https://doi.org/10.5075/epfl-thesis-2090)
-* [Don't Be Lazy, Be Consistent](https://www.cs.mcgill.ca/~kemme/papers/vldb00.html)
+* [Don't Be Lazy, Be Consistent](https://web.archive.org/web/20230407232449/https://www.cs.mcgill.ca/~kemme/papers/vldb00.html)
 
 Prototype implementations have shown a lot of promise. We combined our experience in synchronous database replication and the latest research in the field to create the Galera Replication library and the wsrep API.
 
@@ -76,7 +76,7 @@ In older versions of MariaDB Cluster, there was a 2GB limit on the size of the t
 
 Using streaming replication, the node breaks huge transactions up into smaller and more manageable fragments; it then replicates these fragments to the cluster as it works instead of waiting for the commit. Once certified, the fragment can no longer be aborted by conflicting transactions. As this can have performance consequences both during execution and in the event of rollback, it is recommended that you only use it with large transactions that are unlikely to experience conflict.
 
-For more information on streaming replication, see the [Galera](https://galeracluster.com/library/documentation/streaming-replication.html) documentation.
+For more information, see [Using Streaming Replication for Large Transactions](../galera-management/performance-tuning/using-streaming-replication-for-large-transactions.md).
 
 ## Group Commits
 
@@ -84,11 +84,11 @@ Group Commit support for MariaDB Cluster was introduced in Galera 4.
 
 In MariaDB Group Commit, groups of transactions are flushed together to disk to improve performance. In previous versions of MariaDB, this feature was not available in MariaDB Cluster, as it interfered with the global ordering of transactions for replication. MariaDB Cluster can now take advantage of Group Commit.
 
-For more information on Group Commit, see the [Galera](https://galeracluster.com/library/kb/group-commit.html) documentation.
+For more information on Group Commit, see the [Galera Cluster documentation on Group Commit](https://web.archive.org/web/20220714085516/https://galeracluster.com/library/kb/group-commit.html).
 
 ## See Also
 
-* [Galera Cluster: Galera Replication](https://galeracluster.com/products/)
+* [Galera Cluster: Galera Replication](https://mariadb.com/products/enterprise/galera-cluster/)
 * [What is MariaDB Galera Cluster?](mariadb-galera-cluster-guide.md)
 * [Galera Use Cases](../galera-use-cases.md)
 * [Getting Started with MariaDB/Galera Cluster](../galera-management/installation-and-deployment/getting-started-with-mariadb-galera-cluster.md)

--- a/galera-cluster/readme/mariadb-galera-cluster-guide.md
+++ b/galera-cluster/readme/mariadb-galera-cluster-guide.md
@@ -50,7 +50,7 @@ The functionality of MariaDB Galera Cluster can be obtained by installing the st
 * In [MariaDB 10.4](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.4/what-is-mariadb-104) and later, MariaDB Galera Cluster uses [Galera](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/) 4. This means that the wsrep API version is 26 and the [Galera wsrep provider library](https://github.com/codership/galera/) is version 4.X.
 * In [MariaDB 10.3](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.3/what-is-mariadb-103) and before, MariaDB Galera Cluster uses [Galera](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/3VYeeVGUV4AMqrA3zwy7/) 3. This means that the wsrep API is version 25 and the [Galera wsrep provider library](https://github.com/codership/galera/) is version 3.X.
 
-See [Deciphering Galera Version Numbers](https://galeracluster.com/library/documentation/versioning-information.html/) for more information about how to interpret these version numbers.
+See [Versioning Information](https://web.archive.org/web/20190722120303/https://galeracluster.com/library/documentation/versioning-information.html) for more information about how to interpret these version numbers.
 
 ### Galera 4 Versions
 

--- a/galera-cluster/reference/galera-cluster-system-variables.md
+++ b/galera-cluster/reference/galera-cluster-system-variables.md
@@ -358,7 +358,7 @@ Multiple nodes in a cluster can share the same name, but unique names are advise
 
 #### `wsrep_notify_cmd`
 
-* Description: Command to be executed each time the node state or the cluster membership changes. Can be used for raising an alarm, configuring load balancers and so on. See the [Codership Notification Script page](https://galeracluster.com/library/documentation/notification-cmd.html) for more details.
+* Description: Command to be executed each time the node state or the cluster membership changes. Can be used for raising an alarm, configuring load balancers and so on. See [Using the Notification Command (wsrep_notify_cmd)](../galera-management/configuration/using-the-notification-command-wsrep_notify_cmd.md) for more details.
 * Command line: `--wsrep-notify-command=value`
 * Scope: Global
 * Dynamic: No

--- a/galera-cluster/reference/mariadb-galera-cluster-known-limitations.md
+++ b/galera-cluster/reference/mariadb-galera-cluster-known-limitations.md
@@ -43,7 +43,7 @@ These behaviors were verified in the 2026 Jepsen safety analysis. Developers sho
 * `FLUSH PRIVILEGES` is not replicated.
 * The [query cache](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/optimization-and-tuning/buffers-caches-and-threads/query-cache) needed to be disabled by setting [query\_cache\_size=0](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#query_cache_size) prior to MariaDB Galera Cluster 5.5.40, MariaDB Galera Cluster 10.0.14, and [MariaDB 10.1.2](https://app.gitbook.com/s/aEnK0ZXmUbJzqQrTjFyb/community-server/old-releases/10.1/10.1.2)
 * In an asynchronous replication setup where a master replicates to a Galera node acting as a slave, parallel replication (slave-parallel-threads > 1) on the slave is currently not supported (see [MDEV-6860](https://jira.mariadb.org/browse/MDEV-6860)).
-* The disk-based [Galera gcache](https://galeracluster.com/library/documentation/state-transfer.html#write-set-cache-gcache) is not encrypted ([MDEV-8072](https://jira.mariadb.org/browse/MDEV-8072)).
+* The disk-based [Galera gcache](../high-availability/rapid-node-recovery-with-ist-and-the-gcache.md) is not encrypted ([MDEV-8072](https://jira.mariadb.org/browse/MDEV-8072)).
 * Nodes may have different table definitions, especially temporarily during [rolling schema upgrade](galera-cluster-system-variables.md#wsrep_osu_method) operations, but the same [schema compatibility restrictions](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/ha-and-performance/standard-replication/replication-when-the-primary-and-replica-have-different-table-definitions) apply as they do for row-based replication
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>

--- a/galera-cluster/reference/wsrep-variable-details/wsrep_provider_options.md
+++ b/galera-cluster/reference/wsrep-variable-details/wsrep_provider_options.md
@@ -47,7 +47,7 @@ Note that before Galera 3, the `repl` tag was named `replicator`.
 
 #### `evs.auto_evict`
 
-* Description: Number of entries the node permits for a given delayed node before triggering the Auto Eviction protocol. An entry is added to a delayed list for each delayed response from a node. If set to `0`, the default, the Auto Eviction protocol is disabled for this node. See [Auto Eviction](https://galeracluster.com/library/documentation/auto-eviction.html) for more.
+* Description: Number of entries the node permits for a given delayed node before triggering the Auto Eviction protocol. An entry is added to a delayed list for each delayed response from a node. If set to `0`, the default, the Auto Eviction protocol is disabled for this node. See [Configuring Auto Eviction](../../galera-management/configuration/configuring-auto-eviction.md) for more.
 * Dynamic: No
 * Default: `0`
 
@@ -454,7 +454,7 @@ Note that before Galera 3, the `repl` tag was named `replicator`.
 
 #### `pc.weight`
 
-* Description: Node weight, used for quorum calculation. See the Codership article [Weighted Quorum](https://galeracluster.com/library/documentation/weighted-quorum.html#weighted-quorum).
+* Description: Node weight, used for quorum calculation. See [Quorum Control With Weighted Votes](../../galera-architecture/quorum-control-with-weighted-votes.md).
 * Dynamic: Yes
 * Default: `1`
 
@@ -584,7 +584,7 @@ Note that before Galera 3, the `repl` tag was named `replicator`.
 
 ## See Also
 
-* [Galera parameters documentation from Codership](https://galeracluster.com/library/documentation/galera-parameters.html)
+* [Galera Cluster System Variables](../galera-cluster-system-variables.md)
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>
 

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-oracle/oracle-xe-112-and-mariadb-101-integration-on-ubuntu-1404-and-debian-systems.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/migrating-to-mariadb-from-oracle/oracle-xe-112-and-mariadb-101-integration-on-ubuntu-1404-and-debian-systems.md
@@ -312,7 +312,7 @@ mkdir ~/.sqldeveloper
 Follow the official instructions on the MariaDB website for your specific OS version.
 
 {% hint style="danger" %}
-Do NOT copy the commands below. Go to the [MariaDB Repository Configuration Tool](https://www.google.com/search?q=https://mariadb.org/mariadb/repositories/) to generate the correct commands for your system. The following is only an example.
+Do NOT copy the commands below. Go to the [MariaDB Repository Configuration Tool](https://mariadb.org/download/?t=repo-config) to generate the correct commands for your system. The following is only an example.
 {% endhint %}
 
 ```bash

--- a/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/migration-from-mysql-to-mariadb-cluster-node-by-node-in-place.md
+++ b/server/server-management/install-and-upgrade-mariadb/migrating-to-mariadb/moving-from-mysql/migration-from-mysql-to-mariadb-cluster-node-by-node-in-place.md
@@ -51,7 +51,7 @@ MySQL 8.0 defaults to `caching_sha256_password`. MariaDB does not support the `c
 
 **Support Status:**
 
-* Implemented via [MDEV-9804](https://www.google.com/search?q=https://jira.mariadb.org/browse/MDEV-9804) for version 12.1.1.
+* Implemented via [MDEV-9804](https://jira.mariadb.org/browse/MDEV-9804) for version 12.1.1.
 * Available in the CS release based on [MDEV-37600](https://jira.mariadb.org/browse/MDEV-37600).
 * Already supported in 11.8 Enterprise Server via [MENT-2359](https://jira.mariadb.org/browse/MENT-2359).
 * Available in 11.4 Enterprise Server with the December 2025 release as a rebase of [MDEV-37600](https://jira.mariadb.org/browse/MDEV-37600).

--- a/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-mariadb-enterprise-server-from-10.6-to-11.4.md
+++ b/server/server-management/install-and-upgrade-mariadb/upgrading/upgrade-paths/mariadb-enterprise-server-11.4/upgrade-mariadb-enterprise-server-from-10.6-to-11.4.md
@@ -46,7 +46,7 @@ sudo mariadb-backup --backup \
 {% step %}
 **Modify Repository Configuration**
 
-Update your system's package manager repository to point to MariaDB Enterprise Server 11.4. You will need to regenerate your repository configuration command using the [MariaDB Customer Download Token](https://www.google.com/search?q=https://dlm.mariadb.com/).
+Update your system's package manager repository to point to MariaDB Enterprise Server 11.4. You will need to regenerate your repository configuration command using the [MariaDB Customer Download Token](https://dlm.mariadb.com/).
 
 {% tabs %}
 {% tab title="APT (Debian/Ubuntu)" %}

--- a/server/server-usage/storage-engines/innodb/innodb-page-flushing.md
+++ b/server/server-usage/storage-engines/innodb/innodb-page-flushing.md
@@ -44,7 +44,7 @@ The amount of I/O capacity available to InnoDB can be configured by setting the 
 SET GLOBAL innodb_io_capacity=20000;
 ```
 
-The maximum amount of I/O capacity available to InnoDB in an emergency defaults to either `2000` or twice `innodb_io_capacity`, whichever is higher, or can be directly configured by setting the [innodb\_io\_capacity\_max](https://www.google.com/search?q=innodb-system-variables.md%23innodb_io_capacity_max) system variable.
+The maximum amount of I/O capacity available to InnoDB in an emergency defaults to either `2000` or twice `innodb_io_capacity`, whichever is higher, or can be directly configured by setting the [innodb\_io\_capacity\_max](innodb-system-variables.md#innodb_io_capacity_max) system variable.
 
 #### Device-Specific Recommendations
 


### PR DESCRIPTION
Fifth slice of DOCS-6451. General Resources, Home, Server and Platform are merged; this is **galera-cluster** (105 files, 1,884 links).

## What CI's own checker found

Five errors. What it *didn't* find is the more interesting half.

## The galeracluster.com problem

Every one of the 20 `galeracluster.com` links in our Galera space now 301s back into `mariadb.com`. lychee scores 19 of them green, because a redirect that ends in 200 is a pass. For a reader they are anything but:

| Where the redirect lands | Count | Fix |
|---|---|---|
| A specific, live page in our own docs | 12 | relative link to that page |
| The `galera-cluster` front page (topic lost) | 4 | our own page on the topic, found by hand |
| `mariadb.com/products/...` (content gone) | 3 | Wayback, or the resolved product URL |
| 404 | 1 | our own page (the redirect has a stale extra path segment) |

Two of them pointed at **the page they were on**: `sst.html` → Introduction to SSTs, from Introduction to SSTs; `xtrabackup-options.html` → MariaDB Backup SST Method, from MariaDB Backup SST Method. Both bullets removed.

One resolves to the **wrong content**: the "Galera gcache" citation in Known Limitations redirects to Introduction to SSTs, which contains the string `gcache` exactly zero times. Repointed at *Rapid Node Recovery With IST and the GCache* (9 mentions).

Three had no live equivalent and went to Wayback, each body-checked for the right topic before use: the Safe-To-Bootstrap announcement, Versioning Information, and the Group Commit KB page.

## Google-search-wrapped URLs (repo-wide)

A defect class no checker can see. Ten links across five spaces have an `href` of the form:

```
https://www.google.com/search?q=<the real URL>\&authuser=1
```

lychee passes every one — Google answers 200. The reader lands on a Google search results page. The tell is the `\&authuser=1` suffix; it looks like an AI-assisted authoring export that emitted the search URL instead of the target.

All ten unwrapped. Three of the unwrapped targets were themselves dead and needed a real fix rather than an unwrap: Erlang/OTP has no `man/mysql.html` (the MySQL/OTP repo was already the bullet above it, so the label now points at `erlang.org/docs`); Spring Data R2DBC moved to `.../reference/r2dbc.html`; and the MariaDB repo config tool is now `mariadb.org/download/?t=repo-config`. One was not even an external link — `?q=innodb-system-variables.md%23innodb_io_capacity_max`, a *relative markdown path* wrapped in a Google search, restored to the sibling-file form the rest of that page already uses.

## The Linode 403

`www.linode.com/docs/guides/how-to-set-up-mariadb-galera-clusters-on-ubuntu-2204/` reported 403. It is not a bot block — Linode's docs library moved to Akamai, and the 403 was masking a 301 to `www.akamai.com/cloud/guides/<same slug>`. Confirmed the target renders as *How to Set up MariaDB Galera Clusters on Ubuntu 22.04*, last updated 2024-05-09. Retargeted and relabelled.

## Excludes (+2, now 77)

* `cloud\.ibm\.com` — returns 404 to lychee and 200 to a browser User-Agent on the identical URL. UA-gated; both citations are correct.
* `www\.akamai\.com` — 403 to every scripted client, including the URL above that WebFetch renders fine.

A/B-verified on the space: excluded 9 → 20, errors 3 → 1 (the deliberate canary).

## Verification

* `doc-lint.sh` over all 22 changed pages: **exit 0**, 28s. Proved live with a `no-such-page-canary` run first (exit 1, caught the 404) so the pass isn't the silent-skip false pass.
* Full-space lychee, CI-exact excludes derived programmatically from the workflow: **1,884 links, 1 error — the canary**. Redirects fell 47 → 26.
* Offline relative-link resolver over the space plus every changed file elsewhere: **0 unresolved**.
* `fragcheck.py` repo-wide: 15 dead, all pre-existing in `tools/mariadb-enterprise-operator/api-reference.md`, none introduced.
* Exclude parity workflow ↔ doc-lint: 77 / 77, identical.

## Campaign status

| Space | State |
|---|---|
| general-resources | merged (#1033) |
| home + server | merged (#1034, #1035) |
| platform | merged (#1036) |
| **galera-cluster** | **this PR** |
| connectors, analytics, maxscale, tools | to go |
| mariadb-cloud | measure and file only — Tauseef and Daria's space |
| release-notes | last; 67,421 links across 2,885 files |

Still parked, unchanged: `www.macports.org` is down site-wide, holding one server-space fix; and the General Resources vendor page waits on Daniel Black.
