### PR TITLE
Update 13.0.2 changelog

### DIFF
--- a/release-notes/community-server/changelogs/13.0/13.0.2.md
+++ b/release-notes/community-server/changelogs/13.0/13.0.2.md
@@ -29,7 +29,7 @@ hidden: true
 
 For the highlights of this release, see the [release notes](../../13.0/13.0.2.md).
 
-The revision number links will take you to the revision's page on GitHub. On [GitHub](https://github.com/MariaDB/server/tree/13.0) you can view more details of the revision and view diffs of the code modified in that revision.
+The revision number links will take you to the revision's page on GitHub. On [GitHub](https://github.com/MariaDB/server/compare/mariadb-13.0.1...mariadb-13.0.2) you can view more details of the revision and view diffs of the code modified in that revision.
 
 * Includes all fixes from [MariaDB 12.3.3](../12.3/12.3.3.md)
 * [Revision #ba0d134749](https://github.com/MariaDB/server/commit/ba0d134749) <sup>_<mark style="color:$info;">2026-07-26 19:54:38 -0600</mark>_</sup>


### PR DESCRIPTION
url link - tags are there yet, but for consistency with efe97d4f37d298f55fc2278d79e81110dc1a5e52