### PR TITLE
Remove bash call from generate_plugin_api_docs.sh

### DIFF
--- a/.github/workflows/sync-server-api-plugin-docs.yml
+++ b/.github/workflows/sync-server-api-plugin-docs.yml
@@ -59,7 +59,7 @@ jobs:
             --volume "$dest:/out" \
             --workdir /src/include/mysql \
             ghcr.io/mariadb/mariadb-doc-gen:latest \
-            bash -euxo pipefail -c 'bash generate_plugin_api_docs.sh /out'
+            bash -euxo pipefail -c 'generate_plugin_api_docs.sh /out'
           test -d "$dest/md"
           test -n "$(find "$dest/md" -name '*.md' -print -quit)"
           echo "Generated files:"

--- a/.github/workflows/sync-server-api-plugin-docs.yml
+++ b/.github/workflows/sync-server-api-plugin-docs.yml
@@ -58,8 +58,12 @@ jobs:
             --volume "$PWD/.server-src:/src:ro" \
             --volume "$dest:/out" \
             --workdir /src/include/mysql \
+            --entrypoint bash \
             ghcr.io/mariadb/mariadb-doc-gen:latest \
-            bash -euxo pipefail -c 'generate_plugin_api_docs.sh /out'
+            -euxo pipefail -c 'bash generate_plugin_api_docs.sh /out'
+          # The container writes as root into the bind mount, so the runner
+          # cannot delete or copy the tree afterwards without this.
+          sudo chown -R "$(id -u):$(id -g)" "$dest"
           test -d "$dest/md"
           test -n "$(find "$dest/md" -name '*.md' -print -quit)"
           echo "Generated files:"


### PR DESCRIPTION
Addendum to MDBF-1241: Fixed the workflow failure from executing bash in bash