### PR TITLE
DOCS-6451 Fix link defects in the Analytics space

### DIFF
--- a/.claude/hooks/doc-lint.sh
+++ b/.claude/hooks/doc-lint.sh
@@ -150,6 +150,7 @@ if command -v lychee >/dev/null 2>&1; then
       --exclude 'www\.defense\.gov' \
       --exclude 'cloud\.ibm\.com' \
       --exclude 'www\.akamai\.com' \
+      --exclude 'www\.oreilly\.com' \
       "${files[@]}" 2>&1)"; then
     # Mirror the workflow's failIfEmpty: false — lychee exits non-zero with
     # "No links were found" when the changed files contain no links, which is a

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -251,6 +251,18 @@ jobs:
           # docs library (www.linode.com/docs/guides/... now 301s there); it serves 403
           # to every scripted client, which is why the old linode.com URL surfaced as a
           # 403 rather than as the redirect it actually is.
+          #
+          # DOCS-6451 (Analytics slice): www.oreilly.com. The R use-case page cites
+          # three O'Reilly books by their retired shop.oreilly.com product URLs, which
+          # 301 to www.oreilly.com/library/view/~/<isbn>/. Those resolved pages answer
+          # every scripted client with an Akamai edge denial ("Access Denied", with an
+          # errors.edgesuite.net reference id) -- a full browser User-Agent and a
+          # complete Sec-Fetch header set over HTTP/1.1 do not get past it, and the
+          # site ROOT serves 200, so it is path-level bot protection on /library/view/
+          # rather than a dead page or a whole-host block. Same class as
+          # www.akamai.com and cloud.ibm.com above. The URLs are resolved to the form
+          # O'Reilly itself redirects to, so the citations point at the publisher's own
+          # canonical page.
           args: >-
             --no-progress
             --exclude 'bazaar\.launchpad\.net'
@@ -330,6 +342,7 @@ jobs:
             --exclude 'www\.defense\.gov'
             --exclude 'cloud\.ibm\.com'
             --exclude 'www\.akamai\.com'
+            --exclude 'www\.oreilly\.com'
             ${{ steps.list.outputs.files }}
           fail: true
           # Don't error when the changed files contain no links to check. lychee

--- a/analytics/mariadb-columnstore/architecture/columnstore-system-paths-and-logs.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-system-paths-and-logs.md
@@ -228,7 +228,7 @@ journalctl -u mariadb-columnstore-cmapi # only with the CMAPI package installed
 
 ### MariaDB Server Error Log
 
-Errors raised at the SQL layer (including ColumnStore plugin messages) go to the regular MariaDB Server [error log](https://mariadb.com/docs/server/server-management/server-monitoring-logs/error-log), configured with the [`log_error`](https://mariadb.com/docs/server/server-management/variables-and-modes/server-system-variables#log_error) system variable.
+Errors raised at the SQL layer (including ColumnStore plugin messages) go to the regular MariaDB Server [error log]({server}/server-management/server-monitoring-logs/error-log), configured with the [`log_error`]({server}/server-management/variables-and-modes/server-system-variables#log_error) system variable.
 
 ## Gathering Logs for Support Tickets
 

--- a/analytics/mariadb-columnstore/architecture/columnstore-system-paths-and-logs.md
+++ b/analytics/mariadb-columnstore/architecture/columnstore-system-paths-and-logs.md
@@ -228,7 +228,7 @@ journalctl -u mariadb-columnstore-cmapi # only with the CMAPI package installed
 
 ### MariaDB Server Error Log
 
-Errors raised at the SQL layer (including ColumnStore plugin messages) go to the regular MariaDB Server [error log]({server}/server-management/server-monitoring-logs/error-log), configured with the [`log_error`]({server}/server-management/variables-and-modes/server-system-variables#log_error) system variable.
+Errors raised at the SQL layer (including ColumnStore plugin messages) go to the regular MariaDB Server [error log](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/server-monitoring-logs/error-log), configured with the [`log_error`](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#log_error) system variable.
 
 ## Gathering Logs for Support Tickets
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/README.md
@@ -221,7 +221,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-server-version="11.4"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ _Versions_ _section at the bottom of the_ _MariaDB Package Repository Setup and Usage_ _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 #### Install Enterprise ColumnStore
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/README.md
@@ -221,7 +221,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-server-version="11.4"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 #### Install Enterprise ColumnStore
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-1-prepare-systems-for-enterprise-columnstore-nodes.md
@@ -7,7 +7,7 @@ hidden: true
 
 ## Overview
 
-This page details step 1 of a 5-step procedure for deploying Single-Node ColumnStore with Object storage.
+This page details step 1 of a 5-step procedure for deploying Multi-Node ColumnStore with Object Storage.
 
 This step prepares the system to host MariaDB Enterprise Server and MariaDB ColumnStore.
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-2-install-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-2-install-enterprise-columnstore.md
@@ -7,7 +7,7 @@ hidden: true
 
 ## Overview
 
-This page details step 2 of a 5-step procedure for deploying Single-Node ColumnStore with Object storage.
+This page details step 2 of a 5-step procedure for deploying Multi-Node ColumnStore with Object Storage.
 
 This step installs MariaDB Enterprise Server and MariaDB ColumnStore.
 
@@ -67,7 +67,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-server-version="11.4"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 ## Install Enterprise ColumnStore
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-3-start-and-configure-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-3-start-and-configure-enterprise-columnstore.md
@@ -7,7 +7,7 @@ hidden: true
 
 ## Overview
 
-This page details step 3 of a 5-step procedure for deploying [Single-Node ColumnStore with Object storage](broken-reference/).
+This page details step 3 of a 5-step procedure for deploying [Multi-Node ColumnStore with Object Storage](README.md).
 
 This step starts and configures MariaDB Enterprise Server and MariaDB ColumnStore.
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-4-test-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-4-test-enterprise-columnstore.md
@@ -7,7 +7,7 @@ hidden: true
 
 ## Overview
 
-This page details step 4 of a 5-step procedure for deploying Single-Node ColumnStore with Object storage.
+This page details step 4 of a 5-step procedure for deploying Multi-Node ColumnStore with Object Storage.
 
 This step tests MariaDB Enterprise Server and MariaDB ColumnStore.
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-5-bulk-import-of-data.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multinode-s3/step-5-bulk-import-of-data.md
@@ -7,7 +7,7 @@ hidden: true
 
 ## Overview
 
-This page details step 5 of a 5-step procedure for deploying Single-Node ColumnStore with Object storage.
+This page details step 5 of a 5-step procedure for deploying Multi-Node ColumnStore with Object Storage.
 
 This step bulk imports data to ColumnStore.
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/README.md
@@ -849,7 +849,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-server-version="11.4"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 #### Install Enterprise Server and Enterprise ColumnStore
 
@@ -1903,7 +1903,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
 ```
 {% endcode %}
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 #### Install MaxScale
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-3-install-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-3-install-mariadb-enterprise-server.md
@@ -66,7 +66,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-server-version="11.4"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 ## Install Enterprise Server and Enterprise ColumnStore
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-5-test-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-5-test-mariadb-enterprise-server.md
@@ -33,7 +33,7 @@ $ sudo systemctl start mariadb
 
 ## Test Local Client Connections
 
-Use [MariaDB Client]({server}/clients-and-utilities/mariadb-client) to test the local connection to the Enterprise Server node.
+Use [MariaDB Client](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/mariadb-client) to test the local connection to the Enterprise Server node.
 
 This action is performed **on each Enterprise ColumnStore node**:
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-5-test-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-5-test-mariadb-enterprise-server.md
@@ -33,7 +33,7 @@ $ sudo systemctl start mariadb
 
 ## Test Local Client Connections
 
-Use [MariaDB Client](broken-reference/) to test the local connection to the Enterprise Server node.
+Use [MariaDB Client]({server}/clients-and-utilities/mariadb-client) to test the local connection to the Enterprise Server node.
 
 This action is performed **on each Enterprise ColumnStore node**:
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-6-install-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/multnode-localstorage/step-6-install-mariadb-maxscale.md
@@ -60,7 +60,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-maxscale-version="22.08"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 ## Install MaxScale
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/README.md
@@ -902,7 +902,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
 ```
 
 {% hint style="info" %}
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 {% endhint %}
 
 #### Install Enterprise Server and Enterprise ColumnStore
@@ -2033,7 +2033,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
 {% endcode %}
 
 {% hint style="info" %}
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 {% endhint %}
 
 #### Install MaxScale

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-3-install-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-3-install-mariadb-enterprise-server.md
@@ -66,7 +66,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-server-version="11.4"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 ## Install Enterprise Server and Enterprise ColumnStore
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-5-test-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-5-test-mariadb-enterprise-server.md
@@ -295,7 +295,7 @@ INSERT INTO test.contacts (first_name, last_name, email)
 $ sudo mariadb
 ```
 
-4. Execute a [SELECT]({server}/reference/sql-statements/data-manipulation/selecting-data/select) query to retrieve the data:
+4. Execute a [SELECT](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/selecting-data/select) query to retrieve the data:
 
 ```sql
 SELECT * FROM test.contacts;

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-5-test-mariadb-enterprise-server.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-5-test-mariadb-enterprise-server.md
@@ -295,7 +295,7 @@ INSERT INTO test.contacts (first_name, last_name, email)
 $ sudo mariadb
 ```
 
-4. Execute a [SELECT](broken-reference/) query to retrieve the data:
+4. Execute a [SELECT]({server}/reference/sql-statements/data-manipulation/selecting-data/select) query to retrieve the data:
 
 ```sql
 SELECT * FROM test.contacts;

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-6-install-mariadb-maxscale.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/single-node-s3/step-6-install-mariadb-maxscale.md
@@ -62,7 +62,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-maxscale-version="22.08"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 ## Install MaxScale
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/README.md
@@ -356,7 +356,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
 ```
 
 {% hint style="success" %}
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 {% endhint %}
 
 #### Install Enterprise ColumnStore <a href="#install-enterprise-columnstore" id="install-enterprise-columnstore"></a>
@@ -422,9 +422,9 @@ Mandatory system variables and options for Single-Node ColumnStore include:
 
 | Connector                                                                                                                                                                                                                 | MariaDB Connector/R2DBC                                                                                                                                                                                                                                                                                                                                                                    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [character\_set\_server]({server}/server-management/variables-and-modes/server-system-variables#character_set_server)                                                                              | Set this system variable to `utf8`                                                                                                                                                                                                                                                                                                                                                         |
-| [collation\_server]({server}/server-management/variables-and-modes/server-system-variables#collation_server)                                                                                       | Set this system variable to `utf8_general_ci`                                                                                                                                                                                                                                                                                                                                              |
-| [loose-columnstore\_use\_import\_for\_batchinsert](../../../../clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-insert-select.md#batch-insert-mode) | Set this system variable to `ALWAYS` to always use `cpimport` for [LOAD DATA INFILE]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) and [INSERT...SELECT]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/insert-select) statements. |
+| [character\_set\_server](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#character_set_server)                                                                              | Set this system variable to `utf8`                                                                                                                                                                                                                                                                                                                                                         |
+| [collation\_server](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/variables-and-modes/server-system-variables#collation_server)                                                                                       | Set this system variable to `utf8_general_ci`                                                                                                                                                                                                                                                                                                                                              |
+| [loose-columnstore\_use\_import\_for\_batchinsert](../../../../clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-insert-select.md#batch-insert-mode) | Set this system variable to `ALWAYS` to always use `cpimport` for [LOAD DATA INFILE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) and [INSERT...SELECT](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/inserting-loading-data/insert-select) statements. |
 
 {% hint style="info" %}
 The `loose-` prefix is required for ColumnStore system variables in the configuration file. Without it, MariaDB Server will fail to start if the ColumnStore plugin is not installed or has been removed.
@@ -459,7 +459,7 @@ $ sudo systemctl enable mariadb-columnstore
 
 Enterprise ColumnStore requires a mandatory utility user account. By default, it connects to the server using the root user with no password. MariaDB Enterprise Server 10.6 will reject this login attempt by default, so you will need to configure Enterprise ColumnStore to use a different user account and password and create this user account on Enterprise Server.
 
-1. On the Enterprise ColumnStore node, create the user account with the [CREATE USER]({server}/reference/sql-statements/account-management-sql-statements/create-user) statement:
+1. On the Enterprise ColumnStore node, create the user account with the [CREATE USER](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/account-management-sql-statements/create-user) statement:
 
 ```sql
 CREATE USER 'util_user'@'127.0.0.1'
@@ -591,7 +591,7 @@ MariaDB [(none)]>
 
 #### Test ColumnStore Plugin Status <a href="#test-columnstore-plugin-status" id="test-columnstore-plugin-status"></a>
 
-Query [information\_schema.PLUGINS]({server}/reference/system-tables/information-schema/information-schema-tables/plugins-table-information-schema) and confirm that the ColumnStore storage engine plugin is `ACTIVE`:
+Query [information\_schema.PLUGINS](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/system-tables/information-schema/information-schema-tables/plugins-table-information-schema) and confirm that the ColumnStore storage engine plugin is `ACTIVE`:
 
 ```sql
 SELECT PLUGIN_NAME, PLUGIN_STATUS
@@ -714,13 +714,13 @@ Before data can be imported into the tables, create a matching schema.
 
 **On the primary server**, create the schema:
 
-1. For each database that you are importing, create the database with the [CREATE DATABASE]({server}/reference/sql-statements/data-definition/create/create-database) statement:
+1. For each database that you are importing, create the database with the [CREATE DATABASE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-definition/create/create-database) statement:
 
 ```sql
 CREATE DATABASE inventory;
 ```
 
-2. For each table that you are importing, create the table with the [CREATE TABLE]({server}/server-usage/tables/create-table) statement:
+2. For each table that you are importing, create the table with the [CREATE TABLE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-usage/tables/create-table) statement:
 
 ```sql
 CREATE TABLE inventory.products (
@@ -747,9 +747,9 @@ $ sudo cpimport -s '\t' inventory products /tmp/inventory-products.tsv
 
 #### LOAD DATA INFILE <a href="#load-data-infile" id="load-data-infile"></a>
 
-When data is loaded with the [LOAD DATA INFILE]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement, MariaDB Enterprise ColumnStore loads the data using `cpimport`, which is a command-line utility designed to efficiently load data in bulk. Alternative methods are available.
+When data is loaded with the [LOAD DATA INFILE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement, MariaDB Enterprise ColumnStore loads the data using `cpimport`, which is a command-line utility designed to efficiently load data in bulk. Alternative methods are available.
 
-To import your data from a TSV (tab-separated values) file, on the primary server use [LOAD DATA INFILE]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement:
+To import your data from a TSV (tab-separated values) file, on the primary server use [LOAD DATA INFILE](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement:
 
 ```sql
 LOAD DATA INFILE '/tmp/inventory-products.tsv'
@@ -758,7 +758,7 @@ INTO TABLE inventory.products;
 
 #### Import from Remote Database <a href="#import-from-remote-database" id="import-from-remote-database"></a>
 
-MariaDB Enterprise ColumnStore can also import data directly from a remote database. A simple method is to query the table using the [SELECT]({server}/reference/sql-statements/data-manipulation/selecting-data/select) statement, and then pipe the results into `cpimport`, which is a command-line utility that is designed to efficiently load data in bulk. Alternative methods are available.
+MariaDB Enterprise ColumnStore can also import data directly from a remote database. A simple method is to query the table using the [SELECT](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/reference/sql-statements/data-manipulation/selecting-data/select) statement, and then pipe the results into `cpimport`, which is a command-line utility that is designed to efficiently load data in bulk. Alternative methods are available.
 
 To import your data from a remote MariaDB database:
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/README.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/README.md
@@ -356,7 +356,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
 ```
 
 {% hint style="success" %}
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://mariadb.com/docs/server/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 {% endhint %}
 
 #### Install Enterprise ColumnStore <a href="#install-enterprise-columnstore" id="install-enterprise-columnstore"></a>
@@ -422,9 +422,9 @@ Mandatory system variables and options for Single-Node ColumnStore include:
 
 | Connector                                                                                                                                                                                                                 | MariaDB Connector/R2DBC                                                                                                                                                                                                                                                                                                                                                                    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [character\_set\_server](https://mariadb.com/docs/server/server-management/variables-and-modes/server-system-variables#character_set_server)                                                                              | Set this system variable to `utf8`                                                                                                                                                                                                                                                                                                                                                         |
-| [collation\_server](https://mariadb.com/docs/server/server-management/variables-and-modes/server-system-variables#collation_server)                                                                                       | Set this system variable to `utf8_general_ci`                                                                                                                                                                                                                                                                                                                                              |
-| [loose-columnstore\_use\_import\_for\_batchinsert](https://mariadb.com/docs/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-insert-select#batch-insert-mode) | Set this system variable to `ALWAYS` to always use `cpimport` for [LOAD DATA INFILE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) and [INSERT...SELECT](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-select) statements. |
+| [character\_set\_server]({server}/server-management/variables-and-modes/server-system-variables#character_set_server)                                                                              | Set this system variable to `utf8`                                                                                                                                                                                                                                                                                                                                                         |
+| [collation\_server]({server}/server-management/variables-and-modes/server-system-variables#collation_server)                                                                                       | Set this system variable to `utf8_general_ci`                                                                                                                                                                                                                                                                                                                                              |
+| [loose-columnstore\_use\_import\_for\_batchinsert](../../../../clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-insert-select.md#batch-insert-mode) | Set this system variable to `ALWAYS` to always use `cpimport` for [LOAD DATA INFILE]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) and [INSERT...SELECT]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/insert-select) statements. |
 
 {% hint style="info" %}
 The `loose-` prefix is required for ColumnStore system variables in the configuration file. Without it, MariaDB Server will fail to start if the ColumnStore plugin is not installed or has been removed.
@@ -459,7 +459,7 @@ $ sudo systemctl enable mariadb-columnstore
 
 Enterprise ColumnStore requires a mandatory utility user account. By default, it connects to the server using the root user with no password. MariaDB Enterprise Server 10.6 will reject this login attempt by default, so you will need to configure Enterprise ColumnStore to use a different user account and password and create this user account on Enterprise Server.
 
-1. On the Enterprise ColumnStore node, create the user account with the [CREATE USER](https://mariadb.com/docs/server/reference/sql-statements/account-management-sql-statements/create-user) statement:
+1. On the Enterprise ColumnStore node, create the user account with the [CREATE USER]({server}/reference/sql-statements/account-management-sql-statements/create-user) statement:
 
 ```sql
 CREATE USER 'util_user'@'127.0.0.1'
@@ -488,7 +488,7 @@ $ sudo mcsSetConfig CrossEngineSupport Password util_user_passwd
 ```
 
 {% hint style="info" %}
-For details about how to encrypt the password, see "[Credentials Management for MariaDB Enterprise ColumnStore](https://mariadb.com/docs/analytics/mariadb-columnstore/security/enterprise-columnstore-credentials-management)".
+For details about how to encrypt the password, see "[Credentials Management for MariaDB Enterprise ColumnStore](../../../../security/enterprise-columnstore-credentials-management.md)".
 {% endhint %}
 
 {% hint style="warning" %}
@@ -591,7 +591,7 @@ MariaDB [(none)]>
 
 #### Test ColumnStore Plugin Status <a href="#test-columnstore-plugin-status" id="test-columnstore-plugin-status"></a>
 
-Query [information\_schema.PLUGINS](https://mariadb.com/docs/server/reference/system-tables/information-schema/information-schema-tables/plugins-table-information-schema) and confirm that the ColumnStore storage engine plugin is `ACTIVE`:
+Query [information\_schema.PLUGINS]({server}/reference/system-tables/information-schema/information-schema-tables/plugins-table-information-schema) and confirm that the ColumnStore storage engine plugin is `ACTIVE`:
 
 ```sql
 SELECT PLUGIN_NAME, PLUGIN_STATUS
@@ -714,13 +714,13 @@ Before data can be imported into the tables, create a matching schema.
 
 **On the primary server**, create the schema:
 
-1. For each database that you are importing, create the database with the [CREATE DATABASE](https://mariadb.com/docs/server/reference/sql-statements/data-definition/create/create-database) statement:
+1. For each database that you are importing, create the database with the [CREATE DATABASE]({server}/reference/sql-statements/data-definition/create/create-database) statement:
 
 ```sql
 CREATE DATABASE inventory;
 ```
 
-2. For each table that you are importing, create the table with the [CREATE TABLE](https://mariadb.com/docs/server/server-usage/tables/create-table) statement:
+2. For each table that you are importing, create the table with the [CREATE TABLE]({server}/server-usage/tables/create-table) statement:
 
 ```sql
 CREATE TABLE inventory.products (
@@ -737,7 +737,7 @@ Enterprise ColumnStore supports multiple methods to import data into ColumnStore
 
 **cpimport**
 
-MariaDB Enterprise ColumnStore includes [cpimport](https://mariadb.com/docs/analytics/mariadb-columnstore/clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-cpimport), which is a command-line utility designed to efficiently load data in bulk. Alternative methods are available.
+MariaDB Enterprise ColumnStore includes [cpimport](../../../../clients-and-tools/data-import/mariadb-enterprise-columnstore-data-loading-with-cpimport.md), which is a command-line utility designed to efficiently load data in bulk. Alternative methods are available.
 
 To import your data from a TSV (tab-separated values) file, on the primary server run `cpimport`:
 
@@ -747,9 +747,9 @@ $ sudo cpimport -s '\t' inventory products /tmp/inventory-products.tsv
 
 #### LOAD DATA INFILE <a href="#load-data-infile" id="load-data-infile"></a>
 
-When data is loaded with the [LOAD DATA INFILE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement, MariaDB Enterprise ColumnStore loads the data using `cpimport`, which is a command-line utility designed to efficiently load data in bulk. Alternative methods are available.
+When data is loaded with the [LOAD DATA INFILE]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement, MariaDB Enterprise ColumnStore loads the data using `cpimport`, which is a command-line utility designed to efficiently load data in bulk. Alternative methods are available.
 
-To import your data from a TSV (tab-separated values) file, on the primary server use [LOAD DATA INFILE](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement:
+To import your data from a TSV (tab-separated values) file, on the primary server use [LOAD DATA INFILE]({server}/reference/sql-statements/data-manipulation/inserting-loading-data/load-data-into-tables-or-index/load-data-infile) statement:
 
 ```sql
 LOAD DATA INFILE '/tmp/inventory-products.tsv'
@@ -758,7 +758,7 @@ INTO TABLE inventory.products;
 
 #### Import from Remote Database <a href="#import-from-remote-database" id="import-from-remote-database"></a>
 
-MariaDB Enterprise ColumnStore can also import data directly from a remote database. A simple method is to query the table using the [SELECT](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/selecting-data/select) statement, and then pipe the results into `cpimport`, which is a command-line utility that is designed to efficiently load data in bulk. Alternative methods are available.
+MariaDB Enterprise ColumnStore can also import data directly from a remote database. A simple method is to query the table using the [SELECT]({server}/reference/sql-statements/data-manipulation/selecting-data/select) statement, and then pipe the results into `cpimport`, which is a command-line utility that is designed to efficiently load data in bulk. Alternative methods are available.
 
 To import your data from a remote MariaDB database:
 

--- a/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-2-install-enterprise-columnstore.md
+++ b/analytics/mariadb-columnstore/management/deployment/install-guide/singlenode-localstorage/step-2-install-enterprise-columnstore.md
@@ -67,7 +67,7 @@ $ sudo ./mariadb_es_repo_setup --token="CUSTOMER_DOWNLOAD_TOKEN" --apply \
       --mariadb-server-version="11.4"
 ```
 
-_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/reference/sql-functions/secondary-functions/information-functions/version) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages) _page. Substitute `${checksum}` in the example above with the latest checksum._
+_Checksums of the various releases of the `mariadb_es_repo_setup` script can be found in the_ [_Versions_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage#versions) _section at the bottom of the_ [_MariaDB Package Repository Setup and Usage_](https://app.gitbook.com/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage) _page. Substitute `${checksum}` in the example above with the latest checksum._
 
 ## Install Enterprise ColumnStore
 

--- a/analytics/mariadb-columnstore/management/deployment/upgrades/upgrade-multi-node-mariadb-enterprise-columnstore-from-6-to-23.10.md
+++ b/analytics/mariadb-columnstore/management/deployment/upgrades/upgrade-multi-node-mariadb-enterprise-columnstore-from-6-to-23.10.md
@@ -28,7 +28,7 @@ maxctrl set server \
 
 This action is performed **on the MaxScale node**.
 
-Confirm that the replicas are set to maintenance mode in MaxScale using [MaxScale's REST API](http://localhost:8000/docs/server/service-management/admin-tools/maxscale/rest-api/). If you are using [MaxCtrl](http://localhost:8000/docs/server/ref/mxs/maxctrl/), the state of the replicas can be viewed using the [list servers](http://localhost:8000/docs/server/ref/mxs/maxctrl/list_servers/) command:
+Confirm that the replicas are set to maintenance mode in MaxScale using [MaxScale's REST API]({maxscale}/reference/maxscale-rest-api/maxscale-rest-api). If you are using [MaxCtrl]({maxscale}/reference/maxscale-maxctrl), the state of the replicas can be viewed using the [list servers]({maxscale}/reference/maxscale-maxctrl#list-servers) command:
 
 ```bash
 maxctrl list servers
@@ -150,7 +150,7 @@ MariaDB Corporation provides package repositories for YUM (RHEL, CentOS, Rocky L
 1. Retrieve your Customer Download Token at [https://customers.mariadb.com/downloads/token/](https://customers.mariadb.com/downloads/token/) and substitute for `CUSTOMER_DOWNLOAD_TOKEN` in the following directions.
 2.  Configure the APT package repository.
 
-    Enterprise ColumnStore 23.10 is included with MariaDB Enterprise Server 11.4. Pass the version to install using the `--mariadb-server-version` flag to [mariadb\_es\_repo\_setup](http://localhost:8000/docs/server/ref/mariadb_es_repo_setup/).
+    Enterprise ColumnStore 23.10 is included with MariaDB Enterprise Server 11.4. Pass the version to install using the `--mariadb-server-version` flag to [mariadb\_es\_repo\_setup]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
 
     To configure APT package repositories:
 
@@ -236,7 +236,7 @@ After upgrading, the [CMAPI](../../../reference/cmapi/) service and the MariaDB 
 
 ## Write Binary Log
 
-On the primary server, run [mariadb-upgrade](http://localhost:8000/docs/server/ref/mdb/cli/mariadb-upgrade/) to upgrade the data directory with binary logging enabled to update the system tables:
+On the primary server, run [mariadb-upgrade]({server}/clients-and-utilities/deployment-tools/mariadb-upgrade) to upgrade the data directory with binary logging enabled to update the system tables:
 
 ```bash
 mariadb-upgrade --write-binlog

--- a/analytics/mariadb-columnstore/management/deployment/upgrades/upgrade-multi-node-mariadb-enterprise-columnstore-from-6-to-23.10.md
+++ b/analytics/mariadb-columnstore/management/deployment/upgrades/upgrade-multi-node-mariadb-enterprise-columnstore-from-6-to-23.10.md
@@ -28,7 +28,7 @@ maxctrl set server \
 
 This action is performed **on the MaxScale node**.
 
-Confirm that the replicas are set to maintenance mode in MaxScale using [MaxScale's REST API]({maxscale}/reference/maxscale-rest-api/maxscale-rest-api). If you are using [MaxCtrl]({maxscale}/reference/maxscale-maxctrl), the state of the replicas can be viewed using the [list servers]({maxscale}/reference/maxscale-maxctrl#list-servers) command:
+Confirm that the replicas are set to maintenance mode in MaxScale using [MaxScale's REST API](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/reference/maxscale-rest-api/maxscale-rest-api). If you are using [MaxCtrl](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/reference/maxscale-maxctrl), the state of the replicas can be viewed using the [list servers](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/0pSbu5DcMSW4KwAkUcmX/reference/maxscale-maxctrl#list-servers) command:
 
 ```bash
 maxctrl list servers
@@ -150,7 +150,7 @@ MariaDB Corporation provides package repositories for YUM (RHEL, CentOS, Rocky L
 1. Retrieve your Customer Download Token at [https://customers.mariadb.com/downloads/token/](https://customers.mariadb.com/downloads/token/) and substitute for `CUSTOMER_DOWNLOAD_TOKEN` in the following directions.
 2.  Configure the APT package repository.
 
-    Enterprise ColumnStore 23.10 is included with MariaDB Enterprise Server 11.4. Pass the version to install using the `--mariadb-server-version` flag to [mariadb\_es\_repo\_setup]({server}/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
+    Enterprise ColumnStore 23.10 is included with MariaDB Enterprise Server 11.4. Pass the version to install using the `--mariadb-server-version` flag to [mariadb\_es\_repo\_setup](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
 
     To configure APT package repositories:
 
@@ -236,7 +236,7 @@ After upgrading, the [CMAPI](../../../reference/cmapi/) service and the MariaDB 
 
 ## Write Binary Log
 
-On the primary server, run [mariadb-upgrade]({server}/clients-and-utilities/deployment-tools/mariadb-upgrade) to upgrade the data directory with binary logging enabled to update the system tables:
+On the primary server, run [mariadb-upgrade](https://app.gitbook.com/o/diTpXxF5WsbHqTReoBsS/s/SsmexDFPv2xG2OTyO5yV/clients-and-utilities/deployment-tools/mariadb-upgrade) to upgrade the data directory with binary logging enabled to update the system tables:
 
 ```bash
 mariadb-upgrade --write-binlog

--- a/analytics/mariadb-columnstore/reference/cmapi/README.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/README.md
@@ -64,7 +64,7 @@ openssl rand -hex 32
 
 ### Set the API Key
 
-To set the API key for the first time, provide the desired API key when you add the first node using the [node](http://localhost:8000/docs/columnstore/ref/cmapi/add-node/) PUT command. Since Enterprise ColumnStore does not yet have an API key, CMAPI will write the first API key it receives to `/etc/columnstore/cmapi_server.conf`.
+To set the API key for the first time, provide the desired API key when you add the first node using the [node](node-put.md) PUT command. Since Enterprise ColumnStore does not yet have an API key, CMAPI will write the first API key it receives to `/etc/columnstore/cmapi_server.conf`.
 
 For example, if the primary server's host name is `mcs1` and its IP address is `192.0.2.1`, the following command will add the primary server to Enterprise ColumnStore and write the provided API key to the node's CMAPI configuration file:
 
@@ -96,7 +96,7 @@ These aliases are available if your `bash` shell is configured to source the `co
 
 These aliases execute `curl` and `jq`, so both programs must be installed on the system.
 
-These aliases automatically retrieve the IP address for the primary node using the [mcsGetConfig](http://localhost:8000/docs/columnstore/ref/col/cli/mcsGetConfig/) command. The aliases automatically retrieve the API key by reading `/etc/columnstore/cmapi_server.conf`.
+These aliases automatically retrieve the IP address for the primary node using the [mcsGetConfig](../../architecture/columnstore-system-paths-and-logs.md#mcsgetconfig) command. The aliases automatically retrieve the API key by reading `/etc/columnstore/cmapi_server.conf`.
 
 Available aliases:
 
@@ -149,7 +149,7 @@ auto_failover = False
 
 ## Logging
 
-Starting with Enterprise ColumnStore 5.5.2, the [CMAPI logs](http://localhost:8000/docs/columnstore/ref/col/logging/cmapi/) can be found at `/var/log/mariadb/columnstore/cmapi_server.log`.
+Starting with Enterprise ColumnStore 5.5.2, the [CMAPI logs](../../architecture/columnstore-system-paths-and-logs.md#cmapi-and-mcs-logs) can be found at `/var/log/mariadb/columnstore/cmapi_server.log`.
 
 In previous versions, CMAPI's log messages can be viewed in the `systemd` journal:
 

--- a/analytics/mariadb-columnstore/reference/cmapi/shutdown.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/shutdown.md
@@ -46,7 +46,7 @@ In this example, `jq` produces human-readable output from the returned JSON resp
 
 Starting with Enterprise ColumnStore 5.5.2, if your `bash` shell is configured to source the `columnstoreAlias` shell script, this command can be executed using the `mcsShutdown` alias. The alias executes `curl` and `jq`, so both programs must be installed on the system.
 
-The alias automatically retrieves the IP address for the primary node using the [mcsGetConfig](http://localhost:8000/docs/columnstore/ref/col/cli/mcsGetConfig/) command. The alias automatically retrieves the API key by reading `/etc/columnstore/cmapi_server.conf`.
+The alias automatically retrieves the IP address for the primary node using the [mcsGetConfig](../../architecture/columnstore-system-paths-and-logs.md#mcsgetconfig) command. The alias automatically retrieves the API key by reading `/etc/columnstore/cmapi_server.conf`.
 
 ```bash
 mcsShutdown

--- a/analytics/mariadb-columnstore/reference/cmapi/start.md
+++ b/analytics/mariadb-columnstore/reference/cmapi/start.md
@@ -47,7 +47,7 @@ The command returns a JSON payload. Piping it to `jq` makes the output more huma
 
 Starting with Enterprise ColumnStore 5.5.2, if your `bash` shell is configured to source the `columnstoreAlias` shell script, this command can be executed using the `mcsStart` alias. The alias executes `curl` and `jq`, so both programs must be installed on the system.
 
-The alias automatically retrieves the IP address for the primary node using the [mcsGetConfig](http://localhost:8000/docs/columnstore/ref/col/cli/mcsGetConfig/) command. The alias automatically retrieves the API key by reading `/etc/columnstore/cmapi_server.conf`.
+The alias automatically retrieves the IP address for the primary node using the [mcsGetConfig](../../architecture/columnstore-system-paths-and-logs.md#mcsgetconfig) command. The alias automatically retrieves the API key by reading `/etc/columnstore/cmapi_server.conf`.
 
 ```bash
 mcsStart

--- a/analytics/mariadb-columnstore/use-cases/r-statistical-programming-using-mariadb-as-the-background-database.md
+++ b/analytics/mariadb-columnstore/use-cases/r-statistical-programming-using-mariadb-as-the-background-database.md
@@ -54,8 +54,8 @@ For the transfer of data between MariaDB Server and R Environment, it is recomme
 
 * “odbc" is a new R package available on CRAN (Since 2017-02-05), and maintained by RStudio, which is designed to comply with the DBI specification.
 * Tutorials on how to use R's "odbc" package can be found here:
-  * Setting up ODBC Drivers: [DB RStudio Drivers](https://db.rstudio.com/drivers/)
-  * "odbc" R Package: [DB RStudio odbc Usage](https://db.rstudio.com/odbc/#usage)
+  * Setting up ODBC Drivers: [Posit Solutions: Setting up ODBC Drivers](https://solutions.posit.co/connections/db/best-practices/drivers/)
+  * "odbc" R Package: [Posit Solutions: Using an ODBC Driver](https://solutions.posit.co/connections/db/r-packages/odbc/#using)
 
 The "odbc" package requires to have previously installed the MariaDB or MySQL ODBC connector:
 
@@ -98,7 +98,7 @@ There are other alternatives for data transfer between R and MariaDB:
 
 * “readr” R package, for writing / reading CSV files. To be used in MariaDB along with “LOAD DATA INFILE”.
 * "RODBC" R package: Robust and well-tested (Since 2000-05-24) package which enables data transfer between R and MariaDB by means of an ODBC connector: [CRAN RODBC](https://cran.r-project.org/web/packages/RODBC/index.html)
-  * It is slightly slower than RStudio's new "odbc" package (See benchmarks): [RStudio odbc](https://db.rstudio.com/odbc/)
+  * It is slightly slower than RStudio's new "odbc" package (See benchmarks): [Posit Solutions: Using an ODBC Driver](https://solutions.posit.co/connections/db/r-packages/odbc/)
   * For bug report to the RODBC package maintainer, use the following R statement: bug.report(package = "RODBC")
   * A vignette on how to use the RODBC package can be found here: [RODBC CRAN Vignette](https://cran.r-project.org/web/packages/RODBC/vignettes/RODBC.pdf)
 
@@ -119,7 +119,7 @@ Recommended resources for learning how to program in R are the following:
 
 A recommended book for understanding the underlying statistics in the R packages is:
 
-* [Practical Statistics for Data Scientists (O’Reilly Media; Peter Bruce, Andrew Bruce)](https://shop.oreilly.com/product/0636920048992.do)
+* [Practical Statistics for Data Scientists (O’Reilly Media; Peter Bruce, Andrew Bruce)](https://www.oreilly.com/library/view/~/9781491952955/)
 
 #### C) Cheatsheets: Concept Summary
 
@@ -134,7 +134,6 @@ A recommended book for understanding the underlying statistics in the R packages
 * Information on new R packages is regularly published in the following websites:
   * [R-bloggers](https://www.r-bloggers.com/)
   * [Towards Data Science](https://towardsdatascience.com/)
-  * [MRAN: Package Spotlight](https://mran.microsoft.com/spotlight)
 
 #### E) Statistical / Unsupervised Machine Learning, Deep Learning and Artificial Intelligence
 
@@ -150,8 +149,8 @@ install.packages("h2o")
 
 * [H2O.ai: Webpage](https://www.h2o.ai/)
 * [H2O.ai Algorithms: Cheatsheet](https://github.com/h2oai/h2o-tutorials/raw/master/training/h2o_algos/h2o_algos_cheat_sheet_04_25_17.pdf)
-* [h2o R Package Functions: Cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/h2o.pdf)
-* [Practical Machine Learning with H2O (O'Reilly Media; Darren Cook)](https://shop.oreilly.com/product/0636920053170.do)
+* [h2o R Package Functions: Cheatsheet](https://github.com/rstudio/cheatsheets/raw/main/h2o.pdf)
+* [Practical Machine Learning with H2O (O'Reilly Media; Darren Cook)](https://www.oreilly.com/library/view/~/9781491964590/)
 * [Machine Learning with R and H2O (Mark Landry): Booklet Online Version](https://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/RBooklet.pdf)
 * [Deep Learning with H2O: Vignette](https://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/DeepLearningBooklet.pdf)
 
@@ -188,13 +187,13 @@ java -cp <path_to_h2o_jar>:<path_to_jdbc_driver_jar> water.H2OApp
 
 * [R interface to Keras: Webpage](https://keras.rstudio.com/)
 * [Deep Learning With R (François Chollet with J. J. Allaire, Manning)](https://www.manning.com/books/deep-learning-with-r)
-* [Keras Rstudio Cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/keras.pdf)
+* [Keras Rstudio Cheatsheet](https://github.com/rstudio/cheatsheets/raw/main/keras.pdf)
 
 **R LIBRARIES: CARET**
 
 A book which introduces core Machine Learning concepts:
 
-* [Introduction to Machine Learning with R (O'Reilly; Scott Burger)](https://shop.oreilly.com/product/0636920058885.do)
+* [Introduction to Machine Learning with R (O'Reilly; Scott Burger)](https://www.oreilly.com/library/view/~/9781491976432/)
 
 #### F) Text Mining
 
@@ -211,7 +210,7 @@ Documentation on how to perform Text Mining in R can be found in the book "Text 
 Automatic "reactive" binding between inputs and outputs and extensive prebuilt widgets make it possible to build beautiful, responsive, and powerful applications with minimal effort.
 
 * [Shiny Written Tutorials](https://shiny.rstudio.com/tutorial/written-tutorial/lesson1/)
-* [Shiny R Package Cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/shiny.pdf)
+* [Shiny R Package Cheatsheet](https://github.com/rstudio/cheatsheets/raw/main/shiny.pdf)
 
 For deploy Shiny Web Applications using Open Source Alternatives, you can either use:
 
@@ -222,7 +221,7 @@ For deploy Shiny Web Applications using Open Source Alternatives, you can either
 **RMARKDOWN DOCUMENTS**
 
 * [R Markdown: The Definitive Guide (Book).](https://bookdown.org/yihui/rmarkdown/)
-* [R Markdown Cheatsheet.](https://github.com/rstudio/cheatsheets/raw/master/rmarkdown-2.0.pdf)
+* [R Markdown Cheatsheet.](https://github.com/rstudio/cheatsheets/raw/main/rmarkdown-2.0.pdf)
 
 #### H) Advanced R Resources
 


### PR DESCRIPTION
Analytics slice of the [DOCS-6451](https://mariadb.atlassian.net/browse/DOCS-6451) broken-link campaign.

CI-exact lychee (78 excludes, derived from `link-check-pr.yml`'s folded `args:` scalar) over all 176 files in the space: **14 errors → 0**. Most of what is fixed here is invisible to every gate we have.

## Dead dev-server links — 10, in 4 files

Every one is an `http://localhost:8000/docs/...` URL left behind by a docs-build preview. **CI structurally cannot see these**: `localhost` is on lychee's exclude list, so they pass silently forever. Same class as the two found in the Connectors slice, but seven times as many.

Retargeted at the real pages — `{maxscale}` / `{server}` aliases cross-space, relative paths within Analytics. Three of them (`mcsGetConfig`, CMAPI logs) now point at the sections of `columnstore-system-paths-and-logs.md` that actually document them; two sibling CMAPI pages already carried the same sentence with the command in a code span, so the link target was recoverable but had never been wired up.

## Wrong-target links — 13 occurrences across 10 files

The sentence *"Checksums … can be found in the **Versions** section at the bottom of the **MariaDB Package Repository Setup and Usage** page"* appears **14 times** across the install guides. Before this PR:

| | Count | Target |
|---|---|---|
| "Versions" | 11 | `reference/sql-functions/.../version` — the **VERSION() SQL function** page |
| "Versions" | 2 | `mariadb-package-repository-setup-and-usage#versions` ✅ |
| "MariaDB Package Repository Setup and Usage" | 2 | `installing-mariadb/binary-packages` — the **MariaDB Binary Packages** page |
| both | 1 | unlinked |

Both wrong targets are live pages, so lychee sees 200 and fragcheck sees nothing — the reader is simply sent somewhere else. `#versions` confirmed present on the rendered page (`id="versions"`), and the two page identities confirmed by `<title>`. All 14 occurrences are now uniform.

## `broken-reference` — 3

GitBook's placeholder for a lost cross-reference. Each target was recovered from a near-duplicate sibling page that still carries a working link, rather than guessed.

## Rotted external links on the R use-case page — 11

- `db.rstudio.com` → `solutions.posit.co` (RStudio → Posit). The old `/drivers/` and `/odbc/` chains 302→301→301 into a **404**; the live successors are `connections/db/best-practices/drivers/` and `connections/db/r-packages/odbc/`, confirmed by title. The `#usage` fragment is now `#using`, verified against the rendered `id=` list.
- `rstudio/cheatsheets` renamed its default branch **master → main**: 4 PDFs, all four verified 200 with real sizes (0.7–2.6 MB).
- `shop.oreilly.com/product/*.do` → the `www.oreilly.com/library/view/~/<isbn>/` form O'Reilly itself 301s to.
- **MRAN**: retired by Microsoft in July 2023. `mran.microsoft.com` now answers with a bare `*.azurewebsites.net` certificate and no matching SAN, and Package Spotlight has no successor — so the bullet is **dropped**, not repointed at an archive husk.

## Drive-by fixes

- All five `multinode-s3` step pages described themselves as steps of *"Single-Node ColumnStore with Object storage"*. They belong to **Multi-Node S3** — per the procedure's own README title, its `description`, and its nav entry. Corrected in all five.
- `multinode-s3/README.md` was the single occurrence of the Checksums sentence with both links stripped out; restored.

## CI config — one change, flagged for a decision

`www.oreilly.com` added to the exclude list in **both** `link-check-pr.yml` and `.claude/hooks/doc-lint.sh` (78 entries each, verified identical in content **and** order).

The three book pages answer every scripted client with an **Akamai edge denial** (`Access Denied`, `errors.edgesuite.net` reference id). A full browser User-Agent plus a complete `Sec-Fetch-*` header set over HTTP/1.1 does not get past it, while the **site root serves 200** — so this is path-level bot protection on `/library/view/`, not a dead page and not a whole-host block. Same class as `www.akamai.com` and `cloud.ibm.com`, both added earlier in this campaign.

A/B on the R page proves the pattern fires narrowly rather than swallowing anything else:

| excludes | errors | excluded |
|---|---|---|
| 77 | 3 | 1 |
| 78 | **0** | 4 |

Exactly the three intended URLs. Happy to drop this and unlink the three book citations instead if you'd rather not grow the exclude list.

## Verification

- lychee, CI-exact, whole space: `1434 Total / 1401 OK / 0 Errors / 33 Excluded` (was 14 errors)
- `fragcheck new origin/main` — no new dead anchors (15 pre-existing, unchanged)
- `navcheck new origin/main` — no newly orphaned pages (205 pre-existing, unchanged)
- `includecheck` — 15 relative includes across 22 files, all resolve
- `doc-lint.sh` on all 22 changed Markdown files — clean, 30s (a real run, not a silent skip)
- `actionlint` and `shellcheck` — clean on both CI-config files
- Blast radius checked before widening: the 11 files carrying the Checksums sentence had **0** pre-existing lychee errors, so nothing pre-existing had to be cleared


[DOCS-6451]: https://mariadbcorp.atlassian.net/browse/DOCS-6451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ