### PR TITLE
DOCS-6473: Add mrr_buffer_size tuning guidance to the MRR page

### DIFF
--- a/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md
+++ b/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md
@@ -232,60 +232,68 @@ Multi Range Read only pays off when it can sort a whole batch of row references 
 
 ### Tuning Decision Flow
 
+The flow splits into two parts: deciding whether a larger buffer can help this query at all, and — only if it can — choosing a value and deciding how widely to apply it. Each step is covered in full by the sections below.
+
+#### Part 1: Can a Larger Buffer Help?
+
 ```mermaid
 flowchart TD
-  accTitle: Decision flow for tuning mrr_buffer_size
-  accDescr { This flowchart walks through tuning mrr_buffer_size. Start by identifying the affected query and collecting a baseline. If the query has no MRR-suitable access pattern, tune the query or indexes instead. If MRR is not enabled, enable it for the session or use an MRR hint. If EXPLAIN does not show a Rowid-ordered scan and Handler_mrr_init does not increase, mrr_buffer_size has no effect. If the MRR refill counters are zero, the buffer already holds the whole scan and a larger value cannot help. If the data is already resident in the buffer pool, the benefit is limited. Otherwise check memory headroom and concurrency, then test progressively at session level through 512 KB, 1 MB, 2 MB and 4 MB. Keep a gain that is specific to one workload at session level; consider a global change only when the gain is consistent across representative workloads and memory headroom is sufficient. Monitor after any change, and settle on the smallest value that gives a consistent improvement. }
-  A(["Identify the affected query and collect a baseline"]) --> B{"Does the query use an MRR-suitable access pattern, such as a range scan or a large IN list?"}
-  B -->|"No"| B1["MRR cannot help. Tune the query, its indexes, or the optimizer statistics instead"]
-  B -->|"Yes"| C{"Is MRR enabled for the query?"}
-  C -->|"No"| C1["Set mrr=on for the session, or add an MRR hint, then re-check"]
+  accTitle: Part 1 - deciding whether a larger mrr_buffer_size can help
+  accDescr { Part one of the tuning flow, a sequence of five checks with an exit at each. Identify the affected query and collect a baseline. First, does the query use an MRR-suitable access pattern such as a range scan or a large IN list? If not, MRR cannot help and you should tune the query, its indexes or the optimizer statistics instead. Second, is MRR enabled for the query? If not, set mrr=on for the session or add an MRR hint, then re-check. Third, does EXPLAIN show a Rowid-ordered or Key-ordered scan, and does Handler_mrr_init increase? If not, MRR is not used and mrr_buffer_size has no effect on this query. Fourth, is Handler_mrr_key_refills or Handler_mrr_rowid_refills non-zero? If they are zero, the buffer already holds the whole scan and a larger value cannot help. Fifth, is the data already resident in the InnoDB buffer pool? If it is, the benefit is limited because the extra sorting costs CPU without saving I/O. Only if the data is not resident does a larger buffer look promising, and you continue with part two. }
+  A(["Identify the query,<br/>collect a baseline"]) --> B{"MRR-suitable<br/>access pattern?"}
+  B -->|"No"| B1[["Tune the query,<br/>indexes or statistics"]]
+  B -->|"Yes"| C{"MRR enabled?"}
+  C -->|"No"| C1["Set mrr=on,<br/>or add an MRR hint"]
   C1 --> D
-  C -->|"Yes"| D{"Does EXPLAIN show a Rowid-ordered or Key-ordered scan, and does Handler_mrr_init increase?"}
-  D -->|"No"| D1["MRR is not used, so mrr_buffer_size has no effect on this query"]
-  D -->|"Yes"| E{"Is Handler_mrr_key_refills or Handler_mrr_rowid_refills non-zero?"}
-  E -->|"No"| E1["The buffer already holds the whole scan, so a larger value cannot help"]
-  E -->|"Yes"| F{"Is the data already resident in the InnoDB buffer pool?"}
-  F -->|"Yes"| F1["Benefit is limited: the extra sorting costs CPU without saving I/O"]
-  F -->|"No"| G["Check memory headroom and concurrency: Threads_running, free RAM, swap usage"]
-  G --> H{"Is memory pressure a concern at this concurrency?"}
-  H -->|"Yes"| H1["Leave the global value at the default and test at session level only"]
-  H1 --> I
-  H -->|"No"| I["Test progressively at session level: 512 KB, then 1 MB, 2 MB, 4 MB"]
-  I --> J{"Measurable, repeatable improvement, with the refill counters at zero and no CPU or memory regression?"}
-  J -->|"No"| J1["Revert to the previous value and investigate other tuning"]
-  J -->|"Yes"| K{"Is the gain specific to one application or workload?"}
-  K -->|"Yes"| K1["Keep the larger value at session level, for that workload only"]
-  K -->|"No"| L{"Is the gain consistent across representative workloads, with sufficient memory headroom?"}
-  L -->|"No"| K1
-  L -->|"Yes"| M["A global change may be considered after controlled validation"]
-  M --> N["Monitor after the change: query time, Threads_running, memory and swap, CPU and disk I/O, buffer pool metrics"]
-  K1 --> N
-  N --> O(["Settle on the smallest value that gives a consistent improvement"])
+  C -->|"Yes"| D{"Ordered scan in EXPLAIN?<br/>Handler_mrr_init rising?"}
+  D -->|"No"| D1[["MRR unused:<br/>no effect"]]
+  D -->|"Yes"| E{"Refill counters<br/>non-zero?"}
+  E -->|"No"| E1[["Scan already fits:<br/>no gain possible"]]
+  E -->|"Yes"| F{"Data already in<br/>the buffer pool?"}
+  F -->|"Yes"| F1[["Limited gain:<br/>CPU, not I/O"]]
+  F -->|"No"| G(["A larger buffer<br/>may help &rarr; part 2"])
 
   classDef box fill:#eef2ff,stroke:#33415c,stroke-width:1px,color:#111;
   classDef decision fill:#fff3cd,stroke:#8a6d00,stroke-width:1px,color:#111;
   classDef stop fill:#f1f3f5,stroke:#495057,stroke-width:1px,color:#111;
-  class B,C,D,E,F,H,J,K,L decision;
-  class A,C1,G,I,M,N,O box;
-  class B1,D1,E1,F1,H1,J1,K1 stop;
+  class B,C,D,E,F decision;
+  class A,C1,G box;
+  class B1,D1,E1,F1 stop;
 ```
 
-_Decision flow for tuning `mrr_buffer_size`: confirm MRR is used, confirm the buffer is the limit, weigh memory against concurrency, then test at session level before considering a global change._
+_Part 1: five checks, each with its own exit. The refill counters are the decisive one — at zero, no larger value can help._
 
-The examples in this section use a 100,000-row InnoDB table with a non-unique secondary index, which is enough to make the optimizer pick `range` access with MRR:
+#### Part 2: Choosing and Applying a Value
 
-```sql
-CREATE TABLE tbl (
-  id     INT PRIMARY KEY,
-  key1   INT,
-  filler CHAR(200),
-  KEY (key1)
-) ENGINE=InnoDB;
+```mermaid
+flowchart TD
+  accTitle: Part 2 - choosing an mrr_buffer_size value and deciding how widely to apply it
+  accDescr { Part two of the tuning flow, reached only when part one showed that a larger buffer may help. Check memory headroom and concurrency: Threads_running, free RAM and swap usage. If memory pressure is a concern at this concurrency, leave the global value at the default and test at session level only. Either way, test progressively at session level through 512 KB, 1 MB, 2 MB and 4 MB. If there is no measurable and repeatable improvement, or the refill counters do not reach zero, or CPU or memory regress, revert to the previous value and investigate other tuning. If the improvement holds, ask whether the gain is specific to one application or workload; if it is, keep the larger value at session level for that workload only. If it is not, ask whether the gain is consistent across representative workloads with sufficient memory headroom; if not, again keep it at session level, and if so, a global change may be considered after controlled validation. Monitor after any change - query time, Threads_running, memory and swap, CPU and disk I/O, and buffer pool metrics - and settle on the smallest value that gives a consistent improvement. }
+  G(["From part 1: a larger<br/>buffer may help"]) --> H["Check headroom:<br/>Threads_running,<br/>free RAM, swap"]
+  H --> I{"Memory pressure<br/>a concern?"}
+  I -->|"Yes"| I1["Keep the global<br/>value at the default"]
+  I1 --> J
+  I -->|"No"| J["Test at session level:<br/>512 KB, 1 MB, 2 MB, 4 MB"]
+  J --> K{"Repeatable gain?<br/>Refills at zero,<br/>no regression?"}
+  K -->|"No"| K1[["Revert; investigate<br/>other tuning"]]
+  K -->|"Yes"| L{"Gain specific to<br/>one workload?"}
+  L -->|"Yes"| M1["Keep it at session<br/>level for that workload"]
+  L -->|"No"| M{"Consistent across<br/>workloads, with<br/>memory headroom?"}
+  M -->|"No"| M1
+  M -->|"Yes"| N["A global change may be<br/>considered after<br/>controlled validation"]
+  N --> O["Monitor: query time,<br/>Threads_running, memory,<br/>swap, CPU, I/O, buffer pool"]
+  M1 --> O
+  O --> P(["Settle on the smallest<br/>value that holds up"])
 
-INSERT INTO tbl SELECT seq, seq*7919 % 100000, 'x' FROM seq_1_to_100000;
-ANALYZE TABLE tbl;
+  classDef box fill:#eef2ff,stroke:#33415c,stroke-width:1px,color:#111;
+  classDef decision fill:#fff3cd,stroke:#8a6d00,stroke-width:1px,color:#111;
+  classDef stop fill:#f1f3f5,stroke:#495057,stroke-width:1px,color:#111;
+  class I,K,L,M decision;
+  class G,H,I1,J,M1,N,O,P box;
+  class K1 stop;
 ```
+
+_Part 2: keep a workload-specific gain at session level; a global change is the exception, not the destination._
 
 ### Check That MRR Is Enabled
 

--- a/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md
+++ b/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md
@@ -226,17 +226,268 @@ Multi Range Read is used for scans that do full record reads (i.e., they are not
 
 Multi Range Read will make separate calls for steps #1 and #2, causing TWO increments to `Handler_read_XXX` counters and TWO increments to `Innodb_rows_read` counter. To the uninformed, this looks as if Multi Range Read was making things worse. Actually, it doesn't - the query will still read the same index/table records, and actually Multi Range Read may give speedups because it reads data in disk order.
 
+## Tuning `mrr_buffer_size`
+
+Multi Range Read only pays off when it can sort a whole batch of row references in one pass, so [mrr\_buffer\_size](../system-variables/server-system-variables.md#mrr_buffer_size) is a workload-dependent setting rather than a value to raise across the board. Before increasing it, confirm that the affected query actually uses MRR, that the buffer really is the limiting factor, and that the server has the memory headroom for the larger allocation at the concurrency the workload runs at.
+
+### Tuning Decision Flow
+
+```mermaid
+flowchart TD
+  accTitle: Decision flow for tuning mrr_buffer_size
+  accDescr { This flowchart walks through tuning mrr_buffer_size. Start by identifying the affected query and collecting a baseline. If the query has no MRR-suitable access pattern, tune the query or indexes instead. If MRR is not enabled, enable it for the session or use an MRR hint. If EXPLAIN does not show a Rowid-ordered scan and Handler_mrr_init does not increase, mrr_buffer_size has no effect. If the MRR refill counters are zero, the buffer already holds the whole scan and a larger value cannot help. If the data is already resident in the buffer pool, the benefit is limited. Otherwise check memory headroom and concurrency, then test progressively at session level through 512 KB, 1 MB, 2 MB and 4 MB. Keep a gain that is specific to one workload at session level; consider a global change only when the gain is consistent across representative workloads and memory headroom is sufficient. Monitor after any change, and settle on the smallest value that gives a consistent improvement. }
+  A(["Identify the affected query and collect a baseline"]) --> B{"Does the query use an MRR-suitable access pattern, such as a range scan or a large IN list?"}
+  B -->|"No"| B1["MRR cannot help. Tune the query, its indexes, or the optimizer statistics instead"]
+  B -->|"Yes"| C{"Is MRR enabled for the query?"}
+  C -->|"No"| C1["Set mrr=on for the session, or add an MRR hint, then re-check"]
+  C1 --> D
+  C -->|"Yes"| D{"Does EXPLAIN show a Rowid-ordered or Key-ordered scan, and does Handler_mrr_init increase?"}
+  D -->|"No"| D1["MRR is not used, so mrr_buffer_size has no effect on this query"]
+  D -->|"Yes"| E{"Is Handler_mrr_key_refills or Handler_mrr_rowid_refills non-zero?"}
+  E -->|"No"| E1["The buffer already holds the whole scan, so a larger value cannot help"]
+  E -->|"Yes"| F{"Is the data already resident in the InnoDB buffer pool?"}
+  F -->|"Yes"| F1["Benefit is limited: the extra sorting costs CPU without saving I/O"]
+  F -->|"No"| G["Check memory headroom and concurrency: Threads_running, free RAM, swap usage"]
+  G --> H{"Is memory pressure a concern at this concurrency?"}
+  H -->|"Yes"| H1["Leave the global value at the default and test at session level only"]
+  H1 --> I
+  H -->|"No"| I["Test progressively at session level: 512 KB, then 1 MB, 2 MB, 4 MB"]
+  I --> J{"Measurable, repeatable improvement, with the refill counters at zero and no CPU or memory regression?"}
+  J -->|"No"| J1["Revert to the previous value and investigate other tuning"]
+  J -->|"Yes"| K{"Is the gain specific to one application or workload?"}
+  K -->|"Yes"| K1["Keep the larger value at session level, for that workload only"]
+  K -->|"No"| L{"Is the gain consistent across representative workloads, with sufficient memory headroom?"}
+  L -->|"No"| K1
+  L -->|"Yes"| M["A global change may be considered after controlled validation"]
+  M --> N["Monitor after the change: query time, Threads_running, memory and swap, CPU and disk I/O, buffer pool metrics"]
+  K1 --> N
+  N --> O(["Settle on the smallest value that gives a consistent improvement"])
+
+  classDef box fill:#eef2ff,stroke:#33415c,stroke-width:1px,color:#111;
+  classDef decision fill:#fff3cd,stroke:#8a6d00,stroke-width:1px,color:#111;
+  classDef stop fill:#f1f3f5,stroke:#495057,stroke-width:1px,color:#111;
+  class B,C,D,E,F,H,J,K,L decision;
+  class A,C1,G,I,M,N,O box;
+  class B1,D1,E1,F1,H1,J1,K1 stop;
+```
+
+_Decision flow for tuning `mrr_buffer_size`: confirm MRR is used, confirm the buffer is the limit, weigh memory against concurrency, then test at session level before considering a global change._
+
+The examples in this section use a 100,000-row InnoDB table with a non-unique secondary index, which is enough to make the optimizer pick `range` access with MRR:
+
+```sql
+CREATE TABLE tbl (
+  id     INT PRIMARY KEY,
+  key1   INT,
+  filler CHAR(200),
+  KEY (key1)
+) ENGINE=InnoDB;
+
+INSERT INTO tbl SELECT seq, seq*7919 % 100000, 'x' FROM seq_1_to_100000;
+ANALYZE TABLE tbl;
+```
+
+### Check That MRR Is Enabled
+
+MRR is **off by default**: `mrr`, `mrr_sort_keys`, and `mrr_cost_based` are all absent from the default [optimizer\_switch](../system-variables/server-system-variables.md#optimizer_switch). Check the current setting before anything else:
+
+```sql
+SELECT @@optimizer_switch, @@mrr_buffer_size;
+```
+
+Only `mrr=on` is required for the optimizer to consider MRR. The other two flags change how it decides:
+
+* `mrr_sort_keys=on` additionally enables Key-ordered scans.
+* `mrr_cost_based=on` makes the choice cost-based. With the default `mrr_cost_based=off`, MRR is used whenever it is applicable, which is what you want while testing. Turning it on makes MRR less likely to be chosen, and the MRR cost model is not sufficiently tuned for that to be recommended.
+
+To enable MRR for a single session:
+
+```sql
+SET SESSION optimizer_switch='mrr=on';
+```
+
+From MariaDB 12.0, the [MRR() and NO\_MRR()](../optimizer-hints/index-level-hints.md#mrr-no_mrr) optimizer hints control MRR per query, without changing `optimizer_switch` at all.
+
+### Confirm That the Query Uses MRR
+
+`EXPLAIN` names the strategy in the `Extra` column, and `EXPLAIN FORMAT=JSON` reports it as `mrr_type`:
+
+```sql
+SET SESSION optimizer_switch='mrr=on';
+
+EXPLAIN SELECT COUNT(filler) FROM tbl WHERE key1 BETWEEN 1000 AND 8000;
++------+-------------+-------+-------+---------------+------+---------+------+------+-------------------------------------------+
+| id   | select_type | table | type  | possible_keys | key  | key_len | ref  | rows | Extra                                     |
++------+-------------+-------+-------+---------------+------+---------+------+------+-------------------------------------------+
+|    1 | SIMPLE      | tbl   | range | key1          | key1 | 5       | NULL | 7001 | Using index condition; Rowid-ordered scan |
++------+-------------+-------+-------+---------------+------+---------+------+------+-------------------------------------------+
+
+EXPLAIN FORMAT=JSON SELECT COUNT(filler) FROM tbl WHERE key1 BETWEEN 1000 AND 8000;
+{
+  "query_block": {
+    "select_id": 1,
+    "cost": 8.24703808,
+    "nested_loop": [
+      {
+        "table": {
+          "table_name": "tbl",
+          "access_type": "range",
+          "possible_keys": ["key1"],
+          "key": "key1",
+          "key_length": "5",
+          "used_key_parts": ["key1"],
+          "loops": 1,
+          "rows": 7001,
+          "cost": 8.24703808,
+          "filtered": 100,
+          "index_condition": "tbl.key1 between 1000 and 8000",
+          "mrr_type": "Rowid-ordered scan"
+        }
+      }
+    ]
+  }
+}
+```
+
+The plan is only a prediction. [Handler\_mrr\_init](../system-variables/server-status-variables.md#handler_mrr_init) tells you whether MRR actually ran:
+
+```sql
+FLUSH STATUS;
+SELECT COUNT(filler) FROM tbl WHERE key1 BETWEEN 1000 AND 8000;
+SHOW STATUS LIKE 'Handler_mrr_init';
++------------------+-------+
+| Variable_name    | Value |
++------------------+-------+
+| Handler_mrr_init | 1     |
++------------------+-------+
+```
+
+If `Handler_mrr_init` stays at zero, MRR did not run and `mrr_buffer_size` has no effect on the query.
+
+{% hint style="info" %}
+MariaDB never prints `Using MRR` — that is the MySQL wording. MariaDB shows `Rowid-ordered scan`, `Key-ordered scan`, or `Key-ordered Rowid-ordered scan`. The fields `using_mrr` and `rowid_ordered` come from [Optimizer Trace](../query-optimizer/optimizer-trace/README.md), not from `EXPLAIN FORMAT=JSON`.
+{% endhint %}
+
+### Confirm That the Buffer Is the Limiting Factor
+
+This is the measurement that decides whether raising `mrr_buffer_size` can help at all. When a scan does not fit in the buffer, MRR breaks it into several sort-and-sweep passes and counts each refill in [Handler\_mrr\_key\_refills](../system-variables/server-status-variables.md#handler_mrr_key_refills) and [Handler\_mrr\_rowid\_refills](../system-variables/server-status-variables.md#handler_mrr_rowid_refills).
+
+With the buffer at its 8 KB minimum, a 7,000-row range scan needs four passes:
+
+```sql
+SET SESSION mrr_buffer_size = 8192;
+FLUSH STATUS;
+SELECT COUNT(filler) FROM tbl WHERE key1 BETWEEN 1000 AND 8000;
+SHOW STATUS LIKE 'Handler_mrr%';
++---------------------------+-------+
+| Variable_name             | Value |
++---------------------------+-------+
+| Handler_mrr_init          | 1     |
+| Handler_mrr_key_refills   | 0     |
+| Handler_mrr_rowid_refills | 3     |
++---------------------------+-------+
+```
+
+At 1 MB the same scan runs in a single pass:
+
+```sql
+SET SESSION mrr_buffer_size = 1048576;
+FLUSH STATUS;
+SELECT COUNT(filler) FROM tbl WHERE key1 BETWEEN 1000 AND 8000;
+SHOW STATUS LIKE 'Handler_mrr%';
++---------------------------+-------+
+| Variable_name             | Value |
++---------------------------+-------+
+| Handler_mrr_init          | 1     |
+| Handler_mrr_key_refills   | 0     |
+| Handler_mrr_rowid_refills | 0     |
++---------------------------+-------+
+```
+
+Once both refill counters read zero, the buffer already holds the entire scan and increasing it further cannot improve the query. Non-zero refills are the signal that a larger buffer has something to gain.
+
+### When a Larger Buffer Helps, and When It Does Not
+
+A larger buffer lets MRR order more row references per pass, which turns random reads into a more sequential sweep. That matters when:
+
+* The query uses `range` access over a range large enough to overflow the current buffer.
+* The refill counters above are non-zero.
+* The working set is not fully cached in the InnoDB buffer pool, so the reads reach storage.
+* The workload is reporting or analytical, with relatively low concurrency.
+
+It makes little or no difference when:
+
+* MRR is not selected for the query, or the access pattern is not MRR-suitable.
+* The refill counters are already zero.
+* The data is already resident in the buffer pool, in which case the extra sorting only adds CPU work.
+* Storage is NVMe or similar, where avoiding seeks buys much less.
+* The query is `ORDER BY ... LIMIT n` with a small `n` — MRR reads in disk order, not index order, so it can be slower.
+
+### Weigh Memory Against Concurrency
+
+`mrr_buffer_size` is a **per-table, per-scan** limit, not a per-session one. A single 10-way join that uses MRR on every table can therefore use `10 * @@mrr_buffer_size`, so the total across the server scales with both concurrency and plan shape: 4 MB across 200 concurrent MRR scans is already around 800 MB of potential allocation, and more if those scans sit inside multi-table joins.
+
+Before raising the global value, check the concurrency the server actually runs at and the headroom available:
+
+```sql
+SHOW STATUS LIKE 'Threads_running';
+```
+
+Also review free system memory, swap activity, InnoDB buffer pool size, and any other per-connection buffers already configured. High concurrency combined with a large `mrr_buffer_size` can put the server under memory pressure for a gain that only a few queries see.
+
+### Test at Session Level First
+
+Change the value for one session, and compare against the baseline over several runs of a representative workload:
+
+```sql
+SET SESSION mrr_buffer_size = 524288;
+```
+
+Increase in steps — 512 KB, 1 MB, 2 MB, 4 MB — rather than jumping to a large value, and stop at the first step where the refill counters reach zero. Beyond that point the buffer is no longer the constraint. At each step, measure at least:
+
+* Query execution time, over repeated runs.
+* The MRR refill counters.
+* CPU usage and disk I/O.
+* Rows examined and returned.
+* Memory usage and `Threads_running` under realistic concurrency.
+
+Treat a new value as beneficial only when the improvement is both measurable and repeatable, and the resource cost is acceptable.
+
+### Session Values Versus a Global Change
+
+Keep the global value conservative and raise it per session for the applications or batch jobs that demonstrate a clear benefit:
+
+```sql
+SET SESSION mrr_buffer_size = 4194304;
+```
+
+An improvement seen by one application is not a reason to make that value global — different workloads have different optimal values, and the memory cost applies to every session. Consider `SET GLOBAL` only when the improvement is consistent across workloads that represent the wider environment, memory headroom is sufficient at the real concurrency, and no CPU, I/O, or memory regression shows up under controlled validation.
+
+### Do Not Confuse MRR With Batched Key Access
+
+The two use different buffers, and tuning the wrong one has no effect:
+
+| Access pattern | Buffer controlled by |
+| -------------- | -------------------- |
+| MRR for `range` access | [mrr\_buffer\_size](../system-variables/server-system-variables.md#mrr_buffer_size) |
+| MRR under [Batched Key Access](../query-optimizer/block-based-join-algorithms.md#batch-key-access-join) for `ref` and `eq_ref` joins | [join\_buffer\_size](../system-variables/server-system-variables.md#join_buffer_size) and [join\_buffer\_space\_limit](../system-variables/server-system-variables.md#join_buffer_space_limit) |
+
+A slow join that uses index lookups is a BKA question, not an `mrr_buffer_size` one. And in either case, a larger buffer is not a substitute for fixing the query, the indexes, or the optimizer statistics.
+
+{% hint style="success" %}
+In short: confirm MRR is used by the affected query, confirm the refill counters are non-zero, weigh the workload's memory and concurrency, and test progressively at session level. Use the smallest value that gives a consistent improvement without excessive resource consumption.
+{% endhint %}
+
 ## Multi Range Read Factsheet
 
 * Multi Range Read is used by
   * `range` access method for range scans.
-  * [Batched Key Access](https://mariadb.com/kb/en/Batched_Key_Access) for joins
+  * [Batched Key Access](../query-optimizer/block-based-join-algorithms.md#batch-key-access-join) for joins
 * Multi Range Read can cause slowdowns for small queries over small tables, so it is disabled by default.
-* There are two strategies:
+* There are two strategies, and you can tell which one is used by checking the `Extra` column in `EXPLAIN` output:
   * Rowid-ordered scan
   * Key-ordered scan
-* : and you can tell if either of them is used by checking the `Extra` column in `EXPLAIN` output.
-* There are three [optimizer\_switch](../system-variables/server-system-variables.md#optimizer_switch) flags you can switch ON:
+* All three MRR [optimizer\_switch](../system-variables/server-system-variables.md#optimizer_switch) flags are off by default, and you can switch them ON:
   * `mrr=on` - enable MRR and rowid ordered scans
   * `mrr_sort_keys=on` - enable Key-ordered scans (you must also set `mrr=on` for this to have any effect)
   * `mrr_cost_based=on` - enable cost-based choice whether to use MRR. Currently not recommended, because cost model is not sufficiently tuned yet.
@@ -249,7 +500,7 @@ Multi Range Read will make separate calls for steps #1 and #2, causing TWO incre
   * `Key-ordered scan`
   * `Key-ordered Rowid-ordered scan`
 * MariaDB uses [mrr\_buffer\_size](../system-variables/server-system-variables.md#mrr_buffer_size) as a limit of MRR buffer size for `range` access, while MySQL uses [read\_rnd\_buffer\_size](../system-variables/server-system-variables.md#read_rnd_buffer_size).
-* MariaDB has three MRR counters: [Handler\_mrr\_init](../system-variables/server-status-variables.md#handler_mrr_init), `Handler_mrr_extra_rowid_sorts`, `Handler_mrr_extra_key_sorts`, while MySQL has only `Handler_mrr_init`, and it will only count MRR scans that were used by BKA. MRR scans used by range access are not counted.
+* MariaDB has three MRR counters: [Handler\_mrr\_init](../system-variables/server-status-variables.md#handler_mrr_init), [Handler\_mrr\_key\_refills](../system-variables/server-status-variables.md#handler_mrr_key_refills), and [Handler\_mrr\_rowid\_refills](../system-variables/server-status-variables.md#handler_mrr_rowid_refills), while MySQL has only `Handler_mrr_init`, and it will only count MRR scans that were used by BKA. MRR scans used by range access are not counted.
 
 ##
 

--- a/server/ha-and-performance/optimization-and-tuning/optimizer-hints/index-level-hints.md
+++ b/server/ha-and-performance/optimization-and-tuning/optimizer-hints/index-level-hints.md
@@ -350,7 +350,7 @@ SELECT /*+ MRR(t1 IDX2) */ * FROM t1 WHERE f2 <= 3 AND 3 <= f3;
 ```
 
 ```sql
--- MRR optimization is enabled by optimizer_switch setting (default setting):
+-- MRR optimization is enabled by optimizer_switch setting (it is off by default):
 set optimizer_switch='mrr=on';
 
 -- Disable multi-range read when accessing table `t1`


### PR DESCRIPTION
[DOCS-6473](https://mariadbcorp.atlassian.net/browse/DOCS-6473) supplied a complete "Tuning `mrr_buffer_size` for MariaDB" article plus a large ASCII-art decision flow. Rather than a standalone page, the content lands as a **`## Tuning mrr_buffer_size`** section on the existing [Multi Range Read Optimization](https://github.com/mariadb-corporation/mariadb-docs/blob/main/server/ha-and-performance/optimization-and-tuning/mariadb-internal-optimizations/multi-range-read-optimization.md) page, which already documents the variable under *Buffer Space Management* and the MRR status variables. This follows the precedent of DOCS-6073 (same reporter, same shape: flow diagrams folded into the relevant page).

The ASCII art is now **two inline Mermaid flowcharts**, each with `accTitle`/`accDescr` and a caption. It began as one chart, but that came out 1415x4680 — which a 400px phone column scales to 0.283, rendering a 16px node label at **4.5px**. GitBook wraps mermaid in a pan/zoom container so it was recoverable, but only by pinching. It is now split along the natural seam in the content:

| | size | label at 400px |
|---|---|---|
| before (one chart) | 1415 x 4680 | 4.5px |
| Part 1 — can a larger buffer help? | 709 x 1665 | 9.0px |
| Part 2 — choosing and applying a value | 581 x 2079 | 11.0px |

Both are at or near 1:1 in the normal reading column. Diamond geometry was the main width driver, so the decision labels are now short questions; the detail stays in the `accDescr` and in the prose subsections, which already walk the same path in the same order.

Dead-end nodes also use the subroutine shape `[[...]]` rather than a plain rect. They were distinguished from continuing steps by fill hue alone, and those two fills have a **1.01:1 luminance ratio** — identical in greyscale. Not a WCAG 1.4.1 violation, since each node's text states its own outcome, but the styling did no work for a monochrome reader.

### Accessibility, verified rather than assumed

Checked against the **published** page, whose pre-existing diagram is authored identically and so serves as a control:

- `accTitle`/`accDescr` become `<title id="chart-title-…">` / `<desc id="chart-desc-…">`, referenced by `aria-labelledby`/`aria-describedby` on `role="graphics-document document"`. They are consumed, not leaked as visible text.
- Node label contrast is **16-17:1 in both site themes**. This was a near miss: GitBook's dark theme sets `.label text { fill:#ccc }`, which against these light fills would be **1.44:1**. Mermaid compiles `classDef` with `!important`, so `color:#111` wins — confirmed off the rendered dark-mode pixels, not from the CSS.
- All three blocks parse under `mermaid@11` and are recorded as `syntax: mermaid` in GitBook's content model. Both new ones were rendered and measured. Their on-site render is inferred from the identical control — headless Chrome would not trigger GitBook's lazy mermaid renderer below the fold.

One caveat that is **not** from this PR: in dark mode the `Yes`/`No` edge labels measure **4.43:1**, a hair under WCAG AA's 4.5:1 for normal text. That is GitBook's own mermaid dark theme, is not reachable from `classDef`, and applies to every mermaid diagram on the docs site. Worth its own ticket if we care.

## Source verification

Checked against `mariadb-server` (`sql/sys_vars.cc`, `sql/sql_priv.h`, `sql/multi_range_read.cc`, `sql/opt_range.cc`, `sql/mysqld.cc`) and executed against a live 12.3.3 server. Four claims in the ticket draft did not survive:

| Ticket draft | Corrected to |
|---|---|
| Implies MRR is normally active; "`mrr=on`, `mrr_cost_based=on` — both should be enabled" | MRR is **off by default** — `mrr`, `mrr_sort_keys`, `mrr_cost_based` are all absent from `OPTIMIZER_SWITCH_DEFAULT` (`sql/sql_priv.h:202`). Confirmed live: `mrr=off,mrr_cost_based=off,mrr_sort_keys=off` |
| `mrr_cost_based=on` needed for the optimizer to consider MRR | Only `mrr=on` is needed. `mrr_cost_based=on` makes the choice cost-based and therefore *less* likely; with the default `off`, DS-MRR is forced whenever applicable (`sql/multi_range_read.cc:1932-1941`) |
| Indicators include `Using MRR`, `"using_mrr": true`, `rowid_ordered` | MariaDB never prints `Using MRR` (MySQL wording — no such string in `sql/`). `using_mrr` and `rowid_ordered` are **Optimizer Trace** fields (`sql/opt_range.cc:8039-8040`); `EXPLAIN FORMAT=JSON` reports `mrr_type` (`sql/sql_explain.cc:2921`) |
| "`mrr_buffer_size` is allocated PER THREAD executing MRR" | It is **per-table, per-scan** — a 10-way join using MRR on every table can use `10 * @@mrr_buffer_size`, as the page's own *Buffer Space Management* section already says |

The variable table in the ticket (default `262144`, min `8192`, max `2147483647`, Global/Session, dynamic) checks out exactly, and is unchanged between ES 10.6 and CS 13.0 — so it is stated once rather than duplicated from `server-system-variables.md`.

## What the draft was missing

`Handler_mrr_key_refills` / `Handler_mrr_rowid_refills` — the measurement that actually tells you whether the buffer is the limiting factor. The draft had no way to answer "will a bigger buffer help?" other than trial and error. Both worked examples are real output from a local server: at the 8 KB minimum a 7,000-row range scan takes four passes (`Handler_mrr_rowid_refills = 3`); at 1 MB it takes one (`= 0`). Once the counters read zero, a larger value cannot help — which is now the gate in the flowchart too.

The draft's closing recommendation is preserved as a `success` hint.

## Drive-by fixes

* `optimizer-hints/index-level-hints.md` claimed `mrr=on` is "(default setting)".
* Factsheet: the Batched Key Access link pointed at `mariadb.com/kb/en/` → repointed in-repo; repaired a broken `* : and you can tell...` bullet; noted the three flags are off by default.
* *Differences from MySQL* cited `Handler_mrr_extra_rowid_sorts` and `Handler_mrr_extra_key_sorts`, neither of which exists in the server (`sql/mysqld.cc:8050-8052`) → replaced with the real `Handler_mrr_key_refills` / `Handler_mrr_rowid_refills`, now linked.

## Checks

`doc-lint.sh` (codespell + lychee + includecheck + fragcheck) passes on both changed files. Gate proven live against a seeded probe file, so the pass is real rather than a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-6473]: https://mariadbcorp.atlassian.net/browse/DOCS-6473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
