### PR TITLE
Publish the generated Plugin API landing page at api-plugin/ instead of api-plugin/page-index

### DIFF
--- a/.github/scripts/add_server_plugin_api_to_summary.sh
+++ b/.github/scripts/add_server_plugin_api_to_summary.sh
@@ -12,7 +12,9 @@ summary="$basedir/server/SUMMARY.md"
 # SUMMARY.md paths are relative to the server/ book root.
 summary_dir="reference/plugins/api-plugin"
 parent_title="Plugin API Documentation"
-parent_page="page-index.md"
+# Renamed from the generated page-index.md by the workflow: GitBook treats
+# README.md as the directory index, so the section lands on api-plugin/.
+parent_page="README.md"
 parent_link="${summary_dir}/${parent_page}"
 parent_line="    * [${parent_title}](${parent_link})"
 test -f "$summary"

--- a/.github/workflows/sync-server-api-plugin-docs.yml
+++ b/.github/workflows/sync-server-api-plugin-docs.yml
@@ -75,6 +75,15 @@ jobs:
           rm -rf "$dest_dir"
           mkdir -p "$dest_dir"
           cp -a "$src"/. "$dest_dir"/
+          # GitBook publishes README.md as a directory's index, so renaming the
+          # generated mainpage puts the section landing page at
+          # .../reference/plugins/api-plugin/ instead of .../api-plugin/page-index.
+          # First test fails the step loudly if the mainpage ever stops being
+          # generated; second one refuses to clobber a generated group or page
+          # that happens to be titled README.
+          test -f "$dest_dir/page-index.md"
+          test ! -e "$dest_dir/README.md"
+          mv "$dest_dir/page-index.md" "$dest_dir/README.md"
           rm -rf ".generated-api-plugin"
 
       - name: Update Plugin API Documentation section in SUMMARY.md


### PR DESCRIPTION
Follow-up to #1012 / MDBF-1241, and the answer to the `page-index` vs `README` question raised in Slack.

## What

GitBook publishes a directory's `README.md` as its index, so renaming the generated mainpage on the way in moves the section landing page from

`…/server/reference/plugins/api-plugin/page-index` → `…/server/reference/plugins/api-plugin/`

which is the same shape as `…/server/reference/plugins/` today, and the URL people paste into tickets. Done on our side: the server's doxygen sources and `index.dox` stay untouched.

Two lines of substance — an `mv` in the install step and `parent_page="README.md"` in `add_server_plugin_api_to_summary.sh` — plus two guards.

## The guards, and why each one is there

```sh
test -f "$dest_dir/page-index.md"
test ! -e "$dest_dir/README.md"
mv "$dest_dir/page-index.md" "$dest_dir/README.md"
```

- **First** fails the step loudly if the mainpage ever stops being generated. The SUMMARY script cannot catch that by itself: the nav parent would quietly point at a page that isn't there while `test -s "$bullets_file"` still passed.
- **Second** answers @gkodinov's objection to the rename directly — moxygen names group files after their title, so a doxygen group titled `README` would otherwise be silently clobbered. With this, the step fails instead.

## Verification

Not reasoned about — run.

- **A `workflow_dispatch` run carrying this change plus the #1050 entrypoint fix went green end to end** and updated #1052 to the new layout: `README.md` in the generated directory, and `* [Plugin API Documentation](reference/plugins/api-plugin/README.md)` as the nav parent at `server/SUMMARY.md:2191`.
- Guards checked against the real generated set from #1052: both pass on it, and the second correctly refuses when a `README.md` already exists.
- `add_server_plugin_api_to_summary.sh` run twice against a copy of the current `server/SUMMARY.md` — second run byte-identical, `README.md` excluded from the child bullets.

## Order of merge

This needs #1050 (or an equivalent entrypoint fix) to land first, otherwise the container step never reaches the install step. Nothing publishes until #1052 is merged, so the landing URL is still free to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)