### PR TITLE
DOCS-6451 Fix a dead BuildBot link, and teach fragcheck about tab anchors

### DIFF
--- a/.claude/hooks/fragcheck.py
+++ b/.claude/hooks/fragcheck.py
@@ -22,6 +22,24 @@ WHICH HEADINGS PUBLISH AN ANCHOR:  h2, h3 and h4 ONLY  (DOCS-6503)
     retarget the link at the enclosing section -- never to promote a bold paragraph
     to "#####", which reads as a fix and repairs nothing.
 
+HEADINGS ARE NOT THE ONLY ANCHOR SOURCE:  {% tab title="..." %}  (DOCS-6451)
+    GitBook gives every tab panel id="<slug of the title>" (and its button
+    id="tab-<slug>"), using the same slug rules as a heading and drawing from the
+    SAME per-page id namespace, in document order. So a tab and a heading that slug
+    alike are de-duplicated against each other, not separately. Proven on
+    server/reference/sql-statements/data-definition/atomic-ddl.md, where the tab
+    titled "Background" (line 15) publishes id="background" and the later
+    "## Background" (line 30) is pushed to id="background-1" -- both read off the
+    rendered page. 927 tab titles across the tree.
+
+    Crediting them makes the checker wrong in the PESSIMISTIC direction if omitted:
+    a link to a tab anchor resolves for the reader while the checker calls it dead.
+    That is how this was found -- a cross-space link to
+    mariadb-package-repository-setup-and-usage#mariadb_es_repo_setup was reported
+    as a dead anchor, and the anchor is on the live page, published by a tab.
+    A bare {% tab %} with no title publishes nothing addressable (3 in the tree),
+    so it contributes no anchor.
+
 THE SLUG RULES  (each derived from a rendered id="..." on mariadb.com/docs)
     * lowercase; dots and underscores survive
     * an explicit <a ... id="x"> inside the heading line WINS over the text slug
@@ -120,6 +138,14 @@ FOOTNOTE_ANCHOR = re.compile(r'^user-content-fn(?:ref)?-(.+)$')
 CODESPAN = re.compile(r'`+([^`]*)`+')
 LINK = re.compile(r'\]\(\s*<?([^)>\s]+)>?\s*\)')
 ATTR = re.compile(r'''\b(?:href|url)\s*=\s*["']([^"']+)["']''')
+# GitBook gives every {% tab %} panel an id built from its title, with the same
+# slug rules and the same -1/-2 de-duplication as a heading -- and out of the SAME
+# per-page namespace, in document order. Proven on
+# server/reference/sql-statements/data-definition/atomic-ddl.md, where a tab
+# titled "Background" (line 15) publishes id="background" and the later
+# "## Background" (line 30) is pushed to "background-1". 927 tab titles repo-wide.
+# A bare {% tab %} with no title publishes nothing addressable, so it is skipped.
+TAB_TITLE = re.compile(r'\{%\s*tab\s+title="([^"]*)"\s*%\}')
 SKIP_PREFIX = ('http://', 'https://', 'mailto:', 'ftp://', '//', '/')
 
 # Spelled out instead of collapsing to a dash. Every entry was read off a rendered
@@ -253,11 +279,24 @@ def anchored_headings(path):
     return [h for h in headings_of(path) if h[1] in ANCHORED]
 
 
+def anchor_sources(path):
+    """(line_no, text, explicit_id_or_None) for everything that publishes an
+    anchor, in document order: anchored headings and {% tab %} titles."""
+    out = [(n, text, explicit) for n, _, text, explicit in anchored_headings(path)]
+    for n, line, in_fence in content_lines(path):
+        if in_fence:
+            continue
+        for title in TAB_TITLE.findall(line):
+            out.append((n, title, None))
+    out.sort(key=lambda r: r[0])
+    return out
+
+
 def anchors_of(path):
     """Anchors a markdown file publishes, in document order."""
     seen = Counter()
     out = []
-    for _, _, text, explicit in anchored_headings(path):
+    for _, text, explicit in anchor_sources(path):
         base = explicit if explicit else gitbook_slug(text)
         if not base:
             continue

--- a/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-buildbot-setup-for-macosx.md
+++ b/server/reference/product-development/server-development/tools/buildbot/setup/buildbot-setup-buildbot-setup-for-macosx.md
@@ -177,7 +177,7 @@ sudo cp /sw/share/doc/buildbot-py26/contrib/os-x/net.sourceforge.buildbot.slave.
 ```
 
 {% hint style="warning" %}
-You have to start your build slave via `launchd`, otherwise you will run into several problems. For further details, please refer to [Using Launchd](https://buildbot.net/trac/wiki/UsingLaunchd).
+You have to start your build slave via `launchd`, otherwise you will run into several problems. For further details, please refer to [Using Launchd](https://web.archive.org/web/20101206223248/http://buildbot.net/trac/wiki/UsingLaunchd).
 {% endhint %}
 
 <sub>_This page is licensed: CC BY-SA / Gnu FDL_</sub>


### PR DESCRIPTION
Two things, both fallout from the Connectors slice. Stefan asked me to fold these in rather than spend another DOCS ticket on them.

---

## 1. The last parked file from the Server slice

`buildbot.net/trac/wiki/UsingLaunchd` 404s — the Trac wiki is gone. It was held out of #1035 because `www.macports.org`, cited two lines away on the same page, was down site-wide and I could not tell rot from outage. **MacPorts answers 200 again**, so that link needs no change; this one link is the whole content diff.

Buildbot's current docs have **no launchd page** (`docs.buildbot.net/current` and `/latest`, zero matches), so there is no live equivalent. That does not contradict the Server slice's rule that *a live page beats an archived one for download and install pages*: this is a wiki article, and the page citing it already documents `buildbot-slave` and `buildslave-2.6`, so it is legacy throughout.

Newest 200 snapshot, **2010-12-06**, body-checked: renders as "UsingLaunchd – Buildbot" with 21 mentions of `launchd` and 13 of `plist`. `web.archive.org` is on the lychee exclude list (DOCS-6521), so **CI will not verify this link** — which is why it was checked by hand.

## 2. fragcheck missed an entire class of anchor

**I reported a dead cross-space anchor on #1041 that was never dead.** The Enterprise Manager quickstart links `mariadb-package-repository-setup-and-usage#mariadb_es_repo_setup`, and that page has no heading of that name — so fragcheck's rules said dead. The anchor is on the live page. It comes from a `{% tab title="mariadb_es_repo_setup" %}` block.

GitBook gives every tab panel `id="<slug of title>"`, using the same slug rules as a heading and drawing from the **same per-page id namespace, in document order**. Verified on `atomic-ddl.md`, which has both: the tab titled "Background" (line 15) publishes `id="background"` and the later `## Background` (line 30) is pushed to `id="background-1"` — read off the rendered page, not inferred. `anchors_of()` now merges both sources by line number, which is what reproduces that.

**927 tab titles across the tree**, an anchor source the checker had no rule for.

### Why this is safe to land

The omission made fragcheck wrong in the **pessimistic** direction — it calls a working link dead. Repo-wide the count is **unchanged at 15 dead**, all pre-existing in the operator API reference: no relative link in the tree currently depends on a tab anchor. So this **cannot newly fail any PR**; it can only stop a future false positive. The header comment is updated in the file's own evidence-first style.

### Proof

A/B on a **tab-only** anchor, not asserted: appending `[x](#mariadb_es_repo_setup)` to the repo-setup page reports **1 dead with the patch stashed, 0 dead with it applied**. My first attempt at this proof used `#background`, which was worthless — the heading publishes that slug too, so it passed either way.

`doc-lint-test.sh`: **61 passed / 0 failed**. `fragcheck check/new/ids/risky` clean repo-wide; `codespell` clean; `py_compile` ok.

---

## What is NOT in here, and needs a ticket

Chasing this turned up a much bigger gap, and it is too large to fold in. **Cross-space anchors are completely unchecked.** `fragcheck` resolves relative links only, so every `app.gitbook.com/.../<page>#<anchor>` link is skipped — **7,693 of them across the tree**. A first pass flags ~421 candidate dead anchors, but that number is not yet trustworthy: a resolver has to follow the *nav* path from `SUMMARY.md`, not the file path, because the two differ (DOCS-6590). Spot-checked live, some are genuinely dead (`mariadb-backup-options#-galera-info`, `systemd#interacting-with-multiple-mariadb-server-processes`) and some are fine.

Worth noting there are also **two cross-space URL shapes** — `/o/<org>/s/<space>/…` (5,713) and a short `/s/<space>/…` (35,759). I initially measured only the long one and undercounted by 6×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)